### PR TITLE
release: v0.8.22 — master-token routing fix for /v1/memory + /v1/memories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.22] — 2026-06-10
+
+Master-token routing fix for `/v1/memory/{rid}` and `/v1/memories`. v0.8.21's row-tag canonicalization worked for per-tenant tokens but mis-routed master/cluster-wide tokens — `?namespace=tag` was used as a database selector, causing `404 namespace_not_found` on every tag-shaped namespace value. Algo (yantrikdb-agi) reported this as their #1 blocker on CT 133 (swarm `77ffa517`, 2026-06-10).
+
+### Fixed — master tokens route to `default` DB, `?namespace` always tag filter
+
+Two handlers updated to align with `/v1/recall`'s auth path (`resolve_engine`, which hardcodes `get_database("default")` for cluster master tokens):
+
+1. **`validate_memories_params`** — master token (`principal.tenant_id == None`) now routes `db_namespace` to `"default"`. `?namespace` is exclusively a tag filter, never a database selector. Prior `(None, None)` branch erroring with "namespace is required for cluster-wide tokens" is removed.
+
+2. **`memory_get`** — bypassed `access::resolve_namespace` entirely. Computes `db_namespace` directly from `principal.tenant_id.unwrap_or("default")`. The `?namespace` query param is now plumbed through but has no effect on routing or filtering (rid uniquely identifies the row within the resolved database).
+
+### Updated tests
+
+- `validate::validate_master_token_no_namespace_routes_to_default_db` — new
+- `validate::validate_master_token_with_namespace_uses_default_db_and_tag_filter` — new (pins the exact CT 133 scenario)
+- `memory_get_e2e::pinned_token_with_ns_param_on_nonexistent_rid_returns_404_not_403` — replaces `returns_403_when_pinned_token_asks_for_other_namespace` (old assertion no longer correct)
+- `memory_get_e2e::ns_param_is_ignored_on_point_read` — replaces `cross_namespace_request_via_namespace_param_is_403` (point-read no longer uses `?namespace` for anything)
+
+**99 http_gateway tests pass.**
+
+### Compatibility
+
+- Per-tenant tokens (the bulk of production usage): **unchanged behavior** vs v0.8.21. They keep using their tenant DB and any `?namespace` value still acts as a tag filter.
+- Master tokens: now match `/v1/recall`'s contract. `?namespace` is filter-only. Behavior diff vs v0.8.21:
+  - Master + omit `?namespace`: was 400 "namespace is required", now 200 listing all rows in `default` DB.
+  - Master + `?namespace=fable3`: was 404 `namespace_not_found`, now 200 with rows tagged `fable3` in `default` DB.
+
+### Engine pin unchanged
+
+Stays on v0.7.22 (introduced in v0.8.21). v0.7.24 with `list_records(namespace, kind, since_rid?, limit, order)` is being prepared by yantrikdb-core (swarm `90b7072c`, 2026-06-10); it will land in v0.8.23 wiring `?kind=` + keyset cursor on `/v1/memories`.
+
+### Deferred to v0.8.23+
+
+- Wire `/v1/memories` to engine's `list_records` once published: `?kind=`, `?since_rid=` (keyset cursor), `?order=asc|desc`, response envelope `{records:[...], next_cursor}`. Contract locked with core (swarm `6405b7e5`, 2026-06-10).
+- Link model MCP surface (`record_with_links_partial`, `expand_links` on recall, `link/unlink/linked_records`, `reify_supersedes_links` admin tool).
+- `/v1/admin/audit/leak_candidates` HTTP endpoint.
+- Proposal 5 validation-gate repair UX.
+
 ## [0.8.21] — 2026-06-09
 
 Row-tag model canonicalization on the read path. `/v1/memory/{rid}` and `/v1/memories` now treat `namespace` as an optional row-level tag rather than a tenant scope. The database is the isolation boundary; `namespace` is just an organizational filter on top of it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.8.21"
