### PR TITLE
release: v0.8.23 — /v1/memories structural query primitive (kind/drive_id/cursor/order)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,66 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.23] — 2026-06-10
+
+Structural query primitive on `/v1/memories` — `?kind=`, `?drive_id=`, `?since_rid=` (keyset cursor), `?order=asc|desc` — wired to engine `list_records` (yantrikdb-core v0.7.24). Replaces the fetch-all-then-filter pattern with indexed push-down. Closes algo's perf gap (swarm `c1d810df`, 2026-06-10): "list records of kind X" now uses one SQL plan with indexed VIRTUAL columns instead of a full scan.
+
+### Changed — engine pin v0.7.22 → v0.7.24
+
+v0.7.24 ships:
+- Schema v32: VIRTUAL generated columns `kind = json_extract(metadata,'$.kind')` and `drive_id = json_extract(metadata,'$.drive_id')` with indexes; `json_valid` guard ensures encrypted/malformed metadata resolves to NULL (no migration errors).
+- New `list_records(namespace, kind, drive_id, memory_type, domain, since_rid?, limit, order)` engine method — all filters AND-composed and pushed down to one SQL plan.
+
+Auto-migrates on first open. No backfill. No write-API change.
+
+### Added — `/v1/memories` structural query params
+
+| Param | Behavior |
+|---|---|
+| `?kind=X` | row-level metadata.kind filter (indexed) |
+| `?drive_id=X` | row-level metadata.drive_id filter (indexed) |
+| `?since_rid=R` | keyset cursor (UUIDv7 = lexically chronological) |
+| `?order=asc\|desc` | asc (default, oldest first) or desc (newest first) |
+
+When **any** of the new structural params (`kind`, `drive_id`, `since_rid`, or `order=desc`) is set, the handler routes through `engine.list_records` with response envelope:
+
+```json
+{
+  "records": [ {rid, text, memory_type, importance, metadata: {...}, namespace, ...} ],
+  "next_cursor": "<last_rid>" | null,
+  "limit": N
+}
+```
+
+Without any structural params (legacy/dashboard usage), the existing `engine.list_memories` path is preserved with the `{items, total, limit, offset}` envelope.
+
+### Fixed — record item shape mirrors `/v1/recall`
+
+Records from the new `list_records` path include `metadata` as a **parsed JSON object** (not stringified). Per `yantrikdb-agi`'s shape note (swarm `c1d810df`, 2026-06-10): `/v1/recall` returns parsed `metadata: {...}` but legacy `/v1/memories` returned `metadata_json` as a stringified blob with the parsed `metadata` field null. The new `memory_to_record_item` helper normalizes both stored shapes (Value::String containing JSON, or Value::Object) to a parsed object. Algo's `query_typed()` client can now share its `RecallHit` deserializer with no special-casing.
+
+The legacy `/v1/memories` (no structural params) still emits `metadata_json` for back-compat.
+
+### Tests (4 new, 26 memories_list_tests total)
+
+- `validate::validate_v0823_default_order_is_asc`
+- `validate::validate_v0823_accepts_desc_order`
+- `validate::validate_v0823_rejects_unknown_order`
+- `validate::validate_v0823_kind_drive_id_since_rid_round_trip`
+
+**2,096 workspace tests pass.** No regressions.
+
+### Compatibility
+
+- Legacy clients (no structural params): **unchanged**.
+- `yantrikdb-agi`'s `query_typed()` client: one-commit swap to the new shape.
+- Dashboard: untouched.
+
+### Deferred to v0.8.24+
+
+- Link model MCP surface (`record_with_links_partial`, `expand_links` on recall, `link/unlink/linked_records`, `reify_supersedes_links` admin tool)
+- `/v1/admin/audit/leak_candidates` HTTP endpoint
+- Proposal 5 validation-gate repair UX
+
 ## [0.8.22] — 2026-06-10
 
 Master-token routing fix for `/v1/memory/{rid}` and `/v1/memories`. v0.8.21's row-tag canonicalization worked for per-tenant tokens but mis-routed master/cluster-wide tokens — `?namespace=tag` was used as a database selector, causing `404 namespace_not_found` on every tag-shaped namespace value. Algo (yantrikdb-agi) reported this as their #1 blocker on CT 133 (swarm `77ffa517`, 2026-06-10).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2720,7 +2720,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2757,7 +2757,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4914,8 +4914,8 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb"
