### PR TITLE
ci: surface real failures in Publish-to-crates.io workflow

### DIFF
--- a/.github/scripts/publish-crate.sh
+++ b/.github/scripts/publish-crate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Publish a single workspace crate to crates.io with idempotent semantics:
+#
+#   - exit 0 on success
+#   - exit 0 if the crate is ALREADY PUBLISHED at this version (re-run safety)
+#   - exit non-zero on any OTHER failure (manifest invalid, auth, network…)
+#
+# Background: yantrikos/yantrikdb-server v0.7.3 silently failed to publish
+# because the previous version of this workflow used a blanket
+# `continue-on-error: true`, which swallowed a real "all dependencies must
+# have a version requirement specified" manifest error. The tag was pushed,
+# the workflow reported success, but crates.io stayed at v0.7.2.
+#
+# This script makes the distinction loud.
+#
+# Usage:
+#   .github/scripts/publish-crate.sh <crate-name>
+#
+# Required env:
+#   CARGO_REGISTRY_TOKEN
+
+set -euo pipefail
+
+CRATE="${1:?usage: publish-crate.sh <crate-name>}"
+
+if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+  echo "::error::CARGO_REGISTRY_TOKEN is not set"
+  exit 2
+fi
+
+echo "::group::cargo publish -p ${CRATE} --no-verify"
+# Capture combined output AND exit code without `set -e` aborting us.
+set +e
+out="$(cargo publish -p "${CRATE}" --no-verify 2>&1)"
+rc=$?
+set -e
+echo "${out}"
+echo "::endgroup::"
+
+if [[ $rc -eq 0 ]]; then
+  echo "::notice::${CRATE}: published successfully"
+  exit 0
+fi
+
+# Idempotent re-run: crates.io reports "already exists on crates.io index"
+# verbatim when a version is already published. That's an expected outcome
+# of running this workflow against a tag that's already been published.
+if echo "${out}" | grep -qE "already exists on crates\.io"; then
+  echo "::notice::${CRATE}: already published at this version (idempotent re-run, exit 0)"
+  exit 0
+fi
+
+# Anything else is a genuine publish failure that needs to surface in the
+# workflow status. The most painful class historically:
+#   "all dependencies must have a version requirement specified when publishing"
+# (v0.7.3 → v0.7.4 incident).
+echo "::error::${CRATE}: publish failed for a non-idempotent reason; see log group above"
+exit "$rc"

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -27,15 +27,21 @@ jobs:
             target
           key: publish-${{ hashFiles('**/Cargo.toml') }}
 
-      # Publish in dependency order. Each step uses --no-verify to skip
-      # the local rebuild (we trust CI). continue-on-error allows re-running
-      # the workflow safely if a crate is already published at this version.
+      # Each step uses `.github/scripts/publish-crate.sh`, which:
+      #   - exits 0 on success
+      #   - exits 0 if the crate is already published at this version
+      #     (idempotent re-run safety — replaces the previous blanket
+      #     `continue-on-error: true` that swallowed real failures like
+      #     the v0.7.3 manifest-verification error)
+      #   - exits non-zero on any genuine publish failure
+      #
+      # Order matches the dependency graph: protocol → engine → witness →
+      # server → yql.
 
       - name: Publish yantrikdb-protocol
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p yantrikdb-protocol --no-verify
-        continue-on-error: true
+        run: .github/scripts/publish-crate.sh yantrikdb-protocol
 
       - name: Wait for protocol to be indexed
         run: sleep 30
@@ -43,8 +49,7 @@ jobs:
       - name: Publish yantrikdb (core)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p yantrikdb --no-verify
-        continue-on-error: true
+        run: .github/scripts/publish-crate.sh yantrikdb
 
       - name: Wait for core to be indexed
         run: sleep 30
@@ -52,17 +57,14 @@ jobs:
       - name: Publish yantrikdb-witness
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p yantrikdb-witness --no-verify
-        continue-on-error: true
+        run: .github/scripts/publish-crate.sh yantrikdb-witness
 
       - name: Publish yantrikdb-server
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p yantrikdb-server --no-verify
-        continue-on-error: true
+        run: .github/scripts/publish-crate.sh yantrikdb-server
 
       - name: Publish yql
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p yql --no-verify
-        continue-on-error: true
+        run: .github/scripts/publish-crate.sh yql


### PR DESCRIPTION
## What

Replaces blanket `continue-on-error: true` on every publish step with a wrapper that distinguishes:

- ✅ success → exit 0
- ✅ already-published-at-this-version → exit 0 (idempotent re-run)
- ❌ anything else → exit non-zero (manifest invalid, auth, registry rejection)

## Why

yantrikos/yantrikdb-server v0.7.3 silently failed to publish to crates.io because the workflow swallowed a genuine `all dependencies must have a version requirement specified` error. The tag was pushed, the workflow reported success, but crates.io stayed at v0.7.2. We caught it manually and republished as v0.7.4 — wasted version bump.

After this PR, the same failure mode would stop the workflow at the failing step with a red status, surfaced in the GitHub UI before anyone has to manually grep crates.io for confirmation.

## Implementation

`.github/scripts/publish-crate.sh` — small bash wrapper:

```bash
out="$(cargo publish -p "$CRATE" --no-verify 2>&1)"
rc=$?
if [[ $rc -eq 0 ]]; then exit 0; fi
if echo "$out" | grep -qE "already exists on crates\.io"; then exit 0; fi
exit $rc
```

Uses GitHub Actions log groups + `::notice::` / `::error::` annotations so the success/idempotent/failure distinction is legible in the workflow UI without expanding logs.

## No behaviour change for healthy releases

When everything publishes cleanly, behaviour is identical to today.
When re-running against a tag that's already published, behaviour is identical to today (idempotent, all "already exists" → success).
The only behaviour change is for **genuine failures**, which now correctly fail the workflow instead of being hidden.

## Followups (not in this PR)

- Same hardening for `release.yml` and `docker.yml` if they have similar swallowing patterns (audit separately)
- A "publish-state" admin endpoint that could verify crates.io max_version after the workflow completes (defence-in-depth)