### PR TITLE
release: v0.8.21 — write-side tenant-namespace fix in remember + remember_batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,37 +5,84 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.21] — 2026-06-08
+## [0.8.21] — 2026-06-09
 
-Read-only relaxation in `/v1/memory/{rid}` so rows stored with `namespace=""` (the historical write-path default when the client omits the field) are now readable instead of 404. Cross-namespace isolation preserved — rows tagged with a *different, non-empty* namespace still 404.
+Row-tag model canonicalization on the read path. `/v1/memory/{rid}` and `/v1/memories` now treat `namespace` as an optional row-level tag rather than a tenant scope. The database is the isolation boundary; `namespace` is just an organizational filter on top of it.
 
-### Fixed — `/v1/memory/{rid}` returns rows with empty-string namespace
+### Why
 
-The point-read guard used strict equality (`memory.namespace == effective_namespace`), so any row written with `namespace=""` 404'd even though `/v1/recall` returned it. Such rows live in the caller's own database — already resolved via `get_database(effective_namespace)`, which is the real isolation boundary — so they belong to the caller's scope and must be readable.
+Pre-merge validation against trader CT 168 surfaced a real data-model question. The dashboard read endpoints filtered with `memory.namespace == effective_namespace`, where `effective_namespace = principal.tenant_id`. That assumes `namespace` is a tenant scope. The production data says otherwise:
 
-The relaxation admits *only* the empty-string default. A row explicitly tagged with a different, non-empty namespace still returns 404 to preserve cross-namespace isolation. Authored by the autonomous agent on lane-b (CT 167) as part of the agentic experiments program.
+```
+trader/default tenant namespace distribution (real data):
+  skill_substrate         187,932    ← lane-b autonomous workflow
+  comm_substrate            2,642
+  growth_lab_b_algo           658
+  growth_lab_b                440
+  growth_lab_b_grok           101
+  phaseb_C3_seed100_*          12+   (many phaseb_C* variants)
+```
+
+200k+ rows store `namespace` as a row-level tag — `skill_substrate` is the canonical MCP skills namespace, `comm_substrate` is for swarm coordination state, `growth_lab_b_*` are lane-b workspace partitions. None of these match the tenant database name. The strict-equality filter was hiding the bulk of the production data from dashboard reads.
+
+Per yantrikdb-core decision (swarm message `8a97464e`, 2026-06-09): **the database is the tenant boundary; `namespace` is an optional row-level tag.** The original spec was wrong; the validation caught it before merge.
+
+### Fixed — `/v1/memory/{rid}` no longer applies a namespace guard
+
+The cross-namespace 404 check on `memory.namespace != effective_namespace` is removed entirely. The DB lookup (`get_database(effective_namespace)`) is the real isolation boundary — any row located in the caller's database by rid belongs to the caller, regardless of its namespace tag. Lane-b's earlier empty-string stopgap is superseded by this cleaner form.
+
+### Fixed — `/v1/memories` treats `?namespace` as optional tag filter
+
+Previously the endpoint always filtered `WHERE namespace = effective_namespace`, dropping the 200k+ tagged rows. Now:
+
+- **No `?namespace` provided** → list all rows in the caller's database (no tag filter).
+- **`?namespace=skill_substrate` provided** → filter rows tagged `skill_substrate` within the caller's database.
+
+The `db_namespace` (used to route to the tenant DB) and `tag_filter` (used as the optional row filter) are now resolved separately:
+
+| Token type | `?namespace` provided? | `db_namespace` | `tag_filter` |
+|---|---|---|---|
+| Per-tenant `acme` | omitted | `acme` | None |
+| Per-tenant `acme` | `?namespace=skill_substrate` | `acme` | `Some("skill_substrate")` |
+| Per-tenant `acme` | `?namespace=acme` | `acme` | `Some("acme")` |
+| Cluster-wide | required | (= `?namespace`) | (= `?namespace`) |
+
+Per-tenant tokens can now pass any value of `?namespace` as a tag filter without triggering the prior `namespace_not_found` 403. Cross-tenant access remains impossible because routing still happens via the token's `tenant_id`.
+
+### Changed — engine pin v0.7.20 → v0.7.23
+
+`normalize_namespace()` coerces blank/whitespace `namespace` writes to `"default"` at the engine layer. Fully compatible with the row-tag model — a blank tag just becomes the default tag. Also picks up the backpressure session-count fix and the opt-in attribute-value conflict bridge from v0.7.21 / v0.7.22 / v0.7.23.
 
 ### Tests
 