-version = "0.7.23"
-source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#9fe16bf01d8becf7288adaef391514fde28923e3"
+version = "0.7.24"
+source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#72bd4f79d9acc2cd4c23453cfc817a2eec38da7f"
 dependencies = [
  "aes-gcm",
  "arc-swap",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.8.22"
+version = "0.8.23"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"
@@ -32,7 +32,7 @@ path = "src/main.rs"
 #     accumulated over 39 days). Also introduces the v29 schema migration
 #     with the replication_apply_log audit table for the three-population
 #     audit query (locally-originated / replication-applied / true orphan).
-yantrikdb = { version = "0.7.23", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
+yantrikdb = { version = "0.7.24", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -3464,6 +3464,15 @@ struct MemoriesListParams {
     limit: Option<usize>,
     offset: Option<usize>,
     sort: Option<String>,
+    // v0.8.23: structural query primitive — pushed down to engine.list_records.
+    // `kind` and `drive_id` ride indexed VIRTUAL generated columns over
+    // metadata JSON (engine v0.7.24 schema v32). `since_rid` is a keyset
+    // cursor (UUIDv7 = lexically chronological). `order` is asc (oldest
+    // first, default) or desc (newest first).
+    kind: Option<String>,
+    drive_id: Option<String>,
+    since_rid: Option<String>,
+    order: Option<String>,
 }
 
 fn unix_to_iso(epoch_seconds: f64) -> Option<String> {
@@ -3526,6 +3535,14 @@ struct MemoriesListResolved {
     sort_by: String,
     domain: Option<String>,
     memory_type: Option<String>,
+    /// v0.8.23 structural query primitive params — pushed down to
+    /// engine.list_records (yantrikdb-core v0.7.24).
+    kind: Option<String>,
+    drive_id: Option<String>,
+    since_rid: Option<String>,
+    /// "asc" (oldest first, default) | "desc" (newest first). Validated
+    /// here so callers see a 400 instead of a silent engine fallback.
+    order: String,
 }
 
 fn validate_memories_params(
@@ -3613,6 +3630,17 @@ fn validate_memories_params(
     };
     let _ = access::resolve_namespace; // intentionally bypassed — see above
 
+    // v0.8.23: validate `?order` here so callers see 400 BAD_REQUEST
+    // instead of an engine error. asc (default) | desc.
+    let order = params.order.as_deref().unwrap_or("asc");
+    if order != "asc" && order != "desc" {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            ApiErrorCode::InvalidQueryParameter,
+            format!("order=`{order}` is not recognized; allowed: asc | desc"),
+        ));
+    }
+
     Ok(MemoriesListResolved {
         db_namespace,
         tag_filter,
@@ -3621,6 +3649,10 @@ fn validate_memories_params(
         sort_by: sort_by.to_string(),
         domain: params.domain.clone(),
         memory_type: params.memory_type.clone(),
+        kind: params.kind.clone(),
+        drive_id: params.drive_id.clone(),
+        since_rid: params.since_rid.clone(),
+        order: order.to_string(),
     })
 }
 
@@ -3664,15 +3696,68 @@ async fn memories_list(
 
     let domain = resolved.domain.clone();
     let memory_type = resolved.memory_type.clone();
-    // Tag filter is OPTIONAL — None means "list every row in db_namespace
-    // regardless of namespace tag." This is what makes the 200k+ rows
-    // tagged `skill_substrate`/`comm_substrate`/etc. surface for algo's
-    // and lane-b's workflows when the client omits `?namespace`.
     let tag_filter = resolved.tag_filter.clone();
-    let sort_by = resolved.sort_by.clone();
+    let kind = resolved.kind.clone();
+    let drive_id = resolved.drive_id.clone();
+    let since_rid = resolved.since_rid.clone();
+    let order = resolved.order.clone();
     let limit = resolved.limit;
     let offset = resolved.offset;
     let engine_clone = engine.clone();
+
+    // v0.8.23: when ANY new structural-query param is set (`?kind`,
+    // `?drive_id`, `?since_rid`, `?order=desc`), route through engine's
+    // `list_records` (yantrikdb-core v0.7.24) which pushes ALL filters
+    // down to one SQL plan with the new indexed VIRTUAL columns + keyset
+    // cursor on rid. Response: `{records, next_cursor, limit}` with
+    // metadata parsed as JSON (mirrors /v1/recall's item shape so
+    // clients like yantrikdb-agi's `query_typed()` deserialize through
+    // their existing RecallHit type).
+    //
+    // Otherwise (no new params, asc order), keep the legacy
+    // `list_memories` path with `{items, total, limit, offset}` for
+    // backwards compatibility. Both are valid; the dashboard hasn't
+    // been migrated yet.
+    let uses_list_records =
+        kind.is_some() || drive_id.is_some() || since_rid.is_some() || order == "desc";
+
+    if uses_list_records {
+        let res = tokio::task::spawn_blocking(move || {
+            engine_clone.list_records(
+                tag_filter.as_deref(),
+                kind.as_deref(),
+                drive_id.as_deref(),
+                memory_type.as_deref(),
+                domain.as_deref(),
+                since_rid.as_deref(),
+                limit,
+                &order,
+            )
+        })
+        .await
+        .map_err(|e| {
+            api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ApiErrorCode::InternalError,
+                format!("blocking thread join failed: {e}"),
+            )
+        })?;
+        let (records, next_cursor) = res.map_err(|e| {
+            api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ApiErrorCode::InternalError,
+                format!("list_records failed: {e}"),
+            )
+        })?;
+        let items: Vec<Value> = records.iter().map(memory_to_record_item).collect();
+        return Ok(Json(json!({
+            "records": items,
+            "next_cursor": next_cursor,
+            "limit": resolved.limit,
+        })));
+    }
+
+    let sort_by = resolved.sort_by.clone();
     let res = tokio::task::spawn_blocking(move || {
         engine_clone.list_memories(
             limit,
@@ -3706,6 +3791,39 @@ async fn memories_list(
         "offset": resolved.offset,
         "items": items,
     })))
+}
+
+/// v0.8.23: record item shape for the `list_records`-backed
+/// `/v1/memories` response. Mirrors `/v1/recall`'s item structure
+/// exactly — metadata is a PARSED JSON object (not stringified). Per
+/// yantrikdb-agi's request (swarm c1d810df, 2026-06-10): the goal is
+/// that their existing `RecallHit` deserializer drops in unchanged.
+fn memory_to_record_item(m: &yantrikdb::Memory) -> Value {
+    // The engine returns `metadata` as a serde_json::Value, but some
+    // tenants have legacy rows where the value is a Value::String
+    // containing a JSON-encoded blob (the stringified-metadata pattern
+    // yantrikdb-agi flagged in swarm c1d810df). Normalize both shapes
+    // to a parsed object so the client sees `metadata: {...}` regardless
+    // of how the row was originally written.
+    let metadata = match &m.metadata {
+        Value::String(s) if !s.trim().is_empty() => {
+            serde_json::from_str::<Value>(s).unwrap_or_else(|_| m.metadata.clone())
+        }
+        other => other.clone(),
+    };
+    json!({
+        "rid": m.rid,
+        "text": m.text,
+        "memory_type": m.memory_type,
+        "importance": m.importance,
+        "metadata": metadata,
+        "namespace": m.namespace,
+        "created_at": m.created_at,
+        "created_at_iso": unix_to_iso(m.created_at),
+        "certainty": m.certainty,
+        "domain": m.domain,
+        "source": m.source,
+    })
 }
 
 // ── /v1/memory/{rid} — point read (issue #39 Phase 1 task 197) ──────
@@ -5095,6 +5213,65 @@ mod memories_list_tests {
         let out = validate_memories_params(&p, &params).unwrap();
         assert_eq!(out.db_namespace, "default");
         assert_eq!(out.tag_filter.as_deref(), Some("yantrikos_entity_fable3"));
+    }
+
+    // ── v0.8.23 structural-query primitive params ───────────────────
+
+    #[test]
+    fn validate_v0823_default_order_is_asc() {
+        let p = pinned("acme");
+        let params = MemoriesListParams::default();
+        let out = validate_memories_params(&p, &params).unwrap();
+        assert_eq!(out.order, "asc");
+        assert!(out.kind.is_none());
+        assert!(out.drive_id.is_none());
+        assert!(out.since_rid.is_none());
+    }
+
+    #[test]
+    fn validate_v0823_accepts_desc_order() {
+        let p = pinned("acme");
+        let params = MemoriesListParams {
+            order: Some("desc".into()),
+            ..Default::default()
+        };
+        let out = validate_memories_params(&p, &params).unwrap();
+        assert_eq!(out.order, "desc");
+    }
+
+    #[test]
+    fn validate_v0823_rejects_unknown_order() {
+        let p = pinned("acme");
+        let params = MemoriesListParams {
+            order: Some("backwards".into()),
+            ..Default::default()
+        };
+        let err = validate_memories_params(&p, &params).expect_err("must reject");
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(body_field(&err, "message")
+            .as_str()
+            .unwrap()
+            .contains("asc | desc"));
+    }
+
+    #[test]
+    fn validate_v0823_kind_drive_id_since_rid_round_trip() {
+        // The validator passes these through unmolested; the handler
+        // routes them down to engine.list_records.
+        let p = pinned("acme");
+        let params = MemoriesListParams {
+            kind: Some("operator_reply_v1".into()),
+            drive_id: Some("019ea-drive".into()),
+            since_rid: Some("019eb-cursor".into()),
+            order: Some("desc".into()),
+            ..Default::default()
+        };
+        let out = validate_memories_params(&p, &params).unwrap();
+        assert_eq!(out.kind.as_deref(), Some("operator_reply_v1"));
+        assert_eq!(out.drive_id.as_deref(), Some("019ea-drive"));
+        assert_eq!(out.since_rid.as_deref(), Some("019eb-cursor"));
+        assert_eq!(out.order, "desc");
+        assert_eq!(out.db_namespace, "acme"); // tenant routing unchanged
     }
 }
 