+version = "0.8.22"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.8.21"
+version = "0.8.22"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -3594,24 +3594,22 @@ fn validate_memories_params(
     // Resolve db_namespace (= tenant routing) and tag_filter (= optional
     // row filter) as separate concerns. Per yantrikdb-core decision
     // (swarm 8a97464e, 2026-06-09): `namespace` is a row-level tag, not
-    // a tenant scope, so the prior strict-equality check between
-    // principal.tenant_id and `?namespace` was wrong. Per-tenant tokens
-    // can now pass `?namespace=skill_substrate` to filter; cluster-wide
-    // tokens still must pass `?namespace` to select a database.
+    // a tenant scope. Per yantrikdb-agi report (swarm 77ffa517,
+    // 2026-06-10): master tokens broke under v0.8.21 because the
+    // (None, Some(q)) branch routed `?namespace` to `get_database()`,
+    // 404'ing on every tag-as-namespace query.
+    //
+    // The fix: `?namespace` is ALWAYS a tag filter, never a DB selector.
+    // Master tokens always route to "default" DB (matching
+    // resolve_engine's hardcoded behavior at line 274-296).
     let (db_namespace, tag_filter) = match (&principal.tenant_id, params.namespace.as_deref()) {
         // Per-tenant token: db is fixed by the token. `?namespace` (if any)
         // is a tag filter; it does NOT need to match the tenant.
         (Some(tenant), tag) => (tenant.clone(), tag.map(|s| s.to_string())),
-        // Cluster-wide token: `?namespace` selects the database AND acts
-        // as the tag filter for that listing. Without it we can't route.
-        (None, Some(q)) => (q.to_string(), Some(q.to_string())),
-        (None, None) => {
-            return Err(api_error(
-                StatusCode::BAD_REQUEST,
-                ApiErrorCode::InvalidQueryParameter,
-                "namespace is required for cluster-wide tokens",
-            ));
-        }
+        // Master/cluster-wide token: route to "default" DB (matching
+        // resolve_engine). `?namespace` is a tag filter only, never a DB
+        // selector.
+        (None, tag) => ("default".to_string(), tag.map(|s| s.to_string())),
     };
     let _ = access::resolve_namespace; // intentionally bypassed — see above
 
@@ -3774,15 +3772,32 @@ async fn memory_get(
     use crate::auth::Scope;
 
     access::require_scope(&principal, Scope::Read)?;
-    let effective_namespace = access::resolve_namespace(&principal, params.namespace.as_deref())?;
 
     if let Some(min_seq) = params.min_seq {
         check_min_seq(&state, min_seq)?;
     }
 
+    // Resolve db_namespace (tenant routing) directly from the principal.
+    // Per yantrikdb-core decision (swarm 8a97464e, 2026-06-09) +
+    // yantrikdb-agi report (swarm 77ffa517, 2026-06-10):
+    // - per-tenant token routes to `principal.tenant_id`
+    // - master/cluster-wide token routes to `"default"` (matching
+    //   resolve_engine's hardcoded behavior at line 274-296)
+    // - `?namespace` is irrelevant for point-read (rid uniquely
+    //   identifies the row; namespace tag is row metadata, not scope)
+    //
+    // Prior code used access::resolve_namespace which 403'd master
+    // tokens passing `?namespace=tag` and 404'd whenever the tag was
+    // mistakenly routed as a DB selector. Both paths broke algo's
+    // master-token workflow on CT 133.
+    let db_namespace = principal
+        .tenant_id
+        .clone()
+        .unwrap_or_else(|| "default".to_string());
+
     let db_record = {
         let ctrl = state.control.lock();
-        ctrl.get_database(&effective_namespace)
+        ctrl.get_database(&db_namespace)
             .map_err(|e| {
                 api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -3794,7 +3809,7 @@ async fn memory_get(
                 api_error(
                     StatusCode::FORBIDDEN,
                     ApiErrorCode::NamespaceNotFound,
-                    format!("namespace not found: {effective_namespace}"),
+                    format!("namespace not found: {db_namespace}"),
                 )
             })?
     };
@@ -4732,6 +4747,18 @@ mod memories_list_tests {
             ]))
     }
 
+    fn master() -> Principal {
+        // Cluster-wide / master token. principal.tenant_id == None.
+        // Mirrors what resolve_engine's cluster_secret branch produces.
+        Principal::new("tok_master").with_scopes(ScopeSet::from_iter([
+            Scope::Read,
+            Scope::Write,
+            Scope::Recall,
+            Scope::Forget,
+            Scope::Admin,
+        ]))
+    }
+
     // ── unix_to_iso ─────────────────────────────────────────────────
 
     #[test]