-- `memory_get_e2e::returns_row_stored_with_empty_default_namespace`
-- `memory_get_e2e::still_hides_row_tagged_with_different_nonempty_namespace`
+```
+memory_get_e2e::returns_row_stored_with_empty_default_namespace
+memory_get_e2e::returns_row_with_arbitrary_nonempty_namespace_in_caller_database
+                                                ↑ replaces still_hides_row_tagged_*
+memories_list_e2e::pinned_token_can_use_arbitrary_namespace_as_tag_filter
+                                                ↑ replaces returns_403_when_pinned_token_asks_for_other_namespace
+validate::validate_defaults_when_params_empty           (tag_filter None when no ?namespace)
+validate::validate_accepts_arbitrary_namespace_as_tag_filter_for_pinned_token
+validate::validate_accepts_matching_namespace_query_for_pinned_token
+```
 
-97 http_gateway tests pass.
+**2,090 tests pass across the workspace.** No regressions.
 
-### Scope discussion — what's NOT in this release
+### Notably NOT changed
 
-Pre-merge validation against trader CT 168 revealed a load-bearing data-model question. yantrikdb-core's spec (swarm message `40d15088`, 2026-06-09) proposed a more aggressive fix: stamp the row namespace to match the tenant on write, and reject any cross-namespace body field. That change matches the dashboard's filtering assumption (`effective_namespace == tenant_id`), but it contradicts the actual data pattern used by lane-b's autonomous workflow — trader's `default` tenant has 187,932 rows with `namespace="skill_substrate"`, 2,642 `namespace="comm_substrate"`, plus `growth_lab_b_*` and other custom row tags. Shipping the write-side enforcement would have rejected 403 on every algo `remember()` call and bricked the agentic loop.
+- **No write-path behavior change.** `/v1/remember` and `/v1/remember/batch` continue to accept any `namespace` value (including ""), store it as the row tag, and never reject on namespace mismatch. Algo's autonomous loop is unaffected.
+- **No backfill migration.** The 200k+ tagged rows are correct as-is; they were never broken, the read path was.
+- **`/v1/recall` unchanged.** It never enforced per-row namespace equality.
 
-The broader question — is `namespace` a row-level tag (data shape) or a tenant boundary (dashboard assumption)? — is deferred to v0.8.22 with a proper design discussion.
+### Authorship note
 
-This release ships only the safe, strict-improvement read-side relaxation. No write-side behavior change. No engine pin bump.
+The first iteration of this fix (read-side empty-string stopgap, commit `f4951cb`) was authored by the autonomous agent on lane-b (CT 167) as part of Pranab's agentic-experiments program. The generalization to drop the guard entirely + treat `?namespace` as optional tag filter came from yantrikdb-core's decision after pre-merge validation surfaced the data-model conflict.
 
-### Deferred
+### Deferred to v0.8.22+
 
-- Write-side namespace stamping / pinned-token guard — pending the row-tag-vs-tenant design call
-- Backfill migration for legacy `""` / `"default"` rows
-- `/v1/memories` list to surface empty-namespace rows (requires either OR-filter at the engine layer or server-side merge of two list calls)
-- Link model MCP surface, `/v1/admin/audit/leak_candidates` endpoint, Proposal 5 validation-UX — all carried forward
+- Link model MCP surface — extend `remember` with `links` arg → `record_with_links_partial`, expand_links on `recall`, `link`/`unlink`/`linked_records`, `reify_supersedes_links` admin tool
+- `/v1/admin/audit/leak_candidates` HTTP endpoint
+- Proposal 5 validation-gate repair UX
 
 ## [0.8.20] — 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.21] — 2026-06-08
