### PR TITLE
feat: RFC 006 Phase 5 — claims wire opcodes, GET /v1/claims, deprecat…

### DIFF
--- a/crates/yantrikdb-protocol/src/messages.rs
+++ b/crates/yantrikdb-protocol/src/messages.rs
@@ -214,6 +214,107 @@ pub struct EdgeMsg {
     pub weight: f64,
 }
 
+// ── Claims ────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaimRequest {
+    pub src: String,
+    pub rel_type: String,
+    pub dst: String,
+    #[serde(default = "default_namespace")]
+    pub namespace: String,
+    #[serde(default = "default_polarity")]
+    pub polarity: i32,
+    #[serde(default = "default_modality")]
+    pub modality: String,
+    #[serde(default)]
+    pub valid_from: Option<f64>,
+    #[serde(default)]
+    pub valid_to: Option<f64>,
+    #[serde(default = "default_extractor")]
+    pub extractor: String,
+    #[serde(default)]
+    pub extractor_version: Option<String>,
+    #[serde(default = "default_confidence_band")]
+    pub confidence_band: String,
+    #[serde(default)]
+    pub source_memory_rid: Option<String>,
+    #[serde(default)]
+    pub span_start: Option<i32>,
+    #[serde(default)]
+    pub span_end: Option<i32>,
+    #[serde(default = "default_weight")]
+    pub weight: f64,
+}
+
+fn default_polarity() -> i32 {
+    1
+}
+fn default_modality() -> String {
+    "asserted".into()
+}
+fn default_extractor() -> String {
+    "manual".into()
+}
+fn default_confidence_band() -> String {
+    "medium".into()
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaimOkResponse {
+    pub claim_id: String,
+    pub namespace: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaimsRequest {
+    pub entity: String,
+    #[serde(default = "default_namespace")]
+    pub namespace: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaimsResultMsg {
+    pub claims: Vec<ClaimMsg>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaimMsg {
+    pub claim_id: String,
+    pub src: String,
+    pub dst: String,
+    pub rel_type: String,
+    pub weight: f64,
+    pub polarity: i32,
+    pub modality: String,
+    pub namespace: String,
+    pub confidence_band: String,
+}
+
+// ── Alias ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AliasRequest {
+    pub alias: String,
+    pub canonical_name: String,
+    #[serde(default = "default_namespace")]
+    pub namespace: String,
+    #[serde(default = "default_alias_source")]
+    pub source: String,
+}
+
+fn default_alias_source() -> String {
+    "explicit".into()
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AliasOkResponse {
+    pub alias: String,
+    pub canonical_name: String,
+    pub namespace: String,
+    pub added: bool,
+}
+
 // ── Forget ────────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/yantrikdb-protocol/src/opcodes.rs
+++ b/crates/yantrikdb-protocol/src/opcodes.rs
@@ -36,6 +36,14 @@ pub enum OpCode {
     Edges = 0x42,
     EdgesResult = 0x43,
 
+    // --- Claims (0x44–0x49) ---
+    Claim = 0x44,      // C→S: ingest a claim
+    ClaimOk = 0x45,    // S→C: claim ingested
+    Claims = 0x46,     // C→S: query claims for an entity
+    ClaimsResult = 0x47, // S→C: claims list
+    Alias = 0x48,      // C→S: add entity alias
+    AliasOk = 0x49,    // S→C: alias added
+
     // --- Forget (0x50–0x51) ---
     Forget = 0x50,
     ForgetOk = 0x51,
@@ -113,6 +121,12 @@ impl OpCode {
             0x41 => Some(Self::RelateOk),
             0x42 => Some(Self::Edges),
             0x43 => Some(Self::EdgesResult),
+            0x44 => Some(Self::Claim),
+            0x45 => Some(Self::ClaimOk),
+            0x46 => Some(Self::Claims),
+            0x47 => Some(Self::ClaimsResult),
+            0x48 => Some(Self::Alias),
+            0x49 => Some(Self::AliasOk),
 
             0x50 => Some(Self::Forget),
             0x51 => Some(Self::ForgetOk),
@@ -187,6 +201,12 @@ mod tests {
             OpCode::RelateOk,
             OpCode::Edges,
             OpCode::EdgesResult,
+            OpCode::Claim,
+            OpCode::ClaimOk,
+            OpCode::Claims,
+            OpCode::ClaimsResult,
+            OpCode::Alias,
+            OpCode::AliasOk,
             OpCode::Forget,
             OpCode::ForgetOk,
             OpCode::SessionStart,

--- a/crates/yantrikdb-server/src/command.rs
+++ b/crates/yantrikdb-server/src/command.rs
@@ -86,7 +86,11 @@ pub enum Command {
         resolution_note: Option<String>,
     },
 
-    // ── Claims (RFC 006 Phase 1) ────────────────────────
+    // ── Claims (RFC 006 Phase 5) ────────────────────────
+    GetClaims {
+        entity: String,
+        namespace: Option<String>,
+    },
     IngestClaim {
         src: String,
         rel_type: String,

--- a/crates/yantrikdb-server/src/handler.rs
+++ b/crates/yantrikdb-server/src/handler.rs
@@ -333,6 +333,11 @@ pub fn execute_with_guard(
             })))
         }
 
+        Command::GetClaims { entity, namespace } => {
+            let claims = db.get_claims(&entity, namespace.as_deref())?;
+            Ok(CommandResult::Json(json!({ "claims": claims })))
+        }
+
         Command::IngestClaim {
             src, rel_type, dst, namespace, polarity, modality,
             valid_from, valid_to, extractor, extractor_version,

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -5,8 +5,9 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path as AxumPath, State},
-    http::StatusCode,
+    extract::{Path as AxumPath, Query, State},
+    http::{HeaderValue, StatusCode},
+    response::IntoResponse,
     routing::{delete, get, post},
     Json, Router,
 };
@@ -601,7 +602,7 @@ async fn relate(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
     Json(body): Json<Value>,
-) -> AppResult {
+) -> Result<impl IntoResponse, AppError> {
     let _timer = crate::metrics::HandlerTimer::new("relate");
     check_writable(&state)?;
     let (_, engine) = resolve_engine(
@@ -623,7 +624,17 @@ async fn relate(
             .into(),
         weight: body.get("weight").and_then(|v| v.as_f64()).unwrap_or(1.0),
     };
-    execute_cmd(engine, cmd, state.control.clone(), &state.inflight).await
+    let json = execute_cmd(engine, cmd, state.control.clone(), &state.inflight).await?;
+    let mut response = json.into_response();
+    response.headers_mut().insert(
+        "deprecation",
+        HeaderValue::from_static("true"),
+    );
+    response.headers_mut().insert(
+        "link",
+        HeaderValue::from_static(r#"</v1/claim>; rel="successor-version""#),
+    );
+    Ok(response)
 }
 
 async fn ingest_claim(
@@ -732,6 +743,30 @@ async fn add_alias(
             .into(),
     };
     execute_cmd(engine, cmd, state.control.clone(), &state.inflight).await
+}
+
+async fn get_claims(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> AppResult {
+    let _timer = crate::metrics::HandlerTimer::new("get_claims");
+    let (_, engine) = resolve_engine(
+        &state,
+        headers.get("authorization").and_then(|v| v.to_str().ok()),
+    )?;
+    let entity = params
+        .get("entity")
+        .cloned()
+        .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'entity' query parameter"))?;
+    let namespace = params.get("namespace").cloned();
+    execute_cmd(
+        engine,
+        Command::GetClaims { entity, namespace },
+        state.control.clone(),
+        &state.inflight,
+    )
+    .await
 }
 
 async fn think(
@@ -1334,6 +1369,7 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/v1/forget", post(forget))
         .route("/v1/relate", post(relate))
         .route("/v1/claim", post(ingest_claim))
+        .route("/v1/claims", get(get_claims))
         .route("/v1/alias", post(add_alias))
         .route("/v1/think", post(think))
         .route("/v1/conflicts", get(conflicts))

--- a/crates/yantrikdb-server/src/server.rs
+++ b/crates/yantrikdb-server/src/server.rs
@@ -295,6 +295,8 @@ fn is_write_command(cmd: &Command) -> bool {
             | Command::RememberBatch { .. }
             | Command::Forget { .. }
             | Command::Relate { .. }
+            | Command::IngestClaim { .. }
+            | Command::AddAlias { .. }
             | Command::SessionStart { .. }
             | Command::SessionEnd { .. }
             | Command::Think { .. }
@@ -419,6 +421,46 @@ fn frame_to_command(frame: &Frame) -> anyhow::Result<Command> {
                 resolution_note: req.resolution_note,
             })
         }
+        OpCode::Claim => {
+            let req: ClaimRequest = unpack(&frame.payload)?;
+            Ok(Command::IngestClaim {
+                src: req.src,
+                rel_type: req.rel_type,
+                dst: req.dst,
+                namespace: req.namespace,
+                polarity: req.polarity,
+                modality: req.modality,
+                valid_from: req.valid_from,
+                valid_to: req.valid_to,
+                extractor: req.extractor,
+                extractor_version: req.extractor_version,
+                confidence_band: req.confidence_band,
+                source_memory_rid: req.source_memory_rid,
+                span_start: req.span_start,
+                span_end: req.span_end,
+                weight: req.weight,
+            })
+        }
+        OpCode::Claims => {
+            let req: ClaimsRequest = unpack(&frame.payload)?;
+            Ok(Command::GetClaims {
+                entity: req.entity,
+                namespace: if req.namespace.is_empty() || req.namespace == "default" {
+                    None
+                } else {
+                    Some(req.namespace)
+                },
+            })
+        }
+        OpCode::Alias => {
+            let req: AliasRequest = unpack(&frame.payload)?;
+            Ok(Command::AddAlias {
+                alias: req.alias,
+                canonical_name: req.canonical_name,
+                namespace: req.namespace,
+                source: req.source,
+            })
+        }
         OpCode::Personality => Ok(Command::Personality),
         OpCode::Stats => Ok(Command::Stats),
         OpCode::CreateDb => {
@@ -482,6 +524,12 @@ fn response_opcode_for_json(value: &serde_json::Value) -> OpCode {
         OpCode::RememberOk
     } else if value.get("found").is_some() {
         OpCode::ForgetOk
+    } else if value.get("claim_id").is_some() {
+        OpCode::ClaimOk
+    } else if value.get("claims").is_some() {
+        OpCode::ClaimsResult
+    } else if value.get("alias").is_some() {
+        OpCode::AliasOk
     } else if value.get("edge_id").is_some() {
         OpCode::RelateOk
     } else if value.get("edges").is_some() {


### PR DESCRIPTION
…e POST /v1/relate

- Add Claim/ClaimOk/Claims/ClaimsResult/Alias/AliasOk opcodes (0x44–0x49) to the wire protocol, with typed message structs and full roundtrip test coverage in opcodes.rs
- Wire Claim → IngestClaim, Claims → GetClaims, Alias → AddAlias in the TCP server dispatch; mark IngestClaim and AddAlias as write commands
- Add GET /v1/claims?entity=&namespace= HTTP endpoint backed by the engine's get_claims() (RFC 006 Phase 5, not yet exposed over HTTP)
- Add Deprecation: true and Link: </v1/claim>; rel="successor-version" response headers to POST /v1/relate to signal its successor