### PR TITLE
feat(observability): surface at-rest encryption status (yantrikos/yantrikdb#3)

### DIFF
--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -289,10 +289,22 @@ async fn health_deep(State(state): State<Arc<AppState>>) -> (StatusCode, Json<Va
         StatusCode::SERVICE_UNAVAILABLE
     };
 
+    // Surface at-rest encryption status. Issue #3 (yantrikos/yantrikdb)
+    // reported there was no way to verify encryption was active without
+    // running `strings` on the SQLite file. The TenantPool already knows
+    // whether a master key was configured at startup.
+    let encryption_enabled = state.pool.is_encrypted();
+    let encryption_status = if encryption_enabled {
+        json!({"enabled": true, "algorithm": "AES-256-GCM"})
+    } else {
+        json!({"enabled": false, "algorithm": null})
+    };
+
     (
         status,
         Json(json!({
             "status": if all_pass { "healthy" } else { "degraded" },
+            "encryption": encryption_status,
             "checks": checks,
         })),
     )

--- a/crates/yantrikdb-server/src/main.rs
+++ b/crates/yantrikdb-server/src/main.rs
@@ -727,6 +727,20 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
 
     // Resolve master encryption key (auto-generates if needed)
     let master_key = cfg.encryption.resolve_key(&cfg.server.data_dir)?;
+
+    // Issue #3 (yantrikos/yantrikdb): users on Docker setups reported they
+    // saw NO encryption-related output, leaving them unable to confirm
+    // whether at-rest encryption was active. The previous tracing::info/warn
+    // depended on RUST_LOG and tracing-subscriber config, which didn't
+    // surface in their `docker logs` output. We now also write a
+    // boundary-marker banner to stderr (which Docker always captures) so
+    // the encryption state is impossible to miss at startup.
+    let enc_state = if master_key.is_some() {
+        "enabled (AES-256-GCM)"
+    } else {
+        "disabled — set [encryption] section in config to enable at-rest encryption"
+    };
+    eprintln!("[yantrikdb] encryption: {enc_state}");
     if master_key.is_some() {
         tracing::info!("encryption: enabled (AES-256-GCM)");
     } else {


### PR DESCRIPTION
## What

Observability fix for yantrikos/yantrikdb#3 (filed by @acidport).

@acidport reported that setting `[encryption] key_hex` in
`yantrikdb.toml` appeared to have no effect — no log output, no way to
verify encryption was active short of running `strings` on the SQLite
file.

## Investigation finding (no code regression in encryption itself)

The encryption wiring chain is correct from v0.5.0 forward:
`config -> resolve_key -> TenantPool::new(master_key) ->
YantrikDB::new_encrypted -> EncryptionProvider`. BUT:

- The startup log line uses `tracing::info` which is filtered out under
  some Docker logging configs (e.g. when `RUST_LOG` isn't propagated).
- `/v1/health/deep` returned no encryption-related field, so users had
  no programmatic way to verify state.

So the bug, as @acidport experiences it, is **unverifiability**. If
existing v0.5.0+ users were running with plaintext data despite
`key_hex` set, that's most likely (a) a pre-existing plaintext DB
which encrypts only NEW writes, or (b) an old Docker image that
predates the wiring. Both cases now visible at startup and via
`/v1/health/deep`.

## How

1. `crates/yantrikdb-server/src/main.rs`: add
   `eprintln!("[yantrikdb] encryption: ...")` banner alongside the
   existing `tracing::info/warn`. Stderr is always captured by Docker
   regardless of log-filter config.
2. `crates/yantrikdb-server/src/http_gateway.rs`: `/v1/health/deep`
   response now includes:
   ```json
   {
     "encryption": {
       "enabled": <bool>,
       "algorithm": "AES-256-GCM" | null
     }
   }
   ```

## Test (e2e)

Built the patched binary and started locally with `[encryption] key_hex`
set:

```
$ ./target/release/yantrikdb serve --config /tmp/test-encrypted.toml
[yantrikdb] encryption: enabled (AES-256-GCM)
2026-04-23T... INFO yantrikdb_server: encryption: enabled (AES-256-GCM)
...

$ curl -H "Authorization: Bearer ..." http://localhost:17440/v1/health/deep
{
  "checks": [...],
  "encryption": {
    "algorithm": "AES-256-GCM",
    "enabled": true
  },
  "status": "healthy"
}
```

## Follow-ups (not in this PR)

- Add `--config` to `yantrikdb import` so encrypted DBs can be created
  via CLI import (separate paper cut @acidport noted)
- Document migration path: existing plaintext DBs do NOT auto-encrypt
  on key add; recommend export+import flow

Partial-fix for yantrikos/yantrikdb#3 (the observability half — the
root encryption flow already works as of v0.5.0).