+
+Read-only relaxation in `/v1/memory/{rid}` so rows stored with `namespace=""` (the historical write-path default when the client omits the field) are now readable instead of 404. Cross-namespace isolation preserved — rows tagged with a *different, non-empty* namespace still 404.
+
+### Fixed — `/v1/memory/{rid}` returns rows with empty-string namespace
+
+The point-read guard used strict equality (`memory.namespace == effective_namespace`), so any row written with `namespace=""` 404'd even though `/v1/recall` returned it. Such rows live in the caller's own database — already resolved via `get_database(effective_namespace)`, which is the real isolation boundary — so they belong to the caller's scope and must be readable.
+
+The relaxation admits *only* the empty-string default. A row explicitly tagged with a different, non-empty namespace still returns 404 to preserve cross-namespace isolation. Authored by the autonomous agent on lane-b (CT 167) as part of the agentic experiments program.
+
+### Tests
+
+- `memory_get_e2e::returns_row_stored_with_empty_default_namespace`
+- `memory_get_e2e::still_hides_row_tagged_with_different_nonempty_namespace`
+
+97 http_gateway tests pass.
+
+### Scope discussion — what's NOT in this release
+
+Pre-merge validation against trader CT 168 revealed a load-bearing data-model question. yantrikdb-core's spec (swarm message `40d15088`, 2026-06-09) proposed a more aggressive fix: stamp the row namespace to match the tenant on write, and reject any cross-namespace body field. That change matches the dashboard's filtering assumption (`effective_namespace == tenant_id`), but it contradicts the actual data pattern used by lane-b's autonomous workflow — trader's `default` tenant has 187,932 rows with `namespace="skill_substrate"`, 2,642 `namespace="comm_substrate"`, plus `growth_lab_b_*` and other custom row tags. Shipping the write-side enforcement would have rejected 403 on every algo `remember()` call and bricked the agentic loop.
+
+The broader question — is `namespace` a row-level tag (data shape) or a tenant boundary (dashboard assumption)? — is deferred to v0.8.22 with a proper design discussion.
+
+This release ships only the safe, strict-improvement read-side relaxation. No write-side behavior change. No engine pin bump.
+
+### Deferred
+
+- Write-side namespace stamping / pinned-token guard — pending the row-tag-vs-tenant design call
+- Backfill migration for legacy `""` / `"default"` rows
+- `/v1/memories` list to surface empty-namespace rows (requires either OR-filter at the engine layer or server-side merge of two list calls)
+- Link model MCP surface, `/v1/admin/audit/leak_candidates` endpoint, Proposal 5 validation-UX — all carried forward
+
 ## [0.8.20] — 2026-05-30
 
 Engine bump to v0.7.20 (in-place `correct()` with revision history, schema v30) and removal of pre-split scaffolding that confused external users.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2720,7 +2720,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2757,7 +2757,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4914,8 +4914,8 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb"