### PR DESCRIPTION
## Summary

Wires `GET /v1/memories` to yantrikdb-core v0.7.24's `list_records`, adding the structural query primitive algo (yantrikdb-agi) has been asking for:

- `?kind=X` — indexed `metadata.kind` filter
- `?drive_id=X` — indexed `metadata.drive_id` filter
- `?since_rid=R` — keyset cursor (UUIDv7 = lexically chronological)
- `?order=asc|desc` — default asc

Replaces the fetch-all-then-filter pattern with **one indexed SQL plan** when any of these params is set. Per algo's smoke (swarm `c1d810df`): on `.133` they have 110 fable3-tagged rows with 2 `operator_reply_v1`; `/v1/recall` at top_k=120 surfaced only 1 of 2 (the burying bug), and they had to client-side filter every list call. v0.8.23 fixes the perf gap with a clean structural path.

## What's in

| Surface | v0.8.22 | v0.8.23 |
|---|---|---|
| `/v1/memories` no new params | `{items, total, limit, offset}` (list_memories) | **unchanged** — legacy path preserved |
| `/v1/memories?kind=X` etc | filter ignored | **routes to `list_records`** — `{records, next_cursor, limit}` |
| Record `metadata` field | stringified `metadata_json` + `metadata: null` | **parsed JSON object** mirroring `/v1/recall` shape |
| Engine pin | v0.7.22 | **v0.7.24** (schema v32 auto-migrates; new VIRTUAL generated columns + indexes on `metadata.kind` + `metadata.drive_id`) |

