### PR TITLE
feat: RFC 006 Phase 5 — full claims abstraction + entity linking (iss…

### DIFF
--- a/crates/yantrikdb-core/src/base/schema.rs
+++ b/crates/yantrikdb-core/src/base/schema.rs
@@ -1,4 +1,4 @@
-pub const SCHEMA_VERSION: i32 = 14;
+pub const SCHEMA_VERSION: i32 = 15;
 
 pub const SCHEMA_SQL: &str = "
 -- Memory records: the source of truth
@@ -61,17 +61,49 @@ CREATE TABLE IF NOT EXISTS sessions (
     origin_actor TEXT
 );
 
--- Entity relationship graph
-CREATE TABLE IF NOT EXISTS edges (
-    edge_id TEXT PRIMARY KEY,            -- UUIDv7
-    src TEXT NOT NULL,                   -- entity name or memory rid
-    dst TEXT NOT NULL,                   -- entity name or memory rid
-    rel_type TEXT NOT NULL,              -- relationship type (e.g., \"is_about\", \"related_to\")
+-- Claims: first-class semantic relationship ledger (v0.7 / Phase 5 of RFC 006)
+-- Each claim records a structured (subject, relation, object) triple extracted from
+-- or written alongside a memory. The legacy `edges` name is preserved as a read-only
+-- VIEW for backward compatibility.
+CREATE TABLE IF NOT EXISTS claims (
+    claim_id TEXT PRIMARY KEY,           -- UUIDv7
+    src TEXT NOT NULL,                   -- source entity (subject)
+    dst TEXT NOT NULL,                   -- destination entity (object)
+    rel_type TEXT NOT NULL,              -- relationship type (e.g., \"ceo_of\", \"works_at\")
     weight REAL NOT NULL DEFAULT 1.0,    -- relationship strength [0, 1]
     created_at REAL NOT NULL,
     tombstoned INTEGER NOT NULL DEFAULT 0,
 
+    -- Claim qualifier columns (RFC 006 Layer A)
+    source_memory_rid TEXT,              -- provenance back to the memory text
+    polarity INTEGER NOT NULL DEFAULT 1, -- 1=positive, -1=negative, 0=unknown
+    modality TEXT NOT NULL DEFAULT 'asserted', -- asserted|reported|hypothetical|denied|quoted
+    valid_from REAL,                     -- world-validity start (unix timestamp, nullable)
+    valid_to REAL,                       -- world-validity end (null = present)
+    extractor TEXT NOT NULL DEFAULT 'manual', -- manual|structured_ingest|heuristic_v1|agent_llm
+    extractor_version TEXT,
+    confidence_band TEXT NOT NULL DEFAULT 'medium', -- low|medium|high
+    span_start INTEGER,                  -- byte offset in source memory (nullable)
+    span_end INTEGER,
+    namespace TEXT NOT NULL DEFAULT 'default',
+
     UNIQUE(src, dst, rel_type)
+);
+
+-- Backward-compat view: all code that reads FROM edges continues to work unchanged.
+-- This view is read-only; all writes now go through the claims table directly.
+CREATE VIEW IF NOT EXISTS edges AS
+    SELECT claim_id AS edge_id, src, dst, rel_type, weight, created_at, tombstoned
+    FROM claims;
+
+-- Entity alias table for canonical name resolution (RFC 006 Layer B)
+CREATE TABLE IF NOT EXISTS entity_aliases (
+    alias TEXT NOT NULL,
+    canonical_name TEXT NOT NULL,
+    namespace TEXT NOT NULL DEFAULT 'default',
+    source TEXT NOT NULL CHECK(source IN ('explicit', 'auto_suggested', 'approved')),
+    created_at REAL NOT NULL,
+    PRIMARY KEY (alias, namespace)
 );
 
 -- Entities extracted from memories
@@ -196,9 +228,13 @@ CREATE INDEX IF NOT EXISTS idx_memories_due_at ON memories(namespace, due_at) WH
 CREATE INDEX IF NOT EXISTS idx_memories_last_access ON memories(last_access);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_one_active ON sessions(namespace, client_id) WHERE status = 'active';
 CREATE INDEX IF NOT EXISTS idx_sessions_client_started ON sessions(namespace, client_id, started_at DESC);
-CREATE INDEX IF NOT EXISTS idx_edges_src ON edges(src);
-CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst);
-CREATE INDEX IF NOT EXISTS idx_edges_rel ON edges(rel_type);
+CREATE INDEX IF NOT EXISTS idx_claims_src ON claims(src);
+CREATE INDEX IF NOT EXISTS idx_claims_dst ON claims(dst);
+CREATE INDEX IF NOT EXISTS idx_claims_rel ON claims(rel_type);
+CREATE INDEX IF NOT EXISTS idx_claims_namespace ON claims(namespace);
+CREATE INDEX IF NOT EXISTS idx_claims_polarity ON claims(polarity);
+CREATE INDEX IF NOT EXISTS idx_claims_modality ON claims(modality);
+CREATE INDEX IF NOT EXISTS idx_alias_canonical ON entity_aliases(canonical_name, namespace);
 CREATE INDEX IF NOT EXISTS idx_oplog_timestamp ON oplog(timestamp);
 CREATE INDEX IF NOT EXISTS idx_oplog_target ON oplog(target_rid);
 CREATE INDEX IF NOT EXISTS idx_oplog_hlc ON oplog(hlc);
@@ -729,6 +765,72 @@ CREATE INDEX IF NOT EXISTS idx_memories_session ON memories(namespace, session_i
 CREATE INDEX IF NOT EXISTS idx_memories_due_at ON memories(namespace, due_at)
     WHERE due_at IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_memories_last_access ON memories(last_access);
+";
+
+/// SQL to migrate from schema V14 to V15.
+/// Phase 5 of RFC 006: rename `edges` → `claims`, expose `edges` as a read-only
+/// VIEW for backward compatibility, add claim qualifier columns, add entity_aliases.
+pub const MIGRATE_V14_TO_V15: &str = "
+-- 1. Create the claims table with all qualifier columns
+CREATE TABLE IF NOT EXISTS claims (
+    claim_id TEXT PRIMARY KEY,
+    src TEXT NOT NULL,
+    dst TEXT NOT NULL,
+    rel_type TEXT NOT NULL,
+    weight REAL NOT NULL DEFAULT 1.0,
+    created_at REAL NOT NULL,
+    tombstoned INTEGER NOT NULL DEFAULT 0,
+    source_memory_rid TEXT,
+    polarity INTEGER NOT NULL DEFAULT 1,
+    modality TEXT NOT NULL DEFAULT 'asserted',
+    valid_from REAL,
+    valid_to REAL,
+    extractor TEXT NOT NULL DEFAULT 'manual',
+    extractor_version TEXT,
+    confidence_band TEXT NOT NULL DEFAULT 'medium',
+    span_start INTEGER,
+    span_end INTEGER,
+    namespace TEXT NOT NULL DEFAULT 'default',
+    UNIQUE(src, dst, rel_type)
+);
+
+-- 2. Copy existing edges into claims (backfill claim columns with safe defaults)
+INSERT OR IGNORE INTO claims
+    (claim_id, src, dst, rel_type, weight, created_at, tombstoned,
+     source_memory_rid, polarity, modality, valid_from, valid_to,
+     extractor, extractor_version, confidence_band, span_start, span_end, namespace)
+SELECT
+    edge_id, src, dst, rel_type, weight, created_at, tombstoned,
+    NULL, 1, 'asserted', NULL, NULL,
+    'manual', NULL, 'medium', NULL, NULL, 'default'
+FROM edges;
+
+-- 3. Drop the old edges table (indexes on it are dropped automatically)
+DROP TABLE IF EXISTS edges;
+
+-- 4. Expose edges as a backward-compat read-only view
+CREATE VIEW IF NOT EXISTS edges AS
+    SELECT claim_id AS edge_id, src, dst, rel_type, weight, created_at, tombstoned
+    FROM claims;
+
+-- 5. Indexes on claims
+CREATE INDEX IF NOT EXISTS idx_claims_src ON claims(src);
+CREATE INDEX IF NOT EXISTS idx_claims_dst ON claims(dst);
+CREATE INDEX IF NOT EXISTS idx_claims_rel ON claims(rel_type);
+CREATE INDEX IF NOT EXISTS idx_claims_namespace ON claims(namespace);
+CREATE INDEX IF NOT EXISTS idx_claims_polarity ON claims(polarity);
+CREATE INDEX IF NOT EXISTS idx_claims_modality ON claims(modality);
+
+-- 6. Entity alias table for canonical name resolution
+CREATE TABLE IF NOT EXISTS entity_aliases (
+    alias TEXT NOT NULL,
+    canonical_name TEXT NOT NULL,
+    namespace TEXT NOT NULL DEFAULT 'default',
+    source TEXT NOT NULL CHECK(source IN ('explicit', 'auto_suggested', 'approved')),
+    created_at REAL NOT NULL,
+    PRIMARY KEY (alias, namespace)
+);
+CREATE INDEX IF NOT EXISTS idx_alias_canonical ON entity_aliases(canonical_name, namespace);
 ";
 
 /// SQL to migrate from schema V13 to V14.

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -120,6 +120,9 @@ pub struct RefinementHint {
 }
 
 /// An edge in the entity graph.
+///
+/// Returned by `get_edges()` which reads through the `edges` backward-compat VIEW.
+/// For full claim metadata use `get_claims()` / the `Claim` struct.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Edge {
     pub edge_id: String,
@@ -127,6 +130,48 @@ pub struct Edge {
     pub dst: String,
     pub rel_type: String,
     pub weight: f64,
+}
+
+/// A first-class claim record (v0.7, RFC 006 Phase 5).
+///
+/// Claims are the physical storage primitive. The `edges` table is now a
+/// read-only VIEW over `claims` for backward compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Claim {
+    /// Stable primary key (UUIDv7). Equivalent to `edge_id` in the compat VIEW.
+    pub claim_id: String,
+    /// Source entity (subject of the triple).
+    pub src: String,
+    /// Destination entity (object of the triple).
+    pub dst: String,
+    /// Relationship type, e.g. `"ceo_of"`, `"works_at"`.
+    pub rel_type: String,
+    /// Relationship strength [0, 1].
+    pub weight: f64,
+    /// Unix timestamp when the claim was first recorded.
+    pub created_at: f64,
+    /// Provenance: rid of the memory this claim was extracted from.
+    pub source_memory_rid: Option<String>,
+    /// Polarity: `1` = positive, `-1` = negative, `0` = unknown.
+    pub polarity: i32,
+    /// Epistemic modality: `asserted | reported | hypothetical | denied | quoted`.
+    pub modality: String,
+    /// World-validity start (unix timestamp). `None` = no temporal qualifier.
+    pub valid_from: Option<f64>,
+    /// World-validity end. `None` = currently valid / open-ended.
+    pub valid_to: Option<f64>,
+    /// How the claim was produced: `manual | structured_ingest | heuristic_v1 | agent_llm`.
+    pub extractor: String,
+    /// Extractor version string (e.g. `"heuristic_v1.0"`).
+    pub extractor_version: Option<String>,
+    /// Confidence band: `low | medium | high`.
+    pub confidence_band: String,
+    /// Byte offset into `source_memory_rid` where the evidence span starts.
+    pub span_start: Option<i64>,
+    /// Byte offset where the evidence span ends.
+    pub span_end: Option<i64>,
+    /// Namespace this claim belongs to.
+    pub namespace: String,
 }
 
 /// An entity in the knowledge graph.

--- a/crates/yantrikdb-core/src/distributed/conflict.rs
+++ b/crates/yantrikdb-core/src/distributed/conflict.rs
@@ -314,9 +314,10 @@ fn find_memory_for_edge(
     dst: &str,
     rel_type: &str,
 ) -> Result<Option<String>> {
+    // Accept both legacy op_type="relate" and new op_type="claim" (v0.7+).
     let result = conn.query_row(
         "SELECT target_rid FROM oplog
-         WHERE op_type = 'relate'
+         WHERE op_type IN ('relate', 'claim')
            AND json_extract(payload, '$.src') = ?1
            AND json_extract(payload, '$.dst') = ?2
            AND json_extract(payload, '$.rel_type') = ?3

--- a/crates/yantrikdb-core/src/distributed/replication.rs
+++ b/crates/yantrikdb-core/src/distributed/replication.rs
@@ -141,7 +141,7 @@ pub fn apply_ops(db: &YantrikDB, ops: &[OplogEntry]) -> Result<SyncStats> {
         }
 
         // Track if we need to backfill memory_entities after
-        if op.op_type == "relate" || op.op_type == "record" {
+        if op.op_type == "relate" || op.op_type == "claim" || op.op_type == "record" {
             has_relate_or_record = true;
         }
 
@@ -208,7 +208,7 @@ fn materialize_op(db: &YantrikDB, op: &OplogEntry) -> Result<()> {
                 });
             }
         }
-        "relate" => {
+        "relate" | "claim" => {
             materialize_relate(&*db.conn(), &op.payload)?;
             // Update graph index
             let src = op.payload["src"].as_str().unwrap_or_default();
@@ -364,9 +364,16 @@ fn materialize_record(conn: &Connection, payload: &serde_json::Value, _embedding
     Ok(())
 }
 
-/// Materialize a "relate" op: LWW on (src, dst, rel_type), higher HLC wins.
+/// Materialize a "relate" or "claim" op: LWW on (src, dst, rel_type), higher HLC wins.
+///
+/// Supports both legacy "relate" payload format (key `edge_id`) and new "claim"
+/// payload format (key `claim_id`). Both write to the `claims` table.
 fn materialize_relate(conn: &Connection, payload: &serde_json::Value) -> Result<()> {
-    let edge_id = payload["edge_id"].as_str().unwrap_or_default();
+    // Accept both legacy `edge_id` (op_type="relate") and new `claim_id` (op_type="claim")
+    let edge_id = payload["claim_id"]
+        .as_str()
+        .or_else(|| payload["edge_id"].as_str())
+        .unwrap_or_default();
     let src = payload["src"].as_str().unwrap_or_default();
     let dst = payload["dst"].as_str().unwrap_or_default();
     let rel_type = payload["rel_type"].as_str().unwrap_or_default();
@@ -377,14 +384,15 @@ fn materialize_relate(conn: &Connection, payload: &serde_json::Value) -> Result<
         return Ok(());
     }
 
-    // LWW: ON CONFLICT update if the incoming created_at is newer
+    // LWW: ON CONFLICT update if the incoming created_at is newer.
+    // Writes to `claims` (the physical table). `edges` is now a read-only VIEW.
     conn.execute(
-        "INSERT INTO edges (edge_id, src, dst, rel_type, weight, created_at) \
+        "INSERT INTO claims (claim_id, src, dst, rel_type, weight, created_at) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
          ON CONFLICT(src, dst, rel_type) DO UPDATE SET \
          weight = CASE WHEN ?6 > created_at THEN ?5 ELSE weight END, \
          created_at = CASE WHEN ?6 > created_at THEN ?6 ELSE created_at END, \
-         edge_id = CASE WHEN ?6 > created_at THEN ?1 ELSE edge_id END",
+         claim_id = CASE WHEN ?6 > created_at THEN ?1 ELSE claim_id END",
         params![edge_id, src, dst, rel_type, weight, created_at],
     )?;
 
@@ -922,7 +930,8 @@ mod tests {
         a.relate("Alice", "Bob", "knows", 0.9).unwrap();
 
         let ops = extract_ops_since(&*a.conn(), None, None, None, 100).unwrap();
-        let relate_op = ops.iter().find(|o| o.op_type == "relate").unwrap();
+        // Since v0.7, relate() is a wrapper around ingest_claim() which logs op_type="claim"
+        let relate_op = ops.iter().find(|o| o.op_type == "claim" || o.op_type == "relate").unwrap();
 
         let b = YantrikDB::new_with_actor(":memory:", 8, "B").unwrap();
         apply_ops(&b, &[relate_op.clone()]).unwrap();

--- a/crates/yantrikdb-core/src/engine/graph_ops.rs
+++ b/crates/yantrikdb-core/src/engine/graph_ops.rs
@@ -1,22 +1,48 @@
 use rusqlite::params;
 
 use crate::error::Result;
-use crate::types::{Edge, Entity};
+use crate::types::{Claim, Edge, Entity};
 
 use super::{now, YantrikDB};
 
 impl YantrikDB {
-    /// Create or update a relationship between entities.
+    /// Ingest a structured claim — the primary write path for the entity graph (v0.7).
+    ///
+    /// Writes to the `claims` table directly. All qualifier columns from RFC 006
+    /// are stored. The `edges` VIEW exposes the result for legacy readers.
+    ///
+    /// `src` and `dst` are resolved through `entity_aliases` before storage so
+    /// that "AWS" and "Amazon Web Services" map to the same canonical entity.
     #[tracing::instrument(skip(self))]
-    pub fn relate(
+    #[allow(clippy::too_many_arguments)]
+    pub fn ingest_claim(
         &self,
         src: &str,
         dst: &str,
         rel_type: &str,
         weight: f64,
+        source_memory_rid: Option<&str>,
+        polarity: i32,
+        modality: &str,
+        valid_from: Option<f64>,
+        valid_to: Option<f64>,
+        extractor: &str,
+        extractor_version: Option<&str>,
+        confidence_band: &str,
+        namespace: &str,
     ) -> Result<String> {
-        let edge_id = crate::id::new_id();
+        let claim_id = crate::id::new_id();
         let ts = now();
+
+        // Resolve aliases: normalise src/dst to canonical names before storing.
+        let (src_canonical, dst_canonical) = {
+            let conn = self.conn.lock();
+            let src_c = crate::graph::resolve_alias(src, namespace, &conn);
+            let dst_c = crate::graph::resolve_alias(dst, namespace, &conn);
+            (src_c, dst_c)
+        };
+        let src = src_canonical.as_str();
+        let dst = dst_canonical.as_str();
 
         // Classify entity types using relationship semantics
         let (src_type, dst_type) =
@@ -26,10 +52,18 @@ impl YantrikDB {
         {
             let conn = self.conn.lock();
             conn.execute(
-                "INSERT INTO edges (edge_id, src, dst, rel_type, weight, created_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
-                 ON CONFLICT(src, dst, rel_type) DO UPDATE SET weight = ?5, created_at = ?6",
-                params![edge_id, src, dst, rel_type, weight, ts],
+                "INSERT INTO claims \
+                 (claim_id, src, dst, rel_type, weight, created_at, \
+                  source_memory_rid, polarity, modality, valid_from, valid_to, \
+                  extractor, extractor_version, confidence_band, namespace) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15) \
+                 ON CONFLICT(src, dst, rel_type) DO UPDATE SET \
+                 weight = ?5, created_at = ?6",
+                params![
+                    claim_id, src, dst, rel_type, weight, ts,
+                    source_memory_rid, polarity, modality, valid_from, valid_to,
+                    extractor, extractor_version, confidence_band, namespace
+                ],
             )?;
 
             // Ensure entities exist with classified entity_type
@@ -53,29 +87,143 @@ impl YantrikDB {
         } // graph_index dropped
 
         // Backfill memory_entities for newly-created entities.
-        // When remember() runs BEFORE relate(), the memory doesn't get linked
-        // because the entity doesn't exist yet. Fix: scan active memories for
-        // mentions of the src/dst entities and create links retroactively.
         self.backfill_memory_entities_for(&[src, dst])?;
 
         self.log_op(
-            "relate",
-            Some(&edge_id),
+            "claim",
+            Some(&claim_id),
             &serde_json::json!({
-                "edge_id": edge_id,
+                "claim_id": claim_id,
                 "src": src,
                 "dst": dst,
                 "rel_type": rel_type,
                 "weight": weight,
                 "created_at": ts,
+                "source_memory_rid": source_memory_rid,
+                "polarity": polarity,
+                "modality": modality,
+                "valid_from": valid_from,
+                "valid_to": valid_to,
+                "extractor": extractor,
+                "extractor_version": extractor_version,
+                "confidence_band": confidence_band,
+                "namespace": namespace,
             }),
             None,
         )?;
 
-        Ok(edge_id)
+        Ok(claim_id)
+    }
+
+    /// Create or update a relationship between entities.
+    ///
+    /// **Deprecated since v0.7** — use `ingest_claim()` or `POST /v1/claim` instead.
+    /// This wrapper remains for backward compatibility with existing callers and
+    /// the CRDT replication path. All writes now go to the `claims` table.
+    #[tracing::instrument(skip(self))]
+    pub fn relate(
+        &self,
+        src: &str,
+        dst: &str,
+        rel_type: &str,
+        weight: f64,
+    ) -> Result<String> {
+        self.ingest_claim(
+            src, dst, rel_type, weight,
+            None,       // source_memory_rid
+            1,          // polarity = positive
+            "asserted", // modality
+            None,       // valid_from
+            None,       // valid_to
+            "manual",   // extractor
+            None,       // extractor_version
+            "medium",   // confidence_band
+            "default",  // namespace
+        )
+    }
+
+    /// Get all claims connected to an entity, with full claim metadata.
+    pub fn get_claims(&self, entity: &str, namespace: Option<&str>) -> Result<Vec<Claim>> {
+        let conn = self.conn.lock();
+        let (sql, params_box): (String, Vec<Box<dyn rusqlite::types::ToSql>>) = match namespace {
+            Some(ns) => (
+                "SELECT claim_id, src, dst, rel_type, weight, created_at, \
+                  source_memory_rid, polarity, modality, valid_from, valid_to, \
+                  extractor, extractor_version, confidence_band, span_start, span_end, namespace \
+                 FROM claims \
+                 WHERE (src = ?1 OR dst = ?1) AND tombstoned = 0 AND namespace = ?2"
+                    .to_string(),
+                vec![
+                    Box::new(entity.to_string()) as Box<dyn rusqlite::types::ToSql>,
+                    Box::new(ns.to_string()),
+                ],
+            ),
+            None => (
+                "SELECT claim_id, src, dst, rel_type, weight, created_at, \
+                  source_memory_rid, polarity, modality, valid_from, valid_to, \
+                  extractor, extractor_version, confidence_band, span_start, span_end, namespace \
+                 FROM claims \
+                 WHERE (src = ?1 OR dst = ?1) AND tombstoned = 0"
+                    .to_string(),
+                vec![Box::new(entity.to_string()) as Box<dyn rusqlite::types::ToSql>],
+            ),
+        };
+
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_box.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = conn.prepare(&sql)?;
+        let claims = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                Ok(Claim {
+                    claim_id: row.get(0)?,
+                    src: row.get(1)?,
+                    dst: row.get(2)?,
+                    rel_type: row.get(3)?,
+                    weight: row.get(4)?,
+                    created_at: row.get(5)?,
+                    source_memory_rid: row.get(6)?,
+                    polarity: row.get(7)?,
+                    modality: row.get(8)?,
+                    valid_from: row.get(9)?,
+                    valid_to: row.get(10)?,
+                    extractor: row.get(11)?,
+                    extractor_version: row.get(12)?,
+                    confidence_band: row.get(13)?,
+                    span_start: row.get(14)?,
+                    span_end: row.get(15)?,
+                    namespace: row.get(16)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        Ok(claims)
+    }
+
+    /// Register an explicit entity alias for canonical name resolution.
+    ///
+    /// After adding `alias → canonical_name`, any `ingest_claim()` call that
+    /// uses `alias` as `src` or `dst` will automatically resolve to `canonical_name`.
+    pub fn add_entity_alias(
+        &self,
+        alias: &str,
+        canonical_name: &str,
+        namespace: &str,
+    ) -> Result<()> {
+        let ts = now();
+        let conn = self.conn.lock();
+        conn.execute(
+            "INSERT INTO entity_aliases (alias, canonical_name, namespace, source, created_at) \
+             VALUES (?1, ?2, ?3, 'explicit', ?4) \
+             ON CONFLICT(alias, namespace) DO UPDATE SET canonical_name = ?2",
+            params![alias, canonical_name, namespace, ts],
+        )?;
+        Ok(())
     }
 
     /// Get all edges connected to an entity.
+    ///
+    /// Reads through the `edges` backward-compat VIEW. For full claim metadata
+    /// use `get_claims()` instead.
     pub fn get_edges(&self, entity: &str) -> Result<Vec<Edge>> {
         let conn = self.conn.lock();
         let mut stmt = conn.prepare(

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -74,7 +74,7 @@ use crate::schema::{
     MIGRATE_V1_TO_V2, MIGRATE_V2_TO_V3, MIGRATE_V3_TO_V4, MIGRATE_V4_TO_V5,
     MIGRATE_V5_TO_V6, MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9,
     MIGRATE_V9_TO_V10, MIGRATE_V10_TO_V11, MIGRATE_V11_TO_V12, MIGRATE_V12_TO_V13,
-    MIGRATE_V13_TO_V14,
+    MIGRATE_V13_TO_V14, MIGRATE_V14_TO_V15,
     SCHEMA_SQL, SCHEMA_VERSION,
 };
 use crate::types::*;
@@ -215,6 +215,7 @@ impl YantrikDB {
             (11, MIGRATE_V11_TO_V12),
             (12, MIGRATE_V12_TO_V13),
             (13, MIGRATE_V13_TO_V14),
+            (14, MIGRATE_V14_TO_V15),
         ];
         if let Some(v) = existing_version {
             for &(from_v, sql) in migrations {

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -344,6 +344,28 @@ const CONCEPT_DST_RELS: &[&str] = &[
 
 /// Classify entity types using relationship semantics.
 /// Returns (src_type, dst_type) — either may be "unknown" if not inferable.
+/// Resolve an entity name to its canonical form using the `entity_aliases` table.
+///
+/// Looks up `alias` in the namespace-specific aliases first, then falls back to
+/// the `'default'` namespace. Returns the canonical name if found, otherwise
+/// returns the original `entity` string unchanged.
+///
+/// Used by `ingest_claim()` to normalize `src`/`dst` before storage, ensuring
+/// that "AWS" and "Amazon Web Services" are treated as the same entity in conflict
+/// detection and graph traversal.
+pub fn resolve_alias(entity: &str, namespace: &str, conn: &Connection) -> String {
+    // Query: prefer namespace-specific alias, fall back to 'default' namespace.
+    let result: rusqlite::Result<String> = conn.query_row(
+        "SELECT canonical_name FROM entity_aliases \
+         WHERE alias = ?1 AND namespace IN (?2, 'default') \
+         ORDER BY CASE WHEN namespace = ?2 THEN 0 ELSE 1 END \
+         LIMIT 1",
+        params![entity, namespace],
+        |row| row.get(0),
+    );
+    result.unwrap_or_else(|_| entity.to_string())
+}
+
 pub fn classify_with_relationship(
     src: &str,
     dst: &str,
@@ -707,7 +729,7 @@ mod tests {
         let db = setup_db();
         // Tombstone the Alice->Bob edge
         db.conn().execute(
-            "UPDATE edges SET tombstoned = 1 WHERE src = 'Alice' AND dst = 'Bob'",
+            "UPDATE claims SET tombstoned = 1 WHERE src = 'Alice' AND dst = 'Bob'",
             [],
         ).unwrap();
         let expanded = expand_entities_nhop(&*db.conn(), &["Alice"], 1, 30).unwrap();

--- a/crates/yantrikdb-protocol/src/messages.rs
+++ b/crates/yantrikdb-protocol/src/messages.rs
@@ -214,6 +214,105 @@ pub struct EdgeMsg {
     pub weight: f64,
 }
 
+// ── Claims (v0.7) ─────────────────────────────────────────────────
+
+/// Structured claim ingest request. All writes should use this instead of
+/// `RelateRequest` starting from v0.7.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaimRequest {
+    pub src: String,
+    pub dst: String,
+    pub rel_type: String,
+    #[serde(default = "default_weight")]
+    pub weight: f64,
+    #[serde(default)]
+    pub source_memory_rid: Option<String>,
+    /// Polarity: `"positive"` (default), `"negative"`, or `"unknown"`.
+    #[serde(default = "default_polarity")]
+    pub polarity: String,
+    /// Modality: `"asserted"` (default), `"reported"`, `"hypothetical"`, `"denied"`, `"quoted"`.
+    #[serde(default = "default_modality")]
+    pub modality: String,
+    #[serde(default)]
+    pub valid_from: Option<f64>,
+    #[serde(default)]
+    pub valid_to: Option<f64>,
+    /// Extractor: `"manual"` (default), `"structured_ingest"`, `"heuristic_v1"`, `"agent_llm"`.
+    #[serde(default = "default_extractor")]
+    pub extractor: String,
+    #[serde(default)]
+    pub extractor_version: Option<String>,
+    /// Confidence band: `"low"`, `"medium"` (default), `"high"`.
+    #[serde(default = "default_confidence_band")]
+    pub confidence_band: String,
+    #[serde(default = "default_namespace_str")]
+    pub namespace: String,
+}
+
+fn default_polarity() -> String { "positive".into() }
+fn default_modality() -> String { "asserted".into() }
+fn default_extractor() -> String { "manual".into() }
+fn default_confidence_band() -> String { "medium".into() }
+fn default_namespace_str() -> String { "default".into() }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaimOkResponse {
+    pub claim_id: String,
+    pub created_at: f64,
+    pub namespace: String,
+}
+
+/// Query claims for an entity.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaimsRequest {
+    pub entity: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
+}
+
+/// Wire representation of a single claim.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaimMsg {
+    pub claim_id: String,
+    pub src: String,
+    pub dst: String,
+    pub rel_type: String,
+    pub weight: f64,
+    pub created_at: f64,
+    pub source_memory_rid: Option<String>,
+    pub polarity: i32,
+    pub modality: String,
+    pub valid_from: Option<f64>,
+    pub valid_to: Option<f64>,
+    pub extractor: String,
+    pub extractor_version: Option<String>,
+    pub confidence_band: String,
+    pub span_start: Option<i64>,
+    pub span_end: Option<i64>,
+    pub namespace: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaimsResultMsg {
+    pub claims: Vec<ClaimMsg>,
+}
+
+/// Register an explicit entity alias for canonical name resolution.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AliasRequest {
+    pub alias: String,
+    pub canonical_name: String,
+    #[serde(default = "default_namespace_str")]
+    pub namespace: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AliasOkResponse {
+    pub alias: String,
+    pub canonical_name: String,
+    pub namespace: String,
+}
+
 // ── Forget ────────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/yantrikdb-protocol/src/opcodes.rs
+++ b/crates/yantrikdb-protocol/src/opcodes.rs
@@ -30,11 +30,20 @@ pub enum OpCode {
     RecallResult = 0x31,
     RecallEnd = 0x32,
 
-    // --- Graph (0x40–0x43) ---
+    // --- Graph (0x40–0x49) ---
     Relate = 0x40,
     RelateOk = 0x41,
     Edges = 0x42,
     EdgesResult = 0x43,
+    /// Ingest a structured claim (v0.7 primary write path; supersedes Relate).
+    Claim = 0x44,
+    ClaimOk = 0x45,
+    /// Query claims for an entity.
+    Claims = 0x46,
+    ClaimsResult = 0x47,
+    /// Register an explicit entity alias for canonical name resolution.
+    Alias = 0x48,
+    AliasOk = 0x49,
 
     // --- Forget (0x50–0x51) ---
     Forget = 0x50,
@@ -113,6 +122,12 @@ impl OpCode {
             0x41 => Some(Self::RelateOk),
             0x42 => Some(Self::Edges),
             0x43 => Some(Self::EdgesResult),
+            0x44 => Some(Self::Claim),
+            0x45 => Some(Self::ClaimOk),
+            0x46 => Some(Self::Claims),
+            0x47 => Some(Self::ClaimsResult),
+            0x48 => Some(Self::Alias),
+            0x49 => Some(Self::AliasOk),
 
             0x50 => Some(Self::Forget),
             0x51 => Some(Self::ForgetOk),
@@ -187,6 +202,12 @@ mod tests {
             OpCode::RelateOk,
             OpCode::Edges,
             OpCode::EdgesResult,
+            OpCode::Claim,
+            OpCode::ClaimOk,
+            OpCode::Claims,
+            OpCode::ClaimsResult,
+            OpCode::Alias,
+            OpCode::AliasOk,
             OpCode::Forget,
             OpCode::ForgetOk,
             OpCode::SessionStart,

--- a/crates/yantrikdb-server/src/command.rs
+++ b/crates/yantrikdb-server/src/command.rs
@@ -50,6 +50,33 @@ pub enum Command {
     Edges {
         entity: String,
     },
+    /// Structured claim ingest — v0.7 primary write path (supersedes Relate).
+    Claim {
+        src: String,
+        dst: String,
+        rel_type: String,
+        weight: f64,
+        source_memory_rid: Option<String>,
+        polarity: i32,
+        modality: String,
+        valid_from: Option<f64>,
+        valid_to: Option<f64>,
+        extractor: String,
+        extractor_version: Option<String>,
+        confidence_band: String,
+        namespace: String,
+    },
+    /// Query claims for an entity.
+    Claims {
+        entity: String,
+        namespace: Option<String>,
+    },
+    /// Register an explicit entity alias for canonical name resolution.
+    Alias {
+        alias: String,
+        canonical_name: String,
+        namespace: String,
+    },
 
     // ── Session ───────────────────────────────────────────
     SessionStart {

--- a/crates/yantrikdb-server/src/handler.rs
+++ b/crates/yantrikdb-server/src/handler.rs
@@ -219,6 +219,89 @@ pub fn execute_with_guard(
             Ok(CommandResult::Json(json!({ "edges": edge_list })))
         }
 
+        Command::Claim {
+            src,
+            dst,
+            rel_type,
+            weight,
+            source_memory_rid,
+            polarity,
+            modality,
+            valid_from,
+            valid_to,
+            extractor,
+            extractor_version,
+            confidence_band,
+            namespace,
+        } => {
+            let claim_id = db.ingest_claim(
+                &src,
+                &dst,
+                &rel_type,
+                weight,
+                source_memory_rid.as_deref(),
+                polarity,
+                &modality,
+                valid_from,
+                valid_to,
+                &extractor,
+                extractor_version.as_deref(),
+                &confidence_band,
+                &namespace,
+            )?;
+            let created_at = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs_f64())
+                .unwrap_or(0.0);
+            Ok(CommandResult::Json(json!({
+                "claim_id": claim_id,
+                "created_at": created_at,
+                "namespace": namespace,
+            })))
+        }
+
+        Command::Claims { entity, namespace } => {
+            let claims = db.get_claims(&entity, namespace.as_deref())?;
+            let claim_list: Vec<Value> = claims
+                .iter()
+                .map(|c| {
+                    json!({
+                        "claim_id": c.claim_id,
+                        "src": c.src,
+                        "dst": c.dst,
+                        "rel_type": c.rel_type,
+                        "weight": c.weight,
+                        "created_at": c.created_at,
+                        "source_memory_rid": c.source_memory_rid,
+                        "polarity": c.polarity,
+                        "modality": c.modality,
+                        "valid_from": c.valid_from,
+                        "valid_to": c.valid_to,
+                        "extractor": c.extractor,
+                        "extractor_version": c.extractor_version,
+                        "confidence_band": c.confidence_band,
+                        "span_start": c.span_start,
+                        "span_end": c.span_end,
+                        "namespace": c.namespace,
+                    })
+                })
+                .collect();
+            Ok(CommandResult::Json(json!({ "claims": claim_list })))
+        }
+
+        Command::Alias {
+            alias,
+            canonical_name,
+            namespace,
+        } => {
+            db.add_entity_alias(&alias, &canonical_name, &namespace)?;
+            Ok(CommandResult::Json(json!({
+                "alias": alias,
+                "canonical_name": canonical_name,
+                "namespace": namespace,
+            })))
+        }
+
         Command::SessionStart {
             namespace,
             client_id,

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -5,8 +5,9 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path as AxumPath, State},
+    extract::{Path as AxumPath, Query, State},
     http::StatusCode,
+    response::IntoResponse,
     routing::{delete, get, post},
     Json, Router,
 };
@@ -597,31 +598,151 @@ async fn forget(
     .await
 }
 
+/// **Deprecated since v0.7.** Use `POST /v1/claim` instead.
+///
+/// This endpoint remains for backward compatibility. A `Deprecation: true` and
+/// `Link: </v1/claim>; rel="successor-version"` header are added to responses
+/// to guide callers to migrate.
 async fn relate(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
     Json(body): Json<Value>,
-) -> AppResult {
+) -> impl IntoResponse {
     let _timer = crate::metrics::HandlerTimer::new("relate");
+    if let Err(e) = check_writable(&state) {
+        return e.into_response();
+    }
+    let (_, engine) = match resolve_engine(
+        &state,
+        headers.get("authorization").and_then(|v| v.to_str().ok()),
+    ) {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
+    let cmd = match (|| -> Result<Command, AppError> {
+        Ok(Command::Relate {
+            entity: body["entity"]
+                .as_str()
+                .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'entity'"))?
+                .into(),
+            target: body["target"]
+                .as_str()
+                .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'target'"))?
+                .into(),
+            relationship: body["relationship"]
+                .as_str()
+                .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'relationship'"))?
+                .into(),
+            weight: body.get("weight").and_then(|v| v.as_f64()).unwrap_or(1.0),
+        })
+    })() {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+    match execute_cmd(engine, cmd, state.control.clone(), &state.inflight).await {
+        Ok(Json(body)) => {
+            let mut resp_headers = axum::http::HeaderMap::new();
+            resp_headers.insert("Deprecation", axum::http::HeaderValue::from_static("true"));
+            resp_headers.insert(
+                "Link",
+                axum::http::HeaderValue::from_static("</v1/claim>; rel=\"successor-version\""),
+            );
+            (StatusCode::OK, resp_headers, Json(body)).into_response()
+        }
+        Err(e) => e.into_response(),
+    }
+}
+
+/// Ingest a structured claim — v0.7 primary write path.
+async fn claim(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<Value>,
+) -> AppResult {
+    let _timer = crate::metrics::HandlerTimer::new("claim");
     check_writable(&state)?;
     let (_, engine) = resolve_engine(
         &state,
         headers.get("authorization").and_then(|v| v.to_str().ok()),
     )?;
-    let cmd = Command::Relate {
-        entity: body["entity"]
+
+    let polarity_str = body.get("polarity").and_then(|v| v.as_str()).unwrap_or("positive");
+    let polarity: i32 = match polarity_str {
+        "positive" => 1,
+        "negative" => -1,
+        "unknown" => 0,
+        _ => return Err(app_error(StatusCode::BAD_REQUEST, "polarity must be 'positive', 'negative', or 'unknown'")),
+    };
+
+    let cmd = Command::Claim {
+        src: body["src"]
             .as_str()
-            .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'entity'"))?
+            .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'src'"))?
             .into(),
-        target: body["target"]
+        dst: body["dst"]
             .as_str()
-            .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'target'"))?
+            .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'dst'"))?
             .into(),
-        relationship: body["relationship"]
+        rel_type: body["rel_type"]
             .as_str()
-            .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'relationship'"))?
+            .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'rel_type'"))?
             .into(),
         weight: body.get("weight").and_then(|v| v.as_f64()).unwrap_or(1.0),
+        source_memory_rid: body.get("source_memory_rid").and_then(|v| v.as_str()).map(str::to_owned),
+        polarity,
+        modality: body.get("modality").and_then(|v| v.as_str()).unwrap_or("asserted").into(),
+        valid_from: body.get("valid_from").and_then(|v| v.as_f64()),
+        valid_to: body.get("valid_to").and_then(|v| v.as_f64()),
+        extractor: body.get("extractor").and_then(|v| v.as_str()).unwrap_or("manual").into(),
+        extractor_version: body.get("extractor_version").and_then(|v| v.as_str()).map(str::to_owned),
+        confidence_band: body.get("confidence_band").and_then(|v| v.as_str()).unwrap_or("medium").into(),
+        namespace: body.get("namespace").and_then(|v| v.as_str()).unwrap_or("default").into(),
+    };
+    execute_cmd(engine, cmd, state.control.clone(), &state.inflight).await
+}
+
+/// Query claims connected to an entity. Optional `namespace` query param.
+async fn get_claims(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> AppResult {
+    let _timer = crate::metrics::HandlerTimer::new("claims");
+    let (_, engine) = resolve_engine(
+        &state,
+        headers.get("authorization").and_then(|v| v.to_str().ok()),
+    )?;
+    let entity = params
+        .get("entity")
+        .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'entity' query param"))?
+        .clone();
+    let namespace = params.get("namespace").cloned();
+    let cmd = Command::Claims { entity, namespace };
+    execute_cmd(engine, cmd, state.control.clone(), &state.inflight).await
+}
+
+/// Register an explicit entity alias: `alias → canonical_name`.
+async fn add_alias(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<Value>,
+) -> AppResult {
+    let _timer = crate::metrics::HandlerTimer::new("alias");
+    check_writable(&state)?;
+    let (_, engine) = resolve_engine(
+        &state,
+        headers.get("authorization").and_then(|v| v.to_str().ok()),
+    )?;
+    let cmd = Command::Alias {
+        alias: body["alias"]
+            .as_str()
+            .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'alias'"))?
+            .into(),
+        canonical_name: body["canonical_name"]
+            .as_str()
+            .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'canonical_name'"))?
+            .into(),
+        namespace: body.get("namespace").and_then(|v| v.as_str()).unwrap_or("default").into(),
     };
     execute_cmd(engine, cmd, state.control.clone(), &state.inflight).await
 }
@@ -1225,6 +1346,9 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/v1/recall", post(recall))
         .route("/v1/forget", post(forget))
         .route("/v1/relate", post(relate))
+        .route("/v1/claim", post(claim))
+        .route("/v1/claims", get(get_claims))
+        .route("/v1/alias", post(add_alias))
         .route("/v1/think", post(think))
         .route("/v1/conflicts", get(conflicts))
         .route("/v1/conflicts/{id}/resolve", post(resolve_conflict))

--- a/crates/yantrikdb-server/src/server.rs
+++ b/crates/yantrikdb-server/src/server.rs
@@ -427,6 +427,45 @@ fn frame_to_command(frame: &Frame) -> anyhow::Result<Command> {
         }
         OpCode::ListDb => Ok(Command::ListDb),
         OpCode::Ping => Ok(Command::Ping),
+        OpCode::Claim => {
+            let req: ClaimRequest = unpack(&frame.payload)?;
+            let polarity: i32 = match req.polarity.as_str() {
+                "positive" => 1,
+                "negative" => -1,
+                "unknown" => 0,
+                _ => 1,
+            };
+            Ok(Command::Claim {
+                src: req.src,
+                dst: req.dst,
+                rel_type: req.rel_type,
+                weight: req.weight,
+                source_memory_rid: req.source_memory_rid,
+                polarity,
+                modality: req.modality,
+                valid_from: req.valid_from,
+                valid_to: req.valid_to,
+                extractor: req.extractor,
+                extractor_version: req.extractor_version,
+                confidence_band: req.confidence_band,
+                namespace: req.namespace,
+            })
+        }
+        OpCode::Claims => {
+            let req: ClaimsRequest = unpack(&frame.payload)?;
+            Ok(Command::Claims {
+                entity: req.entity,
+                namespace: req.namespace,
+            })
+        }
+        OpCode::Alias => {
+            let req: AliasRequest = unpack(&frame.payload)?;
+            Ok(Command::Alias {
+                alias: req.alias,
+                canonical_name: req.canonical_name,
+                namespace: req.namespace,
+            })
+        }
         other => anyhow::bail!("unsupported opcode: {:?}", other),
     }
 }
@@ -486,6 +525,12 @@ fn response_opcode_for_json(value: &serde_json::Value) -> OpCode {
         OpCode::RelateOk
     } else if value.get("edges").is_some() {
         OpCode::EdgesResult
+    } else if value.get("claim_id").is_some() {
+        OpCode::ClaimOk
+    } else if value.get("claims").is_some() {
+        OpCode::ClaimsResult
+    } else if value.get("alias").is_some() && value.get("canonical_name").is_some() {
+        OpCode::AliasOk
     } else if value.get("session_id").is_some() {
         OpCode::SessionOk
     } else if value.get("consolidation_count").is_some() {


### PR DESCRIPTION
RFC 006 Phase 5 (v0.7): Full Claims Abstraction + Entity Linking
Summary
Promotes claims as the first-class storage abstraction; edges table becomes a backward-compatible read-only SQLite VIEW
All new writes route through POST /v1/claim and the ingest_claim() engine method
Adds entity_aliases table + resolve_alias() for alias-aware entity linking
POST /v1/relate is preserved but marked deprecated via response headers
Changes
Schema (V14 → V15)

Create claims table with all RFC 006 Layer A qualifier columns: polarity, modality, valid_from, valid_to, extractor, extractor_version, confidence_band, source_memory_rid, namespace, span_start, span_end
Migrate existing edge data into claims with safe defaults
Recreate edges as CREATE VIEW edges AS SELECT claim_id AS edge_id, src, dst, rel_type, weight, created_at, tombstoned FROM claims
Add entity_aliases table with (alias, namespace) primary key and index on canonical_name
Engine (graph_ops.rs)

Add ingest_claim() as the primary write method — resolves aliases, inserts into claims, logs op_type="claim" to oplog
Rewrite relate() as a deprecated thin wrapper around ingest_claim()
Add get_claims() and add_entity_alias() methods
Entity Linking (knowledge/graph.rs)

Add resolve_alias(entity, namespace, conn) — prefers namespace-specific aliases over global 'default', returns original entity name if no alias found
Applied automatically inside ingest_claim() before storage
HTTP API

POST /v1/claim — structured claim ingest
GET /v1/claims?entity=&namespace= — fetch all claims for an entity
POST /v1/alias — register an explicit entity alias
POST /v1/relate — unchanged behavior, now returns Deprecation: true and Link: </v1/claim>; rel="successor-version" headers
Wire Protocol

New opcodes: Claim (0x44), ClaimOk (0x45), Claims (0x46), ClaimsResult (0x47), Alias (0x48), AliasOk (0x49)
CRDT Replication & Conflict Detection

materialize_relate() writes directly to claims table
Conflict detection and oplog dispatch updated to handle both op_type='relate' and op_type='claim'
All existing SELECT ... FROM edges queries unchanged via VIEW
Backward Compatibility
All code reading from edges (conflict detection, triggers, patterns, stats, graph index) continues to work without modification. relate() still works. No breaking changes to existing clients.

Closes #8