@@ -5036,6 +5063,38 @@ mod memories_list_tests {
         // provision means the caller wants to filter by that tag (which
         // happens to coincide with the tenant name here).
         assert_eq!(out.tag_filter.as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn validate_master_token_no_namespace_routes_to_default_db() {
+        // v0.8.22 fix: master/cluster-wide tokens (principal.tenant_id ==
+        // None) route to the "default" database, matching
+        // resolve_engine's hardcoded behavior. Prior to v0.8.22 this
+        // case errored with `namespace is required for cluster-wide
+        // tokens`, blocking algo's master-token workflow on CT 133.
+        let p = master();
+        let params = MemoriesListParams::default();
+        let out = validate_memories_params(&p, &params).unwrap();
+        assert_eq!(out.db_namespace, "default");
+        assert_eq!(out.tag_filter, None);
+    }
+
+    #[test]
+    fn validate_master_token_with_namespace_uses_default_db_and_tag_filter() {
+        // v0.8.22 fix: master tokens with `?namespace=fable3` route to
+        // "default" DB AND apply `fable3` as a tag filter — they no
+        // longer mis-route `?namespace` to `get_database("fable3")`
+        // (which 404'd because `fable3` is a row tag, not a database).
+        // This is the exact case yantrikdb-agi reported on CT 133
+        // (swarm 77ffa517, 2026-06-10).
+        let p = master();
+        let params = MemoriesListParams {
+            namespace: Some("yantrikos_entity_fable3".into()),
+            ..Default::default()
+        };
+        let out = validate_memories_params(&p, &params).unwrap();
+        assert_eq!(out.db_namespace, "default");
+        assert_eq!(out.tag_filter.as_deref(), Some("yantrikos_entity_fable3"));
     }
 }
 
@@ -5401,7 +5460,13 @@ mod memory_get_e2e {
     }
 
     #[tokio::test]
-    async fn returns_403_when_pinned_token_asks_for_other_namespace() {
+    async fn pinned_token_with_ns_param_on_nonexistent_rid_returns_404_not_403() {
+        // Per yantrikdb-core decision (swarm 8a97464e, 2026-06-09) +
+        // yantrikdb-agi report (swarm 77ffa517, 2026-06-10): `?namespace`
+        // is irrelevant on point-read — rid uniquely identifies the row,
+        // the database (gated by the token) is the isolation boundary.
+        // A nonexistent rid returns 404 memory_not_found regardless of
+        // the `?namespace` value the caller supplies.
         let fx = build_fixture("acme");
         let (status, body) = get(
             fx.state.clone(),
@@ -5409,9 +5474,9 @@ mod memory_get_e2e {
             Some(&fx.raw_token),
         )
         .await;
-        assert_eq!(status, 403);
+        assert_eq!(status, 404);
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(v["error"]["code"], "namespace_not_found");
+        assert_eq!(v["error"]["code"], "memory_not_found");
     }
 
     #[tokio::test]
@@ -5447,10 +5512,15 @@ mod memory_get_e2e {
     }
 
     #[tokio::test]
-    async fn cross_namespace_request_via_namespace_param_is_403() {
-        // The handler enforces resolve_namespace BEFORE doing the
-        // engine fetch. A pinned token asking for ?namespace=other
-        // never reaches the engine — 403 namespace_not_found.
+    async fn ns_param_is_ignored_on_point_read() {
+        // Per v0.8.22 row-tag canonicalization: `?namespace` is
+        // irrelevant for /v1/memory/{rid}. The token determines the DB
+        // (per-tenant) or routes to "default" (master); the rid
+        // uniquely identifies the row within that DB. Any value of
+        // `?namespace` returns the same result. This is the strict
+        // generalization of v0.8.21's "drop the namespace guard" fix —
+        // the query param is now plumbed through to the engine layer
+        // but has no effect on routing or filtering for point-read.
         let fx = build_fixture("acme");
         let rid = plant_memory(fx.state.clone(), "acme", "hello").await;
         let (status, body) = get(
@@ -5459,9 +5529,15 @@ mod memory_get_e2e {
             Some(&fx.raw_token),
         )
         .await;
-        assert_eq!(status, 403);
+        assert_eq!(
+            status,
+            200,
+            "?namespace=other must not block the read, got {status}: {}",
+            String::from_utf8_lossy(&body)
+        );
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(v["error"]["code"], "namespace_not_found");
+        assert_eq!(v["rid"], rid);
+        assert_eq!(v["text"], "hello");
     }
 }
 


### PR DESCRIPTION
## Summary

v0.8.21's row-tag canonicalization worked for **per-tenant tokens** but mis-routed **master/cluster-wide tokens**. Algo (yantrikdb-agi) flagged this as their #1 blocker on CT 133 (swarm `77ffa517`, 2026-06-10): `GET /v1/memories?namespace=fable3` returned `404 namespace_not_found` because the master-token branch in v0.8.21 routed `?namespace` to `get_database()`, which fails when the value is a row tag rather than a registered database.

This release aligns `/v1/memories` and `/v1/memory/{rid}` with `/v1/recall`'s auth contract — master tokens always route to `default` DB (matching `resolve_engine`'s hardcoded behavior), and `?namespace` is exclusively a tag filter, never a DB selector.

## Two surgical changes

```rust
// validate_memories_params — was:
(None, Some(q)) => (q.to_string(), Some(q.to_string())),  // ← q used as DB selector (wrong)
(None, None) => Err("namespace is required..."),

// now:
(None, tag) => ("default".to_string(), tag.map(|s| s.to_string())),
```

```rust
// memory_get — was:
let effective_namespace = access::resolve_namespace(&principal, params.namespace.as_deref())?;
ctrl.get_database(&effective_namespace)

// now:
let db_namespace = principal.tenant_id.clone().unwrap_or_else(|| "default".to_string());
ctrl.get_database(&db_namespace)
```

## Tests (4 changed + 2 new = 6 affected)

| Test | Status |
|---|---|
| `validate::validate_master_token_no_namespace_routes_to_default_db` | ✓ NEW |
| `validate::validate_master_token_with_namespace_uses_default_db_and_tag_filter` | ✓ NEW (pins CT 133 scenario) |
| `memory_get_e2e::pinned_token_with_ns_param_on_nonexistent_rid_returns_404_not_403` | ✓ REPLACED |
| `memory_get_e2e::ns_param_is_ignored_on_point_read` | ✓ REPLACED |

**99 http_gateway tests pass. 2,092 workspace tests pass.**

## Behavior diff vs v0.8.21

| Scenario | v0.8.21 | v0.8.22 |
|---|---|---|
| Per-tenant token, any request | unchanged | **unchanged** |
| Master token, no `?namespace` | 400 "namespace is required" | **200** (lists all rows in `default` DB) |
| Master token, `?namespace=fable3` (tag) | 404 `namespace_not_found` | **200** (rows tagged `fable3` in `default` DB) |
| Master token, `/v1/memory/{rid}?namespace=anything` | 403 (if tenant didn't match) | **200** (rid uniquely identifies row; `?namespace` ignored) |

## Test plan

- [x] `cargo check --workspace --tests` clean
- [x] `cargo test --workspace` — 2,092 pass, 0 fail
- [x] `cargo fmt --all -- --check` clean
- [x] Master-token unit tests pin the CT 133 scenario
- [x] Per-tenant token tests confirm no regression
- [ ] Deploy v0.8.22 to **CT 133** (algo's server) — primary unblock target
- [ ] Deploy v0.8.22 to **trader CT 168** — keep parity
- [ ] Algo re-runs reproduction on .133 + confirms /v1/memories?namespace=fable3 now returns rows

## Engine pin

Unchanged — stays on v0.7.22. Engine v0.7.24 with `list_records(namespace, kind, since_rid?, limit, order)` is being prepared by yantrikdb-core (swarm `90b7072c`, 2026-06-10); v0.8.23 will wire `?kind` + keyset cursor on `/v1/memories` once it lands. HTTP contract locked with core in swarm `6405b7e5`.

## Deferred to v0.8.23+

- Wire `/v1/memories` to engine's `list_records` (kind filter, keyset cursor, `{records, next_cursor}` envelope)
- Link model MCP surface
- `/v1/admin/audit/leak_candidates` endpoint
- Proposal 5 validation-UX