## Behavior diff vs v0.8.22

- **Legacy clients (no structural params): unchanged.** Dashboards, scripts using the existing `{items, total, ...}` envelope continue working.
- **New clients (any structural param): get the new `{records, next_cursor, limit}` shape** with parsed metadata. yantrikdb-agi's `query_typed()` deserializes through their existing `RecallHit` type with no special-casing.

Both shapes co-exist on the same endpoint — branch is taken based on whether new params are present.

## Tests

4 new validator tests; 26 memories_list_tests total pass. **2,096 workspace tests pass.** No regressions.

```
validate::validate_v0823_default_order_is_asc
validate::validate_v0823_accepts_desc_order
validate::validate_v0823_rejects_unknown_order
validate::validate_v0823_kind_drive_id_since_rid_round_trip
```

## Test plan

- [x] `cargo check --workspace --tests` clean
- [x] `cargo test --workspace` — 2,096 pass
- [x] `cargo fmt --all -- --check` clean
- [x] Engine pin bumped to published v0.7.24 (crates.io 01:02 UTC 2026-06-10)
- [x] Legacy path unchanged (memories_list_e2e tests still pass)
- [x] New params plumbed: validator → resolved → handler dispatch
- [x] `metadata_json` legacy shape preserved on legacy path for back-compat
- [ ] Deploy v0.8.23 to .133 + trader once merged
- [ ] Algo swaps `query_typed()` to the new endpoint
- [ ] (Engine v0.7.24's schema v32 auto-migration runs on first start on .133 — will watch journalctl)

## Engine contract (locked with core via swarm `6405b7e5`)

```rust
list_records(
  namespace: Option<&str>, kind: Option<&str>, drive_id: Option<&str>,
  memory_type: Option<&str>, domain: Option<&str>, since_rid: Option<&str>,
  limit: usize, order: &str
) -> Result<(Vec<Memory>, Option<String>)>
```

All filters AND-composed and pushed down to SQL.

## Deferred to v0.8.24+

- Link model MCP surface (`record_with_links_partial`, `expand_links` on recall, `link/unlink/linked_records`, `reify_supersedes_links` admin tool)
- `/v1/admin/audit/leak_candidates` HTTP endpoint
- Proposal 5 validation-gate repair UX