### PR TITLE
deps: bump engine yantrikdb 0.7.2 -> 0.7.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2848,9 +2848,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5038,8 +5038,8 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb"
-version = "0.7.2"
-source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#3825f3d2304a9726da5da0813c0d00ea805250a1"
+version = "0.7.15"
+source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#9747c609fe57891e94248deac63e1c867bb5f174"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -5122,7 +5122,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid7",
- "yantrikdb 0.7.2",
+ "yantrikdb 0.7.15",
  "yantrikdb-protocol",
 ]
 

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -17,7 +17,7 @@ name = "yantrikdb"
 path = "src/main.rs"
 
 [dependencies]
-yantrikdb = { version = "0.7.2", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
+yantrikdb = { version = "0.7.15", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime


### PR DESCRIPTION
## Summary

Bumps the yantrikdb engine pin from v0.7.2 to v0.7.15. Picks up 13 patch releases of engine stability work since the last server-side bump.

(Originally drafted as 0.7.2→0.7.11; engine moved forward to v0.7.14 then v0.7.15 mid-PR with four more releases, all included.)

## What this brings in

| Release | Server-relevant change |
|---|---|
| **v0.7.3 + v0.7.8** | Idempotent migration runner. `run_migration_idempotent()` splits batches per-statement and swallows safe replay errors. `meta.schema_version` MAX-stamped on every open. Defensive against the homelab cluster v0.8.13 upgrade incident. |
| **v0.7.9** | New `potion-multilingual-128M` downloadable embedder (101 languages, dim=256, BGE-M3 tokenizer, ~460 MB tarball, SHA-256 pinned). |
| **v0.7.12** | CI lint + test workflows + SLSA build provenance attestation. |
| **v0.7.13** | Embedder tarball extractor handles both layouts (closes engine #15). |
| **v0.7.14** | sdist LICENSE fix + closes engine #18, #19, #22. |
| **v0.7.15** | Restore missing extract call (#26) + fix sdist LICENSE path (#27) — touch-ups on v0.7.13/v0.7.14. |
| v0.7.4, .5, .6, .7, .10, .11 | pyo3-bindings + Python-side improvements; no Rust API changes. Included transitively. |

## No yantrikdb-server source changes

Zero diff in server crates beyond `Cargo.toml` (one line) and `Cargo.lock`.

## Verification

- `cargo check -p yantrikdb-server`: clean (21.44s, 433 pre-existing warnings, zero new ones)
- `cargo test --workspace --exclude yantrikdb-python --exclude yantrikdb-wasm`: **2000 tests pass / 0 fail / 2 ignored**

pyo3 + wasm crates are excluded from local verification because of a host-side Python interpreter path issue unrelated to the bump. CI runs Linux and will exercise them.

## Lockfile

`yantrikdb` git pin advances:
- before: commit `3825f3d2` (v0.7.2 era)
- after:  commit `9747c609` (v0.7.15 = current engine main)

## Related

- Engine cadence summary: yantrikdb-core swarm msg `ab51039c` (2026-05-13T22:06Z)
- Original homelab cluster upgrade incident: yantrikdb-server swarm msg `3467c556`
- Release-gate discipline note from sibling: yantrikdb-core memory rid `019e235e` (end-to-end Python smoke before tag-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)