### PR TITLE
deps: bump engine yantrikdb 0.7.16 -> 0.7.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2811,7 +2811,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2848,7 +2848,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5038,8 +5038,8 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb"
-version = "0.7.16"
-source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#87765e8b6e8d24608bb70e5fbdc81512f960d806"
+version = "0.7.17"
+source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#374318e334919a32bce952f84bcc9a57363ca09c"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -5122,7 +5122,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid7",
- "yantrikdb 0.7.16",
+ "yantrikdb 0.7.17",
  "yantrikdb-protocol",
 ]
 

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -17,7 +17,7 @@ name = "yantrikdb"
 path = "src/main.rs"
 
 [dependencies]
-yantrikdb = { version = "0.7.16", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
+yantrikdb = { version = "0.7.17", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime


### PR DESCRIPTION
## Summary

Picks up engine v0.7.17 which shipped this morning.

## What this brings in

**[engine PR #42](https://github.com/yantrikos/yantrikdb/pull/42) — `db.reembed()` engine-side embedder migration with atomic swap (closes engine #41).**

The engine can now migrate all stored embeddings from one model+dim to another atomically, in-place, without external orchestration. Useful for:

- Trader-class deployments locked into a legacy embedder (e.g. dim=384 MiniLM) that want to migrate to a different model without dumping + re-ingesting data.
- Future v0.8.x decision to flip the in-process server default from `Builtin` (dim=384) to `Bundled` (dim=64) for new deployments — existing dim=384 callers could safely migrate via `db.reembed()` instead of being stranded.

The API is engine-level only in v0.7.17. **Exposing it on the HTTP path is out of scope for this PR** — it would be a separate `POST /v1/admin/reembed` endpoint with auth + cluster-coordination semantics that need their own design pass.

## No yantrikdb-server source changes

Pure dependency bump. `Cargo.toml` one-line + `Cargo.lock` self-update.

Lockfile pins yantrikdb to commit `374318e3` (= engine main = v0.7.17).

## Verification (all CI gates run locally per discipline)

- `cargo fmt --check -p yantrikdb-protocol -p yantrikdb-server`: clean.
- `cargo check -p yantrikdb-server`: clean, 24.09s. Warning count went 433→435; the +2 are from the new engine reembed API surface (informational, no production impact). CI clippy step has `continue-on-error: true` for the server crate so these don't gate.
- `cargo test --workspace --exclude yantrikdb-python --exclude yantrikdb-wasm`: **2005 tests pass / 0 fail / 2 ignored**.

## Related context

Engine v0.7.17 timing is directly relevant to the yantrikdb-agi trader-upgrade-on-CT-168 conversation in flight on swarmcode. Pre-v0.7.17, the trader was effectively locked into its dim=384 MiniLM data — switching to a different embedder would have required dump + re-ingest. Now there's a safe migration path. Not blocking the immediate trader upgrade (which keeps strategy=builtin/dim=384) but unblocks future flexibility.

## Not in this PR

- Release tag (would be v0.8.17). Open a follow-up release PR after this merges.
- HTTP-surface exposure of `db.reembed()`. Separate scope.
- Docker smoke test (the #34/#35 follow-up). Separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)