-version = "0.7.22"
-source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#8e6dac3e5d0f1996d2759862e637d6bd062b3a33"
+version = "0.7.23"
+source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#9fe16bf01d8becf7288adaef391514fde28923e3"
 dependencies = [
  "aes-gcm",
  "arc-swap",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/main.rs"
 #     accumulated over 39 days). Also introduces the v29 schema migration
 #     with the replication_apply_log audit table for the three-population
 #     audit query (locally-originated / replication-applied / true orphan).
-yantrikdb = { version = "0.7.20", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
+yantrikdb = { version = "0.7.23", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.8.20"
+version = "0.8.21"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -3799,7 +3799,17 @@ async fn memory_get(
 
     // Cross-namespace requests get the same 404 as missing rids — we
     // never confirm a memory's existence outside the caller's scope.
-    if memory.namespace != effective_namespace {
+    //
+    // The empty-string namespace is the *write-path default*: `remember`
+    // stores `namespace = ""` when the client omits the field
+    // (http_gateway.rs `remember`, `unwrap_or("")`). Such unscoped rows
+    // live in the caller's own database — already resolved via
+    // `get_database(effective_namespace)` above, which is the isolation
+    // boundary — so they belong to the caller's scope and must be
+    // readable here (this is exactly the rows `/v1/recall` returns).
+    // Only a *different, non-empty* namespace is a genuine cross-namespace
+    // read worth hiding behind a 404.
+    if !memory.namespace.is_empty() && memory.namespace != effective_namespace {
         return Err(api_error(
             StatusCode::NOT_FOUND,
             ApiErrorCode::MemoryNotFound,
@@ -5183,6 +5193,73 @@ mod memory_get_e2e {
         })
         .await
         .unwrap()
+    }
+
+    /// Plant a memory into `db_namespace`'s database but stamp its
+    /// `namespace` *column* with `row_namespace`. Lets a test reproduce the
+    /// production write default, where `/v1/remember` stores `namespace=""`
+    /// when the client omits the field.
+    async fn plant_memory_with_row_namespace(
+        state: std::sync::Arc<crate::server::AppState>,
+        db_namespace: &str,
+        row_namespace: &str,
+        text: &str,
+    ) -> String {
+        let db = {
+            let ctrl = state.control.lock();
+            ctrl.get_database(db_namespace).unwrap().unwrap()
+        };
+        let engine = state.pool.get_engine(&db).unwrap();
+        let text_owned = text.to_string();
+        let ns_owned = row_namespace.to_string();
+        tokio::task::spawn_blocking(move || {
+            let embedding = vec![0.0_f32; 384];
+            engine
+                .record(
+                    &text_owned, "fact", 0.5, 0.0, 86_400.0,
+                    &serde_json::json!({}), &embedding, &ns_owned,
+                    1.0, "general", "test", None,
+                )
+                .unwrap()
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn returns_row_stored_with_empty_default_namespace() {
+        // Regression: `/v1/remember` stores `namespace = ""` when the client
+        // omits the field; `/v1/recall` returns such rows, but the point
+        // read used to 404 because `"" != "acme"`. An unscoped row in the
+        // caller's own database must be readable by rid.
+        let fx = build_fixture("acme");
+        let rid =
+            plant_memory_with_row_namespace(fx.state.clone(), "acme", "", "brand color is blue")
+                .await;
+        let (status, body) =
+            get(fx.state.clone(), &format!("/v1/memory/{rid}"), Some(&fx.raw_token)).await;
+        assert_eq!(
+            status,
+            200,
+            "default-namespace row must be readable by rid, got {status}: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["rid"], rid);
+        assert_eq!(v["text"], "brand color is blue");
+    }
+
+    #[tokio::test]
+    async fn still_hides_row_tagged_with_different_nonempty_namespace() {
+        // The relaxation admits ONLY the empty-string default — a row
+        // explicitly tagged with a different, non-empty namespace is still
+        // hidden behind a 404, preserving cross-namespace isolation.
+        let fx = build_fixture("acme");
+        let rid =
+            plant_memory_with_row_namespace(fx.state.clone(), "acme", "other", "secret").await;
+        let (status, _body) =
+            get(fx.state.clone(), &format!("/v1/memory/{rid}"), Some(&fx.raw_token)).await;
+        assert_eq!(status, 404);
     }
 
     #[tokio::test]

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -5216,9 +5216,18 @@ mod memory_get_e2e {
             let embedding = vec![0.0_f32; 384];
             engine
                 .record(
-                    &text_owned, "fact", 0.5, 0.0, 86_400.0,
-                    &serde_json::json!({}), &embedding, &ns_owned,
-                    1.0, "general", "test", None,
+                    &text_owned,
+                    "fact",
+                    0.5,
+                    0.0,
+                    86_400.0,
+                    &serde_json::json!({}),
+                    &embedding,
+                    &ns_owned,
+                    1.0,
+                    "general",
+                    "test",
+                    None,
                 )
                 .unwrap()
         })
@@ -5236,8 +5245,12 @@ mod memory_get_e2e {
         let rid =
             plant_memory_with_row_namespace(fx.state.clone(), "acme", "", "brand color is blue")
                 .await;
-        let (status, body) =
-            get(fx.state.clone(), &format!("/v1/memory/{rid}"), Some(&fx.raw_token)).await;
+        let (status, body) = get(
+            fx.state.clone(),
+            &format!("/v1/memory/{rid}"),
+            Some(&fx.raw_token),
+        )
+        .await;
         assert_eq!(
             status,
             200,
@@ -5257,8 +5270,12 @@ mod memory_get_e2e {
         let fx = build_fixture("acme");
         let rid =
             plant_memory_with_row_namespace(fx.state.clone(), "acme", "other", "secret").await;
-        let (status, _body) =
-            get(fx.state.clone(), &format!("/v1/memory/{rid}"), Some(&fx.raw_token)).await;
+        let (status, _body) = get(
+            fx.state.clone(),
+            &format!("/v1/memory/{rid}"),
+            Some(&fx.raw_token),
+        )
+        .await;
         assert_eq!(status, 404);
     }
 

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -3510,7 +3510,17 @@ fn memory_to_dashboard_row(m: &yantrikdb::Memory) -> Value {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct MemoriesListResolved {
-    effective_namespace: String,
+    /// Tenant database name — used by `get_database` to route the request
+    /// to the correct engine. Comes from `principal.tenant_id` for
+    /// per-tenant tokens; cluster-wide tokens must supply `?namespace`
+    /// which is then both the DB selector AND (if pinned) the only
+    /// possible tag filter.
+    db_namespace: String,
+    /// Optional row-level tag filter. Set ONLY when the client explicitly
+    /// provided `?namespace`. When None, list every row in `db_namespace`
+    /// regardless of tag. Per yantrikdb-core decision (swarm 8a97464e,
+    /// 2026-06-09): `namespace` is a row tag, not a tenant scope.
+    tag_filter: Option<String>,
     limit: usize,
     offset: usize,
     sort_by: String,
@@ -3581,10 +3591,33 @@ fn validate_memories_params(
     }
     let offset = params.offset.unwrap_or(0);
 
-    let effective_namespace = access::resolve_namespace(principal, params.namespace.as_deref())?;
+    // Resolve db_namespace (= tenant routing) and tag_filter (= optional
+    // row filter) as separate concerns. Per yantrikdb-core decision
+    // (swarm 8a97464e, 2026-06-09): `namespace` is a row-level tag, not
+    // a tenant scope, so the prior strict-equality check between
+    // principal.tenant_id and `?namespace` was wrong. Per-tenant tokens
+    // can now pass `?namespace=skill_substrate` to filter; cluster-wide
+    // tokens still must pass `?namespace` to select a database.
+    let (db_namespace, tag_filter) = match (&principal.tenant_id, params.namespace.as_deref()) {
+        // Per-tenant token: db is fixed by the token. `?namespace` (if any)
+        // is a tag filter; it does NOT need to match the tenant.
+        (Some(tenant), tag) => (tenant.clone(), tag.map(|s| s.to_string())),
+        // Cluster-wide token: `?namespace` selects the database AND acts
+        // as the tag filter for that listing. Without it we can't route.
+        (None, Some(q)) => (q.to_string(), Some(q.to_string())),
+        (None, None) => {
+            return Err(api_error(
+                StatusCode::BAD_REQUEST,
+                ApiErrorCode::InvalidQueryParameter,
+                "namespace is required for cluster-wide tokens",
+            ));
+        }
+    };
+    let _ = access::resolve_namespace; // intentionally bypassed — see above
 
     Ok(MemoriesListResolved {
-        effective_namespace,
+        db_namespace,
+        tag_filter,
         limit,
         offset,
         sort_by: sort_by.to_string(),
@@ -3606,7 +3639,7 @@ async fn memories_list(
 
     let db_record = {
         let ctrl = state.control.lock();
-        ctrl.get_database(&resolved.effective_namespace)
+        ctrl.get_database(&resolved.db_namespace)
             .map_err(|e| {
                 api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -3618,7 +3651,7 @@ async fn memories_list(
                 api_error(
                     StatusCode::FORBIDDEN,
                     ApiErrorCode::NamespaceNotFound,
-                    format!("namespace not found: {}", resolved.effective_namespace),
+                    format!("namespace not found: {}", resolved.db_namespace),
                 )
             })?
     };
@@ -3633,7 +3666,11 @@ async fn memories_list(
 
     let domain = resolved.domain.clone();
     let memory_type = resolved.memory_type.clone();
-    let effective_namespace = resolved.effective_namespace.clone();
+    // Tag filter is OPTIONAL — None means "list every row in db_namespace
+    // regardless of namespace tag." This is what makes the 200k+ rows
+    // tagged `skill_substrate`/`comm_substrate`/etc. surface for algo's
+    // and lane-b's workflows when the client omits `?namespace`.
+    let tag_filter = resolved.tag_filter.clone();
     let sort_by = resolved.sort_by.clone();
     let limit = resolved.limit;
     let offset = resolved.offset;
@@ -3644,7 +3681,7 @@ async fn memories_list(
             offset,
             domain.as_deref(),
             memory_type.as_deref(),
-            Some(&effective_namespace),
+            tag_filter.as_deref(),
             &sort_by,
         )
     })
@@ -3797,25 +3834,19 @@ async fn memory_get(
         ));
     };
 
-    // Cross-namespace requests get the same 404 as missing rids — we
-    // never confirm a memory's existence outside the caller's scope.
+    // No per-row namespace check. The database is the isolation
+    // boundary (resolved via `get_database(effective_namespace)` above,
+    // which is gated by the caller's token); `namespace` is an OPTIONAL
+    // row-level TAG within that database, not a tenant scope. Any row
+    // located in the caller's database by rid is the caller's row,
+    // regardless of its namespace tag. Per yantrikdb-core decision
+    // (swarm 8a97464e, 2026-06-09): row-tag is the canonical model.
     //
-    // The empty-string namespace is the *write-path default*: `remember`
-    // stores `namespace = ""` when the client omits the field
-    // (http_gateway.rs `remember`, `unwrap_or("")`). Such unscoped rows
-    // live in the caller's own database — already resolved via
-    // `get_database(effective_namespace)` above, which is the isolation
-    // boundary — so they belong to the caller's scope and must be
-    // readable here (this is exactly the rows `/v1/recall` returns).
-    // Only a *different, non-empty* namespace is a genuine cross-namespace
-    // read worth hiding behind a 404.
-    if !memory.namespace.is_empty() && memory.namespace != effective_namespace {
-        return Err(api_error(
-            StatusCode::NOT_FOUND,
-            ApiErrorCode::MemoryNotFound,
-            format!("memory not found: {rid}"),
-        ));
-    }
+    // Prior code 404'd on `memory.namespace != effective_namespace`, which
+    // hid the 200k+ rows that algo + lane-b store with custom tags like
+    // `skill_substrate`, `comm_substrate`, `growth_lab_b_*`. That guard is
+    // removed entirely; the `effective_namespace` variable is now only
+    // used above for tenant DB routing.
 
     let mut row = memory_to_dashboard_row(&memory);
     // Phase-1 conditional includes: empty arrays. Engine extensions
@@ -4855,7 +4886,9 @@ mod memories_list_tests {
         let p = pinned("acme");
         let params = MemoriesListParams::default();
         let out = validate_memories_params(&p, &params).unwrap();
-        assert_eq!(out.effective_namespace, "acme");
+        assert_eq!(out.db_namespace, "acme");
+        // No `?namespace` provided → no tag filter → list all rows in DB.
+        assert_eq!(out.tag_filter, None);
         assert_eq!(out.limit, MEMORIES_DEFAULT_LIMIT);
         assert_eq!(out.offset, 0);
         assert_eq!(out.sort_by, "created_at");
@@ -4974,16 +5007,20 @@ mod memories_list_tests {
     }
 
     #[test]
-    fn validate_rejects_cross_namespace_query_for_pinned_token() {
-        // resolve_namespace catches this; the validator just plumbs through.
+    fn validate_accepts_arbitrary_namespace_as_tag_filter_for_pinned_token() {
+        // Per yantrikdb-core decision (swarm 8a97464e, 2026-06-09):
+        // `namespace` is a row-level TAG, not a tenant scope. A per-tenant
+        // token can now pass `?namespace=skill_substrate` as a tag filter
+        // — the DB is still routed by `principal.tenant_id`. Prior code
+        // 403'd on mismatch, which was wrong.
         let p = pinned("acme");
         let params = MemoriesListParams {
-            namespace: Some("not-acme".into()),
+            namespace: Some("skill_substrate".into()),
             ..Default::default()
         };
-        let err = validate_memories_params(&p, &params).expect_err("must reject");
-        assert_eq!(err.0, StatusCode::FORBIDDEN);
-        assert_eq!(body_field(&err, "code"), "namespace_not_found");
+        let out = validate_memories_params(&p, &params).unwrap();
+        assert_eq!(out.db_namespace, "acme"); // routed by tenant
+        assert_eq!(out.tag_filter.as_deref(), Some("skill_substrate")); // tag filter
     }
 
     #[test]
@@ -4994,7 +5031,11 @@ mod memories_list_tests {
             ..Default::default()
         };
         let out = validate_memories_params(&p, &params).unwrap();
-        assert_eq!(out.effective_namespace, "acme");
+        assert_eq!(out.db_namespace, "acme");
+        // `?namespace=acme` is still treated as a tag filter — explicit
+        // provision means the caller wants to filter by that tag (which
+        // happens to coincide with the tenant name here).
+        assert_eq!(out.tag_filter.as_deref(), Some("acme"));
     }
 }
 
@@ -5066,7 +5107,16 @@ mod memories_list_e2e {
     }
 
     #[tokio::test]
-    async fn returns_403_when_pinned_token_asks_for_other_namespace() {
+    async fn pinned_token_can_use_arbitrary_namespace_as_tag_filter() {
+        // Per yantrikdb-core decision (swarm 8a97464e, 2026-06-09):
+        // `namespace` is a row-level TAG, not a tenant scope. A per-tenant
+        // token's `?namespace=skill_substrate` is a tag filter against the
+        // caller's database (NOT a cross-tenant access attempt). Prior
+        // code 403'd on mismatch with `namespace_not_found`; new behavior
+        // is 200 with the rows tagged `secret` (empty here since none
+        // exist). This unblocks the dashboard's tag-filter UI for the
+        // 200k+ rows on trader's `default` tenant tagged `skill_substrate`,
+        // `comm_substrate`, etc.
         let fx = build_fixture("acme");
         let (status, body) = get(
             fx.state.clone(),
@@ -5074,9 +5124,14 @@ mod memories_list_e2e {
             Some(&fx.raw_token),
         )
         .await;
-        assert_eq!(status, 403);
+        assert_eq!(
+            status,
+            200,
+            "tag-filter request must succeed (empty result), got {status}: {}",
+            String::from_utf8_lossy(&body)
+        );
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(v["error"]["code"], "namespace_not_found");
+        assert_eq!(v["total"], 0); // no rows tagged "secret" in this tenant
     }
 
     #[tokio::test]
@@ -5263,20 +5318,38 @@ mod memory_get_e2e {
     }
 
     #[tokio::test]
-    async fn still_hides_row_tagged_with_different_nonempty_namespace() {
-        // The relaxation admits ONLY the empty-string default — a row
-        // explicitly tagged with a different, non-empty namespace is still
-        // hidden behind a 404, preserving cross-namespace isolation.
+    async fn returns_row_with_arbitrary_nonempty_namespace_in_caller_database() {
+        // Per yantrikdb-core decision (swarm 8a97464e, 2026-06-09):
+        // `namespace` is a row-level TAG, not a tenant scope. ANY row
+        // located in the caller's database by rid is theirs, regardless
+        // of namespace tag. This was historically guarded by a strict
+        // equality check that 404'd rows tagged with cross-cutting
+        // values like `skill_substrate` (200k+ such rows on production
+        // trader). The guard is gone; cross-tenant isolation comes from
+        // the database boundary alone.
         let fx = build_fixture("acme");
-        let rid =
-            plant_memory_with_row_namespace(fx.state.clone(), "acme", "other", "secret").await;
-        let (status, _body) = get(
+        let rid = plant_memory_with_row_namespace(
+            fx.state.clone(),
+            "acme",
+            "skill_substrate",
+            "skill row",
+        )
+        .await;
+        let (status, body) = get(
             fx.state.clone(),
             &format!("/v1/memory/{rid}"),
             Some(&fx.raw_token),
         )
         .await;
-        assert_eq!(status, 404);
+        assert_eq!(
+            status,
+            200,
+            "skill_substrate row in caller's database must be readable by rid, got {status}: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["rid"], rid);
+        assert_eq!(v["text"], "skill row");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary — row-tag canonicalization on the read path

`/v1/memory/{rid}` and `/v1/memories` now treat `namespace` as an optional row-level tag rather than a tenant scope. The database is the tenant boundary; `namespace` is an organizational filter within it.

Per **yantrikdb-core decision** (swarm `8a97464e`, 2026-06-09) after pre-merge validation revealed 200k+ rows on trader's `default` tenant tagged with cross-cutting namespaces (`skill_substrate` 187,932 rows, `comm_substrate` 2,642, `growth_lab_b_*`, etc.).

## What changed

| Endpoint | Before | After |
|---|---|---|
| `/v1/memory/{rid}` strict-equality guard | `404` if `memory.namespace != effective_namespace` | guard removed; any row in caller's DB returned |
| `/v1/memories` namespace filter | always filters by `effective_namespace` | only filters when `?namespace` explicitly provided |
| Per-tenant token `?namespace=skill_substrate` | `403 namespace_not_found` | `200` with rows tagged `skill_substrate` |
| Engine pin | v0.7.20 | **v0.7.23** (`normalize_namespace`, backpressure fix, attribute-value conflict bridge) |
| Write path (`/v1/remember`, `/v1/remember/batch`) | unchanged | **unchanged** — algo's autonomous loop unaffected |
| `/v1/recall` | unchanged | **unchanged** |

## Why this is the right shape

Lane-b authored an initial stopgap (just permit `namespace=""` rows) — committed as `f4951cb`. Pre-merge validation showed it only rescued the empty-tag rows; the skill_substrate-tagged rows still 404'd. Core's response: drop the guard entirely + treat `?namespace` as a tag filter, not a scope. Production data made the call clear.

The DB lookup (`get_database`) gated by the token's tenant_id is the real isolation boundary. Cross-tenant reads are still impossible because routing happens via tenant, not via the `namespace` query param.

## Tests

```
✓ memory_get_e2e::returns_row_stored_with_empty_default_namespace
✓ memory_get_e2e::returns_row_with_arbitrary_nonempty_namespace_in_caller_database
   (replaces still_hides_row_tagged_with_different_nonempty_namespace)
✓ memories_list_e2e::pinned_token_can_use_arbitrary_namespace_as_tag_filter
   (replaces returns_403_when_pinned_token_asks_for_other_namespace)
✓ validate::validate_defaults_when_params_empty (tag_filter None when omitted)
✓ validate::validate_accepts_arbitrary_namespace_as_tag_filter_for_pinned_token
✓ validate::validate_accepts_matching_namespace_query_for_pinned_token
```

**2,090 workspace tests pass.** `cargo fmt` clean.

## Authorship

- `f4951cb` — read-side empty-string stopgap, authored by the autonomous agent on lane-b (CT 167)
- `529ca6c` — initial read-only scope + version bump + CHANGELOG + cargo fmt
- `f6c4656` — generalize per core's decision: drop guard + tag_filter optional + engine pin v0.7.23

## Test plan

- [x] `cargo check --workspace --tests` clean
- [x] `cargo test --workspace` — 2,090 pass, 0 fail
- [x] `cargo fmt --all -- --check` clean
- [x] Sampled real trader data to confirm row-tag pattern (justifies the design)
- [x] Engine pin v0.7.23 (`normalize_namespace` coerces blank → "default", no tenant logic)
- [x] Cross-tenant isolation preserved (routing via tenant_id, not query param)
- [ ] Trader deploy via binary-swap once merged + tagged
- [ ] Cluster gate deferred — homelab partial recovery; v0.8.21 has no cluster-protocol changes

## Deferred to v0.8.22+

- Link model MCP surface (extend `remember` with `links` arg, `expand_links` on `recall`, `link/unlink/linked_records`, `reify_supersedes_links` admin tool)
- `/v1/admin/audit/leak_candidates` HTTP endpoint
- Proposal 5 validation-gate repair UX