### PR TITLE
feat: v0.8.24 — autonomous hygiene worker + admin surface (RFC 027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.24] — 2026-06-11
+
+**The active memory server begins — autonomous hygiene (RFC 027, pillar 1: time).** The server now drives the engine's maintenance cycle on a per-tenant schedule, so closing loops (conflict burn-down, trigger prune, importance recalibration, entity backfill, auto-relate) is **structural, not voluntary**. The engine deliberately owns no timer ("a storage engine scheduling itself is the wrong boundary"); the server is the host that decides cadence. Addresses the write-rich/close-poor diagnosis: hygiene becomes a property of the deployment, not of client discipline.
+
+### Changed — engine pin v0.7.24 → v0.8.0
+
+Engine v0.8.0 ("World's Best Memory System") is additive and backward-compatible (schema via `CREATE TABLE IF NOT EXISTS`; new public API only). v0.8.24 consumes its `run_maintenance_cycle(&MaintenanceCycleConfig) → MaintenanceCycleReport` and `last_maintenance_cycle()` surface. No wire-protocol change; `/v1/recall`, `/v1/remember`, `/v1/memories` unchanged.
+
+### Added — `[maintenance]` config block
+
+```toml
+[maintenance]
+enabled = true              # master switch (default on)
+interval_secs = 600         # per-tenant cadence (10 min)
+initial_delay_secs = 120    # base delay before first cycle (+ per-tenant jitter)
+pause_during_replication_catchup = true  # skip when this node doesn't accept writes
+run_split_oversized = false # heavy pass — opt-in
+run_repair_artifacts = false# heavy pass — opt-in
+max_pending_triggers = 64
+max_auto_relate_edges = 500
+split_min_chars = 1500
+```
+
+Defaults are **on + light**, so existing deployments gain hygiene on upgrade with no config change; the heavy corpus-rewriting passes stay opt-in.
+
+### Added — `MaintenanceWorker` (per-tenant sleep cycle)
+
+Joins the existing `WorkerRegistry`. Each tenant's loop, after a jittered initial delay:
+- **Cluster-safety gate** — runs `run_maintenance_cycle()` only where writes are accepted (standalone or the current leader). On a follower/learner it skips, because the cycle mutates state and would otherwise fork the state machine (the v0.8.18 class of bug). Mutations propagate through the normal replication path.
+- **Backpressure gate** — reuses the enrichment-pressure rule; skips a tick when the engine is behind on its delta tier.
+- Runs on `spawn_blocking`; idempotent (a missed or double-run tick converges).
+
+### Added — admin endpoints (master-token gated)
+
+| Endpoint | Behavior |
+|---|---|
+| `POST /v1/admin/maintenance/run` | Operator-triggered cycle. `?tenant=<name>` for one, else all. Optional body `{split_oversized, repair_artifacts}` enables heavy passes. **Refuses with 409 on a node that doesn't accept writes** (hit the leader). |
+| `GET /v1/admin/maintenance/status` | Per-tenant last-cycle summary (from `last_maintenance_cycle()`), worker liveness, and this node's write-acceptance state. |
+
+### Added — maintenance metrics (`/metrics`)
+
+Per-tenant counters: `yantrikdb_maintenance_runs_total`, `_conflicts_resolved_total`, `_triggers_pruned_total`, `_consolidations_total`, `_entities_linked_total`, `_relations_upserted_total`, `_failures_total`, `_pass_errors_total`; `_runs_skipped_total{reason}` (`not_write_accepting` / `backpressure`); and the `_duration_ms` summary. The write-rich/close-poor dashboard.
+
 ## [0.8.23] — 2026-06-10
 
 Structural query primitive on `/v1/memories` — `?kind=`, `?drive_id=`, `?since_rid=` (keyset cursor), `?order=asc|desc` — wired to engine `list_records` (yantrikdb-core v0.7.24). Replaces the fetch-all-then-filter pattern with indexed push-down. Closes algo's perf gap (swarm `c1d810df`, 2026-06-10): "list records of kind X" now uses one SQL plan with indexed VIRTUAL columns instead of a full scan.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2720,7 +2720,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2757,7 +2757,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4914,8 +4914,8 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb"
-version = "0.7.24"
-source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#72bd4f79d9acc2cd4c23453cfc817a2eec38da7f"
+version = "0.8.0"
+source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#da3caabbfed93a0a9c016e8691a6495ae9e5bf26"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.8.22"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.8.23"
+version = "0.8.24"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"
@@ -17,22 +17,23 @@ name = "yantrikdb"
 path = "src/main.rs"
 
 [dependencies]
-# Engine v0.7.19 pins the v0.7.18 + v0.7.19 reliability arc. Required fixes
-# since v0.7.17:
-#   - v0.7.18: spawn_all_workers() bundles materializer + compactor. The
-#     compactor was never spawned by yantrikdb-server pre-0.8.18, so every
-#     deployment wedged at delta_max=256 writes per delta-tier saturation
-#     window (production trader's intermittent 503 storms; fresh installs
-#     locked permanently after the 256th write). spawn_all_workers also
-#     stores a guard so engine drop = worker shutdown.
-#   - v0.7.19: compensating DELETE on Backpressure rolls back the memories
-#     INSERT when vec_index.append returns Err — closes the orphaned-
-#     memories provenance gap. Pre-0.7.19, every 503'd write left an
-#     untracked memories row (trader's `default` DB has 23,043 such orphans
-#     accumulated over 39 days). Also introduces the v29 schema migration
-#     with the replication_apply_log audit table for the three-population
-#     audit query (locally-originated / replication-applied / true orphan).
-yantrikdb = { version = "0.7.24", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
+# Engine v0.8.0 — the "World's Best Memory System" program. Additive and
+# backward-compatible with the v0.7.x line (schema additions via CREATE TABLE
+# IF NOT EXISTS; new public API only). v0.8.24 pins it to drive the autonomous
+# maintenance cycle from the server host:
+#   - run_maintenance_cycle(&MaintenanceCycleConfig) -> MaintenanceCycleReport:
+#     the unified "sleep cycle" — think (consolidation + conflict scan +
+#     trigger expiry) → entity backfill → auto-relate → conflict burn-down →
+#     trigger prune → importance recalibration → (opt-in) split/repair. The
+#     engine deliberately owns NO timer thread ("a storage engine scheduling
+#     itself is the wrong boundary"); the host drives cadence. RFC 027 / #55.
+#   - last_maintenance_cycle() -> Option<String>: persisted JSON of the last
+#     cycle for the status endpoint + boot digest.
+#   - session_digest(&SessionDigestConfig) -> SessionDigest, chain_head(ns):
+#     wired by v0.8.25 (RFC 023 / #56).
+# Carries forward the v0.7.18 compactor + v0.7.19 orphan-rollback reliability
+# arc that every deployment since v0.8.18 depends on.
+yantrikdb = { version = "0.8.0", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime

--- a/crates/yantrikdb-server/src/background.rs
+++ b/crates/yantrikdb-server/src/background.rs
@@ -12,14 +12,60 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use yantrikdb::types::ThinkConfig;
-use yantrikdb::YantrikDB;
+use yantrikdb::{MaintenanceCycleConfig, YantrikDB};
 
-use crate::config::BackgroundSection;
+use crate::config::{BackgroundSection, MaintenanceSection};
+
+/// Live check of whether this node should run state-mutating maintenance.
+///
+/// RFC 027 cluster-safety invariant: `run_maintenance_cycle()` mutates state
+/// (resolves conflicts, prunes triggers, recalibrates importance, upserts
+/// edges). Running it independently on a follower would fork the state
+/// machine — the v0.8.18 class of bug. So maintenance runs **only where writes
+/// are accepted** (standalone, or the current leader); the mutations then
+/// propagate through the same replication path as every other write.
+///
+/// The gate is polled every tick because the role changes on failover. It
+/// mirrors the exact write-acceptance logic the wire/HTTP write path uses
+/// (openraft leader → raft-lite `accepts_writes()` → standalone-always).
+#[derive(Clone)]
+pub struct WriteAcceptanceGate {
+    inner: Arc<dyn Fn() -> bool + Send + Sync>,
+}
+
+impl WriteAcceptanceGate {
+    /// Standalone / single-node: always accepts writes.
+    pub fn standalone() -> Self {
+        Self {
+            inner: Arc::new(|| true),
+        }
+    }
+
+    /// Build from a live predicate (closure over the raft/cluster handles).
+    pub fn from_fn(f: impl Fn() -> bool + Send + Sync + 'static) -> Self {
+        Self { inner: Arc::new(f) }
+    }
+
+    /// Whether this node currently accepts writes (leader or standalone).
+    pub fn accepts_writes(&self) -> bool {
+        (self.inner)()
+    }
+}
+
+impl std::fmt::Debug for WriteAcceptanceGate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WriteAcceptanceGate(accepts={})", self.accepts_writes())
+    }
+}
 
 /// Manages background worker tasks per database.
 pub struct WorkerRegistry {
     workers: Mutex<HashMap<i64, DatabaseWorkers>>,
     config: BackgroundSection,
+    /// RFC 027 / v0.8.24: autonomous-maintenance cadence config.
+    maintenance: MaintenanceSection,
+    /// Cluster write-acceptance gate for the maintenance loop.
+    write_gate: WriteAcceptanceGate,
 }
 
 struct DatabaseWorkers {
@@ -32,10 +78,16 @@ struct DatabaseWorkers {
 }
 
 impl WorkerRegistry {
-    pub fn new(config: &BackgroundSection) -> Self {
+    pub fn new(
+        config: &BackgroundSection,
+        maintenance: &MaintenanceSection,
+        write_gate: WriteAcceptanceGate,
+    ) -> Self {
         Self {
             workers: Mutex::new(HashMap::new()),
             config: config.clone(),
+            maintenance: maintenance.clone(),
+            write_gate,
         }
     }
 
@@ -125,6 +177,29 @@ impl WorkerRegistry {
             let id = db_id;
             handles.push(tokio::spawn(async move {
                 null_embedding_check_loop(engine, interval, token, name, id).await;
+            }));
+        }
+
+        // RFC 027 / v0.8.24: the sleep cycle. Drive the engine's
+        // run_maintenance_cycle() on a per-tenant timer so closing loops
+        // (conflict burn-down, trigger prune, importance recalibration, entity
+        // backfill, auto-relate) is structural, not voluntary. Cluster-safe:
+        // runs only where writes are accepted (see WriteAcceptanceGate).
+        if self.maintenance.enabled && self.maintenance.interval_secs > 0 {
+            let interval = Duration::from_secs(self.maintenance.interval_secs);
+            // Per-tenant jitter on the initial delay so N tenants don't fire
+            // their first (and subsequent aligned) cycles in lockstep. Derive
+            // it deterministically from db_id — no RNG needed, and stable
+            // across restarts for reproducible scheduling.
+            let jitter = Duration::from_secs((db_id.unsigned_abs() % 60) + 1);
+            let initial_delay = Duration::from_secs(self.maintenance.initial_delay_secs) + jitter;
+            let engine = Arc::clone(&engine);
+            let token = cancel.clone();
+            let name = db_name.clone();
+            let mcfg = self.maintenance.clone();
+            let gate = self.write_gate.clone();
+            handles.push(tokio::spawn(async move {
+                maintenance_loop(engine, interval, initial_delay, token, name, mcfg, gate).await;
             }));
         }
 
@@ -603,6 +678,149 @@ async fn wal_checkpoint_loop(
     }
 }
 
+/// Translate the server-side [`MaintenanceSection`] into the engine's
+/// [`MaintenanceCycleConfig`]. The light idempotent passes are always on; the
+/// heavy corpus-rewriting passes (split, repair) are gated by config.
+pub fn maintenance_cycle_config(m: &MaintenanceSection) -> MaintenanceCycleConfig {
+    MaintenanceCycleConfig {
+        run_think: true,
+        burn_down_conflicts: true,
+        prune_triggers: true,
+        max_pending_triggers: m.max_pending_triggers,
+        recalibrate_importance: true,
+        backfill_entities: true,
+        auto_relate: true,
+        max_auto_relate_edges: m.max_auto_relate_edges,
+        split_oversized: m.run_split_oversized,
+        split_min_chars: m.split_min_chars,
+        repair_artifacts: m.run_repair_artifacts,
+    }
+}
+
+/// The sleep cycle (RFC 027 / v0.8.24). Drives `run_maintenance_cycle()` on a
+/// per-tenant timer, gated for cluster safety (write-acceptance) and load
+/// (backpressure). Idempotent: a missed or double-run tick converges.
+#[allow(clippy::too_many_arguments)]
+async fn maintenance_loop(
+    engine: Arc<YantrikDB>,
+    interval: Duration,
+    initial_delay: Duration,
+    cancel: CancellationToken,
+    db_name: String,
+    cfg: MaintenanceSection,
+    write_gate: WriteAcceptanceGate,
+) {
+    // Initial (jittered) delay — let the engine settle and avoid a startup
+    // stampede across tenants.
+    tokio::select! {
+        _ = tokio::time::sleep(initial_delay) => {}
+        _ = cancel.cancelled() => return,
+    }
+
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = cancel.cancelled() => {
+                tracing::debug!(db = %db_name, "maintenance worker shutting down");
+                return;
+            }
+        }
+
+        // Cluster-safety gate: only mutate state where writes are accepted
+        // (standalone or leader). On a follower this would fork the state
+        // machine. `pause_during_replication_catchup = false` is an operator
+        // escape hatch that disables the gate (unsafe on clusters).
+        if cfg.pause_during_replication_catchup && !write_gate.accepts_writes() {
+            crate::metrics::record_maintenance_skipped(&db_name, "not_write_accepting");
+            tracing::debug!(
+                db = %db_name,
+                "maintenance: node does not accept writes (follower/learner) — skipping tick"
+            );
+            continue;
+        }
+
+        // Backpressure gate: hygiene is load-bound work. Reuse the existing
+        // enrichment-pressure rule — if the engine is behind on its delta
+        // tier, skip this tick rather than compound the pressure.
+        let cfg_for_blocking = cfg.clone();
+        let result = tokio::task::spawn_blocking({
+            let engine = Arc::clone(&engine);
+            let db_name = db_name.clone();
+            move || {
+                let db = engine.as_ref();
+                let pending = db.count_pending_ops().unwrap_or(0).max(0) as u64;
+                let threshold = effective_enrichment_threshold(db, None);
+                if pending > threshold {
+                    crate::metrics::record_maintenance_skipped(&db_name, "backpressure");
+                    tracing::debug!(
+                        db = %db_name,
+                        pending,
+                        threshold,
+                        "maintenance: engine under pressure — skipping tick"
+                    );
+                    return None;
+                }
+
+                let _hold_timer = crate::metrics::LockHoldTimer::start("worker_maintenance");
+                let start = std::time::Instant::now();
+                let engine_cfg = maintenance_cycle_config(&cfg_for_blocking);
+                match db.run_maintenance_cycle(&engine_cfg) {
+                    Ok(report) => Some((report, start.elapsed().as_secs_f64() * 1000.0)),
+                    Err(e) => {
+                        crate::metrics::record_maintenance_failed(&db_name);
+                        tracing::error!(db = %db_name, error = %e, "maintenance cycle failed");
+                        None
+                    }
+                }
+            }
+        })
+        .await;
+
+        if let Ok(Some((report, duration_ms))) = result {
+            let conflicts_resolved = report
+                .conflicts
+                .as_ref()
+                .map(|c| c.auto_resolved)
+                .unwrap_or(0);
+            let triggers_pruned = report
+                .triggers
+                .as_ref()
+                .map(|t| t.expired_overdue + t.expired_over_cap)
+                .unwrap_or(0);
+            crate::metrics::record_maintenance_cycle(
+                &db_name,
+                duration_ms,
+                report.think_consolidations.unwrap_or(0) as u64,
+                conflicts_resolved as u64,
+                triggers_pruned as u64,
+                report.entities_linked.unwrap_or(0) as u64,
+                report.relations_upserted.unwrap_or(0) as u64,
+                report.errors.len() as u64,
+            );
+            // Only log when the cycle did real work or hit a pass error.
+            let did_work = report.think_consolidations.unwrap_or(0) > 0
+                || conflicts_resolved > 0
+                || triggers_pruned > 0
+                || report.relations_upserted.unwrap_or(0) > 0
+                || report.entities_linked.unwrap_or(0) > 0
+                || !report.errors.is_empty();
+            if did_work {
+                tracing::info!(
+                    db = %db_name,
+                    duration_ms = duration_ms as u64,
+                    consolidations = report.think_consolidations.unwrap_or(0),
+                    conflicts_resolved,
+                    triggers_pruned,
+                    entities_linked = report.entities_linked.unwrap_or(0),
+                    relations_upserted = report.relations_upserted.unwrap_or(0),
+                    pass_errors = report.errors.len(),
+                    "maintenance cycle complete"
+                );
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -654,5 +872,66 @@ mod tests {
         // Pin the constant. Future-debugging readers benefit from
         // the explicit value showing up in test output.
         assert_eq!(ENRICHMENT_PAUSE_THRESHOLD_FLOOR, 50);
+    }
+
+    // ── RFC 027 / v0.8.24 maintenance ───────────────────────────────
+
+    #[test]
+    fn maintenance_config_maps_section_defaults() {
+        // Default section → light passes on, heavy passes off, engine caps.
+        let section = MaintenanceSection::default();
+        let cfg = maintenance_cycle_config(&section);
+        assert!(cfg.run_think);
+        assert!(cfg.burn_down_conflicts);
+        assert!(cfg.prune_triggers);
+        assert!(cfg.recalibrate_importance);
+        assert!(cfg.backfill_entities);
+        assert!(cfg.auto_relate);
+        // Heavy passes opt-in — off by default so a routine cycle stays cheap.
+        assert!(!cfg.split_oversized);
+        assert!(!cfg.repair_artifacts);
+        assert_eq!(cfg.max_pending_triggers, 64);
+        assert_eq!(cfg.max_auto_relate_edges, 500);
+        assert_eq!(cfg.split_min_chars, 1500);
+    }
+
+    #[test]
+    fn maintenance_config_honors_heavy_pass_optin() {
+        let section = MaintenanceSection {
+            run_split_oversized: true,
+            run_repair_artifacts: true,
+            max_pending_triggers: 16,
+            max_auto_relate_edges: 100,
+            split_min_chars: 2000,
+            ..MaintenanceSection::default()
+        };
+        let cfg = maintenance_cycle_config(&section);
+        assert!(cfg.split_oversized);
+        assert!(cfg.repair_artifacts);
+        assert_eq!(cfg.max_pending_triggers, 16);
+        assert_eq!(cfg.max_auto_relate_edges, 100);
+        assert_eq!(cfg.split_min_chars, 2000);
+    }
+
+    #[test]
+    fn write_gate_standalone_always_accepts() {
+        // Single-node: maintenance always runs.
+        assert!(WriteAcceptanceGate::standalone().accepts_writes());
+    }
+
+    #[test]
+    fn write_gate_reflects_live_predicate() {
+        // The cluster-safety invariant: the gate is polled live, so a
+        // follower→leader transition flips it. Simulate with a toggle.
+        let leader = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let gate = {
+            let leader = Arc::clone(&leader);
+            WriteAcceptanceGate::from_fn(move || leader.load(std::sync::atomic::Ordering::Relaxed))
+        };
+        // Follower: maintenance must NOT run (would fork the state machine).
+        assert!(!gate.accepts_writes());
+        // Promoted to leader: now it runs.
+        leader.store(true, std::sync::atomic::Ordering::Relaxed);
+        assert!(gate.accepts_writes());
     }
 }

--- a/crates/yantrikdb-server/src/config/mod.rs
+++ b/crates/yantrikdb-server/src/config/mod.rs
@@ -23,6 +23,11 @@ pub struct ServerConfig {
     pub encryption: EncryptionSection,
     pub embedding: EmbeddingSection,
     pub background: BackgroundSection,
+    /// RFC 027 / v0.8.24: autonomous-hygiene cadence. The server drives the
+    /// engine's `run_maintenance_cycle()` on a per-tenant schedule so closing
+    /// loops (conflict burn-down, trigger prune, importance recalibration,
+    /// entity backfill, auto-relate) is structural, not voluntary.
+    pub maintenance: MaintenanceSection,
     pub limits: LimitsSection,
     pub cluster: ClusterSection,
     /// RFC 014-A: cluster-transport mTLS. Optional in legacy cluster
@@ -206,6 +211,55 @@ pub struct BackgroundSection {
     /// a function of wall-clock time, not engine load).
     #[serde(default)]
     pub enrichment_pause_threshold: Option<u64>,
+}
+
+/// RFC 027 / v0.8.24 — the sleep cycle. The server drives the engine's
+/// `run_maintenance_cycle()` on a per-tenant timer so the close mechanisms
+/// the engine already has (conflict burn-down, trigger prune, importance
+/// recalibration, entity backfill, auto-relate) run structurally, with no
+/// agent in the loop. Defaults are on + light: an existing deployment gains
+/// hygiene on upgrade with no config change, and the heavy corpus-rewriting
+/// passes stay opt-in.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct MaintenanceSection {
+    /// Master switch. Default `true` — hygiene is the point.
+    pub enabled: bool,
+    /// Cadence per tenant, in seconds. Default 600 (10 minutes).
+    pub interval_secs: u64,
+    /// Base delay before a tenant's first cycle, in seconds. Per-tenant jitter
+    /// is added on top so N tenants don't stampede on startup. Default 120.
+    pub initial_delay_secs: u64,
+    /// Skip a tick if this node is catching up replication (openraft mode).
+    /// Default `true` — don't pile maintenance mutations onto a node that is
+    /// still applying the backlog.
+    pub pause_during_replication_catchup: bool,
+    /// Heavy pass: split oversized episodic dumps into atomic facts. Opt-in.
+    pub run_split_oversized: bool,
+    /// Heavy pass: repair leaked tool-call artifacts in the corpus. Opt-in.
+    pub run_repair_artifacts: bool,
+    /// Cap for the trigger prune (engine default 64).
+    pub max_pending_triggers: usize,
+    /// Cap on edges upserted per auto-relate pass (engine default 500).
+    pub max_auto_relate_edges: usize,
+    /// Minimum plaintext length for the split pass (engine default 1500).
+    pub split_min_chars: usize,
+}
+
+impl Default for MaintenanceSection {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval_secs: 600,
+            initial_delay_secs: 120,
+            pause_during_replication_catchup: true,
+            run_split_oversized: false,
+            run_repair_artifacts: false,
+            max_pending_triggers: 64,
+            max_auto_relate_edges: 500,
+            split_min_chars: 1500,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -2027,6 +2027,118 @@ async fn metrics(State(state): State<Arc<AppState>>) -> String {
         }
     }
 
+    // RFC 027 / v0.8.24 — autonomous-maintenance metrics. The write-rich/
+    // close-poor dashboard: how often hygiene ran per tenant and what it
+    // closed, plus skip/failure counters and the cycle-duration histogram.
+    {
+        let aggs = crate::metrics::maintenance_aggs_snapshot();
+        if !aggs.is_empty() {
+            out.push_str("# HELP yantrikdb_maintenance_runs_total Maintenance cycles completed\n");
+            out.push_str("# TYPE yantrikdb_maintenance_runs_total counter\n");
+            for (db, a) in &aggs {
+                out.push_str(&format!(
+                    "yantrikdb_maintenance_runs_total{{db=\"{db}\"}} {}\n",
+                    a.runs
+                ));
+            }
+            out.push_str(
+                "# HELP yantrikdb_maintenance_conflicts_resolved_total Conflicts auto-resolved by maintenance\n",
+            );
+            out.push_str("# TYPE yantrikdb_maintenance_conflicts_resolved_total counter\n");
+            for (db, a) in &aggs {
+                out.push_str(&format!(
+                    "yantrikdb_maintenance_conflicts_resolved_total{{db=\"{db}\"}} {}\n",
+                    a.conflicts_resolved
+                ));
+            }
+            out.push_str(
+                "# HELP yantrikdb_maintenance_triggers_pruned_total Pending triggers expired by maintenance\n",
+            );
+            out.push_str("# TYPE yantrikdb_maintenance_triggers_pruned_total counter\n");
+            for (db, a) in &aggs {
+                out.push_str(&format!(
+                    "yantrikdb_maintenance_triggers_pruned_total{{db=\"{db}\"}} {}\n",
+                    a.triggers_pruned
+                ));
+            }
+            out.push_str(
+                "# HELP yantrikdb_maintenance_consolidations_total Consolidations performed by maintenance\n",
+            );
+            out.push_str("# TYPE yantrikdb_maintenance_consolidations_total counter\n");
+            for (db, a) in &aggs {
+                out.push_str(&format!(
+                    "yantrikdb_maintenance_consolidations_total{{db=\"{db}\"}} {}\n",
+                    a.consolidations
+                ));
+            }
+            out.push_str(
+                "# HELP yantrikdb_maintenance_entities_linked_total Memory-entity links backfilled by maintenance\n",
+            );
+            out.push_str("# TYPE yantrikdb_maintenance_entities_linked_total counter\n");
+            for (db, a) in &aggs {
+                out.push_str(&format!(
+                    "yantrikdb_maintenance_entities_linked_total{{db=\"{db}\"}} {}\n",
+                    a.entities_linked
+                ));
+            }
+            out.push_str(
+                "# HELP yantrikdb_maintenance_relations_upserted_total Co-occurrence edges upserted by maintenance\n",
+            );
+            out.push_str("# TYPE yantrikdb_maintenance_relations_upserted_total counter\n");
+            for (db, a) in &aggs {
+                out.push_str(&format!(
+                    "yantrikdb_maintenance_relations_upserted_total{{db=\"{db}\"}} {}\n",
+                    a.relations_upserted
+                ));
+            }
+            out.push_str(
+                "# HELP yantrikdb_maintenance_failures_total Maintenance cycles that returned an error\n",
+            );
+            out.push_str("# TYPE yantrikdb_maintenance_failures_total counter\n");
+            for (db, a) in &aggs {
+                out.push_str(&format!(
+                    "yantrikdb_maintenance_failures_total{{db=\"{db}\"}} {}\n",
+                    a.failures
+                ));
+            }
+            out.push_str(
+                "# HELP yantrikdb_maintenance_pass_errors_total Per-pass errors recorded across maintenance cycles\n",
+            );
+            out.push_str("# TYPE yantrikdb_maintenance_pass_errors_total counter\n");
+            for (db, a) in &aggs {
+                out.push_str(&format!(
+                    "yantrikdb_maintenance_pass_errors_total{{db=\"{db}\"}} {}\n",
+                    a.pass_errors
+                ));
+            }
+        }
+
+        let skipped = crate::metrics::maintenance_skipped_snapshot();
+        if !skipped.is_empty() {
+            out.push_str(
+                "# HELP yantrikdb_maintenance_runs_skipped_total Maintenance ticks skipped, by reason\n",
+            );
+            out.push_str("# TYPE yantrikdb_maintenance_runs_skipped_total counter\n");
+            for (db, reason, count) in &skipped {
+                out.push_str(&format!(
+                    "yantrikdb_maintenance_runs_skipped_total{{db=\"{db}\",reason=\"{reason}\"}} {count}\n"
+                ));
+            }
+        }
+
+        let (mcount, msum) = crate::metrics::maintenance_duration_totals();
+        if mcount > 0 {
+            out.push_str(
+                "# HELP yantrikdb_maintenance_duration_ms Maintenance-cycle wall-clock duration (ms)\n",
+            );
+            out.push_str("# TYPE yantrikdb_maintenance_duration_ms summary\n");
+            out.push_str(&format!("yantrikdb_maintenance_duration_ms_sum {msum}\n"));
+            out.push_str(&format!(
+                "yantrikdb_maintenance_duration_ms_count {mcount}\n"
+            ));
+        }
+    }
+
     // Append per-handler histograms, lock-wait histograms, request counters
     out.push_str(&crate::metrics::global().render_prometheus());
 
@@ -2523,6 +2635,190 @@ fn require_master_token(state: &AppState, headers: &axum::http::HeaderMap) -> Re
         StatusCode::FORBIDDEN,
         "debug endpoints require the cluster master token",
     ))
+}
+
+/// Whether this node currently accepts writes (leader or standalone).
+/// Mirrors the wire/HTTP write-path gate so state-mutating admin actions
+/// (like a manual maintenance run) don't fork the cluster state machine.
+fn node_accepts_writes(state: &AppState) -> bool {
+    if let Some(ref assembly) = state.raft {
+        let m = assembly.raft.metrics().borrow().clone();
+        return matches!(m.state, openraft::ServerState::Leader);
+    }
+    if let Some(ref cluster) = state.cluster {
+        return cluster.state.accepts_writes();
+    }
+    true
+}
+
+#[derive(serde::Deserialize)]
+struct MaintenanceTenantQuery {
+    /// Restrict the action to a single named tenant (database). When absent,
+    /// the action covers every database.
+    tenant: Option<String>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct MaintenanceRunBody {
+    /// Run the heavy split-oversized-episodes pass (default false).
+    #[serde(default)]
+    split_oversized: bool,
+    /// Run the heavy tool-call-artifact repair pass (default false).
+    #[serde(default)]
+    repair_artifacts: bool,
+}
+
+/// Resolve the set of (db_id, name, engine) the maintenance action targets.
+/// `?tenant=<name>` selects one; absent selects all databases. Loads each
+/// engine (and starts its workers) as a side effect.
+fn resolve_maintenance_targets(
+    state: &AppState,
+    tenant: Option<&str>,
+) -> Result<Vec<(i64, String, EngineHandle)>, AppError> {
+    let records = {
+        let control = state.control.lock();
+        if let Some(name) = tenant {
+            let rec = control
+                .get_database(name)
+                .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+                .ok_or_else(|| {
+                    app_error(
+                        StatusCode::NOT_FOUND,
+                        format!("database '{name}' not found"),
+                    )
+                })?;
+            vec![rec]
+        } else {
+            control
+                .list_databases()
+                .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        }
+    };
+    let mut out = Vec::with_capacity(records.len());
+    for rec in records {
+        let engine = state
+            .pool
+            .get_engine(&rec)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        state
+            .workers
+            .start_for_database(rec.id, rec.name.clone(), std::sync::Arc::clone(&engine));
+        out.push((rec.id, rec.name, engine));
+    }
+    Ok(out)
+}
+
+/// POST /v1/admin/maintenance/run — RFC 027 / v0.8.24. Operator-triggered
+/// maintenance cycle. Master-token gated. `?tenant=<name>` runs one tenant;
+/// absent runs all. Optional body enables the heavy opt-in passes.
+///
+/// Cluster-safe: refuses to run on a node that does not accept writes
+/// (follower/learner), because `run_maintenance_cycle` mutates state and would
+/// fork the state machine. Hit the leader instead.
+async fn admin_maintenance_run(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    axum::extract::Query(params): axum::extract::Query<MaintenanceTenantQuery>,
+    body: Option<Json<MaintenanceRunBody>>,
+) -> AppResult {
+    let _timer = crate::metrics::HandlerTimer::new("admin_maintenance_run");
+    require_master_token(&state, &headers)?;
+
+    if !node_accepts_writes(&state) {
+        return Err(app_error(
+            StatusCode::CONFLICT,
+            "this node does not accept writes (follower/learner); \
+             run maintenance on the leader",
+        ));
+    }
+
+    let opts = body.map(|b| b.0).unwrap_or_default();
+    let targets = resolve_maintenance_targets(&state, params.tenant.as_deref())?;
+
+    let mut results = Vec::with_capacity(targets.len());
+    for (_db_id, name, engine) in targets {
+        let cfg = yantrikdb::MaintenanceCycleConfig {
+            split_oversized: opts.split_oversized,
+            repair_artifacts: opts.repair_artifacts,
+            ..Default::default()
+        };
+        let start = std::time::Instant::now();
+        let outcome = tokio::task::spawn_blocking(move || engine.run_maintenance_cycle(&cfg))
+            .await
+            .map_err(|e| {
+                app_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("join error: {e}"),
+                )
+            })?;
+        let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
+        match outcome {
+            Ok(report) => {
+                let conflicts_resolved = report
+                    .conflicts
+                    .as_ref()
+                    .map(|c| c.auto_resolved)
+                    .unwrap_or(0);
+                let triggers_pruned = report
+                    .triggers
+                    .as_ref()
+                    .map(|t| t.expired_overdue + t.expired_over_cap)
+                    .unwrap_or(0);
+                crate::metrics::record_maintenance_cycle(
+                    &name,
+                    duration_ms,
+                    report.think_consolidations.unwrap_or(0) as u64,
+                    conflicts_resolved as u64,
+                    triggers_pruned as u64,
+                    report.entities_linked.unwrap_or(0) as u64,
+                    report.relations_upserted.unwrap_or(0) as u64,
+                    report.errors.len() as u64,
+                );
+                results.push(json!({
+                    "tenant": name,
+                    "duration_ms": duration_ms,
+                    "report": serde_json::to_value(&report).unwrap_or(Value::Null),
+                }));
+            }
+            Err(e) => {
+                crate::metrics::record_maintenance_failed(&name);
+                results.push(json!({ "tenant": name, "error": e.to_string() }));
+            }
+        }
+    }
+
+    Ok(Json(json!({ "ran": results.len(), "results": results })))
+}
+
+/// GET /v1/admin/maintenance/status — RFC 027 / v0.8.24. Master-token gated.
+/// Returns the last persisted maintenance-cycle summary per tenant plus worker
+/// liveness and this node's write-acceptance state.
+async fn admin_maintenance_status(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    axum::extract::Query(params): axum::extract::Query<MaintenanceTenantQuery>,
+) -> AppResult {
+    let _timer = crate::metrics::HandlerTimer::new("admin_maintenance_status");
+    require_master_token(&state, &headers)?;
+
+    let targets = resolve_maintenance_targets(&state, params.tenant.as_deref())?;
+    let mut tenants = Vec::with_capacity(targets.len());
+    for (_db_id, name, engine) in targets {
+        let last = engine.last_maintenance_cycle().ok().flatten();
+        let parsed = last
+            .as_deref()
+            .and_then(|s| serde_json::from_str::<Value>(s).ok());
+        tenants.push(json!({
+            "tenant": name,
+            "last_maintenance_cycle": parsed,
+        }));
+    }
+
+    Ok(Json(json!({
+        "active_workers": state.workers.active_count(),
+        "accepts_writes": node_accepts_writes(&state),
+        "tenants": tenants,
+    })))
 }
 
 async fn debug_history(
@@ -4059,6 +4355,12 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/v1/cluster/remove", post(cluster_remove))
         .route("/v1/admin/control-snapshot", get(control_snapshot))
         .route("/v1/admin/snapshot", post(admin_snapshot))
+        // RFC 027 / v0.8.24 — autonomous-maintenance operator surface.
+        .route("/v1/admin/maintenance/run", post(admin_maintenance_run))
+        .route(
+            "/v1/admin/maintenance/status",
+            get(admin_maintenance_status),
+        )
         // RFC 008 Warrant Flow substrate
         .route("/v1/claim_with_lineage", post(ingest_claim_with_lineage))
         .route("/v1/mobility", get(get_mobility))
@@ -4654,11 +4956,35 @@ pub(crate) mod e2e_test_support {
     /// - no cluster, no openraft, no control runtime — Phase 1 read
     ///   endpoints don't need them and stubs avoid spawning runtimes.
     pub fn build_fixture(tenant_namespace: &str) -> E2eFixture {
+        build_fixture_impl(tenant_namespace, None)
+    }
+
+    /// Build a fixture with a cluster context configured — for testing the
+    /// cluster-safety gates on the maintenance admin endpoints (RFC 027).
+    /// `role` drives write-acceptance (Single→Standalone accepts; Voter→
+    /// Follower rejects); `secret` becomes the cluster master token.
+    pub fn build_fixture_with_cluster(
+        tenant_namespace: &str,
+        role: crate::config::NodeRole,
+        secret: &str,
+    ) -> E2eFixture {
+        build_fixture_impl(tenant_namespace, Some((role, secret.to_string())))
+    }
+
+    fn build_fixture_impl(
+        tenant_namespace: &str,
+        cluster: Option<(crate::config::NodeRole, String)>,
+    ) -> E2eFixture {
         let tmp = tempfile::tempdir().expect("tempdir");
         let data_dir = tmp.path().to_path_buf();
 
         let mut cfg = crate::config::ServerConfig::default();
         cfg.server.data_dir = data_dir.clone();
+        if let Some((role, ref secret)) = cluster {
+            cfg.cluster.node_id = 1;
+            cfg.cluster.role = role;
+            cfg.cluster.cluster_secret = Some(secret.clone());
+        }
 
         // control DB + one tenant + one token
         let control_path = data_dir.join("control.db");
@@ -4674,20 +5000,41 @@ pub(crate) mod e2e_test_support {
         let control = Arc::new(Mutex::new(control));
 
         let pool = Arc::new(crate::tenant_pool::TenantPool::new(&cfg, None, None));
-        let workers = crate::background::WorkerRegistry::new(&cfg.background);
+        let workers = crate::background::WorkerRegistry::new(
+            &cfg.background,
+            &cfg.maintenance,
+            crate::background::WriteAcceptanceGate::standalone(),
+        );
         let admission = crate::admission::AdmissionState::new(Default::default());
         let commit_log: Arc<dyn crate::commit::MutationCommitter> =
             Arc::new(crate::commit::LocalSqliteCommitter::open_in_memory().expect("commit log"));
         let jobs: Arc<dyn crate::jobs::JobQueue> =
             Arc::new(crate::jobs::LocalSqliteJobQueue::open_in_memory().expect("jobs queue"));
-        let auth_provider: Arc<dyn crate::auth::AuthProvider> =
-            Arc::new(ControlDbAuthProvider::new(Arc::clone(&control), None));
+        let cluster_secret = cluster.as_ref().map(|(_, s)| s.clone());
+        let auth_provider: Arc<dyn crate::auth::AuthProvider> = Arc::new(
+            ControlDbAuthProvider::new(Arc::clone(&control), cluster_secret),
+        );
+
+        let cluster_ctx = cluster.map(|(role, _)| {
+            let node_state = Arc::new(
+                crate::cluster::NodeState::new(1, role, data_dir.join("raft.json"))
+                    .expect("node state"),
+            );
+            let peers = Arc::new(crate::cluster::PeerRegistry::new(&cfg.cluster.peers));
+            Arc::new(crate::cluster::ClusterContext::new(
+                cfg.cluster.clone(),
+                node_state,
+                peers,
+                Arc::clone(&pool),
+                Some(Arc::clone(&control)),
+            ))
+        });
 
         let state = Arc::new(AppState {
             control,
             pool,
             workers,
-            cluster: None,
+            cluster: cluster_ctx,
             inflight: std::sync::atomic::AtomicU32::new(0),
             admission,
             control_runtime: None,
@@ -4723,6 +5070,33 @@ pub(crate) mod e2e_test_support {
             builder = builder.header("authorization", format!("Bearer {tok}"));
         }
         let req = builder.body(axum::body::Body::empty()).unwrap();
+        let res = app.oneshot(req).await.expect("oneshot");
+        let status = res.status();
+        let bytes = to_bytes(res.into_body(), 1024 * 1024)
+            .await
+            .expect("body bytes");
+        (status, bytes)
+    }
+
+    /// Helper: POST (empty JSON body) against the production router.
+    pub async fn post(
+        state: Arc<AppState>,
+        path: &str,
+        bearer: Option<&str>,
+    ) -> (axum::http::StatusCode, axum::body::Bytes) {
+        use axum::body::to_bytes;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let app = super::router(state);
+        let mut builder = Request::builder()
+            .uri(path)
+            .method("POST")
+            .header("content-type", "application/json");
+        if let Some(tok) = bearer {
+            builder = builder.header("authorization", format!("Bearer {tok}"));
+        }
+        let req = builder.body(axum::body::Body::from("{}")).unwrap();
         let res = app.oneshot(req).await.expect("oneshot");
         let status = res.status();
         let bytes = to_bytes(res.into_body(), 1024 * 1024)
@@ -4845,6 +5219,105 @@ mod identity_scope_e2e {
         assert!(
             !s.contains(&fx.raw_token),
             "raw bearer token leaked into response body"
+        );
+    }
+}
+
+#[cfg(test)]
+mod maintenance_e2e {
+    use super::e2e_test_support::{build_fixture, build_fixture_with_cluster, get, post};
+    use crate::config::NodeRole;
+
+    #[tokio::test]
+    async fn status_requires_bearer() {
+        let fx = build_fixture("acme");
+        let (status, _) = get(fx.state.clone(), "/v1/admin/maintenance/status", None).await;
+        assert_eq!(status, 401);
+    }
+
+    #[tokio::test]
+    async fn status_rejects_non_master_token() {
+        // Single-node, no cluster secret → master-token gate denies any token.
+        let fx = build_fixture("acme");
+        let (status, _) = get(
+            fx.state.clone(),
+            "/v1/admin/maintenance/status",
+            Some(&fx.raw_token),
+        )
+        .await;
+        assert_eq!(status, 403);
+    }
+
+    #[tokio::test]
+    async fn run_rejects_non_master_token() {
+        let fx = build_fixture("acme");
+        let (status, _) = post(
+            fx.state.clone(),
+            "/v1/admin/maintenance/run",
+            Some(&fx.raw_token),
+        )
+        .await;
+        assert_eq!(status, 403);
+    }
+
+    #[tokio::test]
+    async fn status_ok_with_master_token() {
+        let fx = build_fixture_with_cluster("acme", NodeRole::Single, "test-master");
+        let (status, body) = get(
+            fx.state.clone(),
+            "/v1/admin/maintenance/status",
+            Some("test-master"),
+        )
+        .await;
+        assert_eq!(status, 200);
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        // Standalone (Single role) accepts writes.
+        assert_eq!(v["accepts_writes"], true);
+        assert!(v["tenants"].is_array(), "status must list tenants");
+    }
+
+    #[tokio::test]
+    async fn run_ok_on_write_accepting_node() {
+        // Standalone accepts writes → maintenance runs and returns a report
+        // per tenant. The cycle is idempotent on an empty engine.
+        let fx = build_fixture_with_cluster("acme", NodeRole::Single, "test-master");
+        let (status, body) = post(
+            fx.state.clone(),
+            "/v1/admin/maintenance/run",
+            Some("test-master"),
+        )
+        .await;
+        assert_eq!(status, 200, "body: {}", String::from_utf8_lossy(&body));
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(v["ran"].as_u64().unwrap() >= 1, "should run >=1 tenant");
+        let results = v["results"].as_array().expect("results array");
+        assert!(!results.is_empty());
+        assert!(results[0]["tenant"].is_string());
+    }
+
+    #[tokio::test]
+    async fn run_refused_on_follower_is_cluster_safe() {
+        // THE cluster-safety invariant (RFC 027): a follower must NOT run
+        // maintenance — it mutates state and would fork the state machine.
+        // Voter role starts as Follower → does not accept writes → 409.
+        let fx = build_fixture_with_cluster("acme", NodeRole::Voter, "test-master");
+        let (status, body) = post(
+            fx.state.clone(),
+            "/v1/admin/maintenance/run",
+            Some("test-master"),
+        )
+        .await;
+        assert_eq!(
+            status,
+            409,
+            "follower must refuse maintenance; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let msg = v["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            msg.contains("does not accept writes"),
+            "409 must explain the write-acceptance gate; got: {msg}"
         );
     }
 }

--- a/crates/yantrikdb-server/src/main.rs
+++ b/crates/yantrikdb-server/src/main.rs
@@ -1839,9 +1839,10 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
         tracing::warn!("encryption: disabled — set [encryption] to enable at-rest encryption");
     }
 
-    // Create tenant pool and background worker registry
+    // Create tenant pool. The background worker registry is built later
+    // (just before AppState) so its maintenance loop can capture the live
+    // cluster write-acceptance gate (RFC 027 cluster-safety invariant).
     let pool = Arc::new(TenantPool::new(&cfg, embedder, master_key));
-    let workers = background::WorkerRegistry::new(&cfg.background);
     let control = Arc::new(Mutex::new(control));
 
     // v0.8.8: eager engine warm-up. A database server should serve queries
@@ -2173,6 +2174,27 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
                 control.clone(),
                 cfg.cluster.cluster_secret.clone(),
             ));
+
+        // RFC 027 cluster-safety: the maintenance loop must only mutate state
+        // where writes are accepted (standalone or leader), else it forks the
+        // state machine. Build a live gate mirroring the wire/HTTP write path:
+        // openraft leader → raft-lite accepts_writes() → standalone-always.
+        let write_gate = {
+            let raft = raft_assembly.clone();
+            let cluster = cluster_ctx.clone();
+            background::WriteAcceptanceGate::from_fn(move || {
+                if let Some(ref assembly) = raft {
+                    let m = assembly.raft.metrics().borrow().clone();
+                    return matches!(m.state, openraft::ServerState::Leader);
+                }
+                if let Some(ref c) = cluster {
+                    return c.state.accepts_writes();
+                }
+                true
+            })
+        };
+        let workers =
+            background::WorkerRegistry::new(&cfg.background, &cfg.maintenance, write_gate);
 
         let state = Arc::new(AppState {
             control,

--- a/crates/yantrikdb-server/src/metrics.rs
+++ b/crates/yantrikdb-server/src/metrics.rs
@@ -161,6 +161,30 @@ pub struct MetricsStore {
     /// "is the threshold tuned right" — without this the operator is
     /// guessing.
     enrichment_pending_at_pause: Mutex<HistogramData>,
+
+    /// RFC 027 / v0.8.24 — per-tenant maintenance-cycle aggregates. The
+    /// write-rich/close-poor dashboard: how often hygiene ran and what it
+    /// closed. Keyed by db name.
+    maintenance_aggs: Mutex<HashMap<String, MaintenanceAgg>>,
+    /// Counter: maintenance ticks skipped, keyed by (db, reason). Reasons:
+    /// `not_write_accepting` (follower/learner) and `backpressure`.
+    maintenance_skipped: Mutex<HashMap<(String, &'static str), u64>>,
+    /// Histogram: maintenance-cycle wall-clock duration in milliseconds.
+    maintenance_duration_ms: Mutex<HistogramData>,
+}
+
+/// RFC 027 / v0.8.24 — running totals for one tenant's maintenance loop.
+#[derive(Default, Clone)]
+pub struct MaintenanceAgg {
+    pub runs: u64,
+    pub failures: u64,
+    pub consolidations: u64,
+    pub conflicts_resolved: u64,
+    pub triggers_pruned: u64,
+    pub entities_linked: u64,
+    pub relations_upserted: u64,
+    pub pass_errors: u64,
+    pub last_duration_ms: f64,
 }
 
 impl MetricsStore {
@@ -193,6 +217,9 @@ impl MetricsStore {
             enrichment_paused: Mutex::new(HashMap::new()),
             enrichment_resumed: Mutex::new(HashMap::new()),
             enrichment_pending_at_pause: Mutex::new(HistogramData::new()),
+            maintenance_aggs: Mutex::new(HashMap::new()),
+            maintenance_skipped: Mutex::new(HashMap::new()),
+            maintenance_duration_ms: Mutex::new(HistogramData::new()),
         }
     }
 
@@ -520,6 +547,69 @@ pub fn record_enrichment_paused(db_name: &str, pending: u64) {
 pub fn record_enrichment_resumed(db_name: &str) {
     let mut map = global().enrichment_resumed.lock();
     *map.entry(db_name.to_string()).or_insert(0) += 1;
+}
+
+/// RFC 027 / v0.8.24 — record one completed maintenance cycle. Primitive
+/// args (not `&MaintenanceCycleReport`) so this module stays a leaf, matching
+/// [`record_openraft_gauges`]. The caller extracts the counts from the report.
+#[allow(clippy::too_many_arguments)]
+pub fn record_maintenance_cycle(
+    db_name: &str,
+    duration_ms: f64,
+    consolidations: u64,
+    conflicts_resolved: u64,
+    triggers_pruned: u64,
+    entities_linked: u64,
+    relations_upserted: u64,
+    pass_errors: u64,
+) {
+    {
+        let mut map = global().maintenance_aggs.lock();
+        let agg = map.entry(db_name.to_string()).or_default();
+        agg.runs += 1;
+        agg.consolidations += consolidations;
+        agg.conflicts_resolved += conflicts_resolved;
+        agg.triggers_pruned += triggers_pruned;
+        agg.entities_linked += entities_linked;
+        agg.relations_upserted += relations_upserted;
+        agg.pass_errors += pass_errors;
+        agg.last_duration_ms = duration_ms;
+    }
+    global().maintenance_duration_ms.lock().observe(duration_ms);
+}
+
+/// RFC 027 — record a maintenance tick that was skipped. `reason` is a
+/// static label: `not_write_accepting` or `backpressure`.
+pub fn record_maintenance_skipped(db_name: &str, reason: &'static str) {
+    let mut map = global().maintenance_skipped.lock();
+    *map.entry((db_name.to_string(), reason)).or_insert(0) += 1;
+}
+
+/// RFC 027 — record a maintenance cycle that returned an error (the whole
+/// `run_maintenance_cycle` call failed, distinct from per-pass errors).
+pub fn record_maintenance_failed(db_name: &str) {
+    let mut map = global().maintenance_aggs.lock();
+    map.entry(db_name.to_string()).or_default().failures += 1;
+}
+
+/// Snapshot of per-tenant maintenance aggregates. For `/metrics` rendering.
+pub fn maintenance_aggs_snapshot() -> Vec<(String, MaintenanceAgg)> {
+    let map = global().maintenance_aggs.lock();
+    map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+}
+
+/// Snapshot of maintenance skip counts per (db, reason). For `/metrics`.
+pub fn maintenance_skipped_snapshot() -> Vec<(String, &'static str, u64)> {
+    let map = global().maintenance_skipped.lock();
+    map.iter()
+        .map(|((db, reason), v)| (db.clone(), *reason, *v))
+        .collect()
+}
+
+/// Snapshot of the maintenance-duration histogram totals (count, sum_ms).
+pub fn maintenance_duration_totals() -> (u64, f64) {
+    let h = global().maintenance_duration_ms.lock();
+    (h.count, h.sum)
 }
 
 /// Snapshot of enrichment pause counts per db. For `/metrics` rendering.

--- a/docker/yantrikdb.toml
+++ b/docker/yantrikdb.toml
@@ -23,3 +23,25 @@ data_dir = "/var/lib/yantrikdb"
 #     dim = 384
 strategy = "bundled"
 dim = 64
+
+# RFC 027 / v0.8.24 — the sleep cycle. The server drives the engine's
+# autonomous maintenance (conflict burn-down, trigger prune, importance
+# recalibration, entity backfill, auto-relate) on a per-tenant timer so closing
+# loops is structural, not voluntary. All values below are defaults — this
+# block is shown for discoverability; omitting it gives identical behavior.
+[maintenance]
+enabled = true              # master switch
+interval_secs = 600         # cadence per tenant (10 minutes)
+initial_delay_secs = 120    # base delay before first cycle (+ per-tenant jitter)
+# Cluster safety: maintenance mutates state, so it runs ONLY where writes are
+# accepted (standalone or the current leader); followers skip. Set false only
+# as an operator escape hatch (unsafe on multi-voter clusters).
+pause_during_replication_catchup = true
+# Heavy corpus-rewriting passes — opt-in (off by default keeps a routine cycle
+# cheap). The scheduled loop honors these; the admin /run endpoint takes them
+# per-request in its body.
+run_split_oversized = false
+run_repair_artifacts = false
+max_pending_triggers = 64   # cap for the trigger-prune pass
+max_auto_relate_edges = 500 # cap on edges upserted per auto-relate pass
+split_min_chars = 1500      # min plaintext length for the split pass

--- a/docs/rfcs/rfc_027_active_memory_server.md
+++ b/docs/rfcs/rfc_027_active_memory_server.md
@@ -1,0 +1,134 @@
+# RFC 027 — The Active Memory Server
+
+Status: **Draft** (2026-06-11)
+Author: Pranab Sarkar + Claude Fable 5
+Triggered by: yantrikdb engine **v0.8.0** ("World's Best Memory System") shipping the autonomous-hygiene API, and Fable's substrate self-critique (memory rid `019eb344`): *every close mechanism the engine has is **voluntary** — it relies on a client remembering to call it.* Write-rich, close-poor: 36 open vs 7 resolved conflicts, 16 pending triggers, 0 archived, 44/2,532 consolidated on the live corpus.
+Constraint: **additive surface** (zero v1 breakage), **enterprise grade** (no band-aids), **cluster-safe** (the v0.8.18 regression is the standing reminder), **evidence-gated** (claims cite runnable harnesses).
+Part of: the active-memory-server program — saga epics #55–#60.
+
+## Motivation
+
+Engine v0.8.0 finished the *cognition* layer. Its `maintenance` module docstring states the boundary precisely:
+
+> "every hygiene mechanism the engine has (consolidation, conflict resolution, trigger expiry, importance correction) exists, but closing them was voluntary — and the substrate itself documents that voluntary agent protocols don't survive drift. … The engine deliberately does NOT own a timer thread — a storage engine scheduling itself is the wrong boundary. It exposes `run_maintenance_cycle()`; **the host decides the cadence**."
+
+**yantrikdb-server is that host.** This is the architectural seam: the engine provides idempotent, safe, fault-isolated passes; the server provides time, lifecycle, trust-on-the-wire, push, fleet coordination, and proof. Every competitor (mem0, Zep, Letta, Hermes's pluggable memory) is a *passive* store — you call it, it answers, and it forgets to tend itself. The thesis of this RFC is that the best memory server is an **active** one: it runs its own hygiene, briefs the agent at boot, marks stale beliefs on every read, and calls the agent back when something needs resolving.
+
+The empirical anchor for "why this matters" is the cross-corpus k-sweep (memory rid `019eb47e`): supersession-aware retrieval is the one structural capability RAG-over-notes cannot buy back at *any* retrieval budget `k` (RAG scores current-value 0.00 at k=8/20/50; the substrate's revision chain scores 0.78–1.00). The server's job is to make that capability — and the hygiene that keeps it true — a property of the *deployment*, not of client discipline.
+
+## Goals
+
+1. **Hygiene is structural, not voluntary.** A loaded engine gets its `run_maintenance_cycle()` driven on a host schedule with zero agent in the loop.
+2. **The server owns the agent's wake/sleep ritual.** One-call boot digest; end-of-session capture.
+3. **Trust travels on the wire.** Age, supersession, and conflict stamps ride every recall hit.
+4. **Memory calls back.** Triggers/conflicts/maintenance outcomes are pushed (SSE), not only polled.
+5. **Fleet, not single-user.** Multiple agents share one substrate with attributable writes + leak audit.
+6. **Proof.** Served (not engine-direct) numbers, CI-gated, README-cited.
+7. **Zero v1 breakage.** Every change is additive to config, HTTP, and MCP surfaces.
+
+## Non-goals
+
+- **No reasoning/agent layer in the server.** Cognition stays in the engine; orchestration stays in the client (Hermes, lane-b, the MCP consumer). Building an agent loop here would compete with our own users.
+- **No new retrieval primitives before the close-loop ships.** Fable's diagnosis was *close-poor*, not *query-poor*; v0.8.23 + engine v0.8.0 already cover structural query. Resist scope creep into more `recall` variants.
+- **The engine does not get a timer.** We honor the engine's boundary: the server schedules, the engine executes.
+- **No silent caps.** If a pass is skipped (backpressure, replication catch-up, cluster non-leader), it is logged and counted, never silently dropped.
+
+## The six pillars and their sequencing
+
+| Release | Pillar | Surface |
+|---|---|---|
+| **v0.8.24** (#55) | **Time** | `MaintenanceWorker` drives `run_maintenance_cycle()` per tenant on a schedule; `[maintenance]` config; admin run/status endpoints; metrics |
+| **v0.8.25** (#56) | **Lifecycle** | `GET /v1/session/digest`, `POST /v1/session/end`, trust metadata on recall hits |
+| **v0.8.26** (#57) | **Trust + Push** | `GET /v1/events` (SSE), `GET /v1/current` (chain head), optional webhooks |
+| **v0.8.27** (#58) | **Fleet** | `/v1/admin/audit/leak_candidates`, write provenance, link-model surface |
+| parallel (#59) | **Proof** | server-tier load + current-value + failover benchmarks, CI gate, README evidence |
+
+Each ships through the full release gate (workspace tests, **cluster-mode validation**, changelog, PR, tag, deploy, smoke, swarm-notify).
+
+---
+
+## v0.8.24 — Autonomous hygiene (this release)
+
+### Engine API consumed
+
+```rust
+// re-exported at the crate root: yantrikdb::{MaintenanceCycleConfig, MaintenanceCycleReport}
+impl YantrikDB {
+    pub fn run_maintenance_cycle(&self, config: &MaintenanceCycleConfig) -> Result<MaintenanceCycleReport>;
+    pub fn last_maintenance_cycle(&self) -> Result<Option<String>>; // persisted JSON of last cycle
+}
+```
+
+`MaintenanceCycleConfig::default()` runs the light, idempotent passes (`run_think`, `burn_down_conflicts`, `prune_triggers` @ max 64, `recalibrate_importance`, `backfill_entities`, `auto_relate` @ max 500 edges) and leaves the heavy corpus-rewriting passes (`split_oversized`, `repair_artifacts`) **off** by default. The report carries per-pass sub-reports and an `errors: Vec<String>` — **a failing pass never aborts the cycle**, and the engine persists the summary to its `meta` table under `last_maintenance_cycle`.
+
+### Design
+
+The existing `background::WorkerRegistry` ([background.rs](../../crates/yantrikdb-server/src/background.rs)) already owns the per-database worker lifecycle: it spawns `tokio` loops with a `CancellationToken`, runs engine work on `spawn_blocking`, records `LockHoldTimer` metrics, and is started per engine-load via `start_for_database(db_id, db_name, engine)`. The maintenance loop joins this registry — no new lifecycle machinery.
+
+```
+[maintenance]
+enabled = true                          # master switch; default on
+interval_secs = 600                     # cadence per tenant (10 min default)
+initial_delay_secs = 120                # jitter base; stagger so tenants don't stampede
+pause_during_replication_catchup = true # skip a tick if this node is catching up
+run_split_oversized = false             # heavy pass — opt-in
+run_repair_artifacts = false            # heavy pass — opt-in
+max_pending_triggers = 64
+max_auto_relate_edges = 500
+```
+
+The loop, per tenant:
+1. **Wait** `interval_secs` (after an `initial_delay_secs` + per-tenant jitter so N tenants don't fire in lockstep).
+2. **Backpressure gate** — reuse the existing enrichment-pressure rule: if `count_pending_ops() > effective_enrichment_threshold(...)`, **skip** this tick (record `maintenance_runs_skipped{reason="backpressure"}`). Hygiene is load-bound, exactly the class the existing rule pauses.
+3. **Cluster gate** (see below).
+4. Build `MaintenanceCycleConfig` from the `[maintenance]` block; call `engine.run_maintenance_cycle()` on `spawn_blocking`.
+5. Record metrics from the report; emit a single `tracing::info!` line when the cycle did real work.
+
+### Cluster safety (the load-bearing decision)
+
+`run_maintenance_cycle()` **mutates state** (resolves conflicts, prunes triggers, rewrites importance, upserts edges). On a replicated cluster, running it independently on every node would **fork the state machine** — the precise class of bug the v0.8.18 cluster regression burned us on.
+
+**Rule: maintenance runs only where writes are accepted.** Concretely the worker checks the cluster state and runs the cycle **iff the node accepts writes** (standalone, or the current leader). On a follower/learner it skips with `maintenance_runs_skipped{reason="not_leader"}`. The mutations then propagate through the normal replication path that every other write uses — no second write channel, no divergence.
+
+- In **standalone** mode (`raft_mode = "disabled"`, e.g. CT 141 today) the node always accepts writes → maintenance always runs. This is the common case.
+- In **openraft** mode the leader runs it; on leadership change the new leader picks up the cadence. A cycle is idempotent, so a double-run across a failover converges.
+
+This is the single most important test target for the release: a maintenance cycle on a clustered node must not produce state the followers don't also receive through replication.
+
+### HTTP surface (additive, master-token gated)
+
+```
+POST /v1/admin/maintenance/run        # operator-triggered cycle; ?tenant=<db> optional
+GET  /v1/admin/maintenance/status     # last_maintenance_cycle() per tenant + worker liveness
+```
+
+`run` returns the `MaintenanceCycleReport` JSON. `status` parses each tenant's persisted `last_maintenance_cycle` and reports `ran_at`, the sub-report counts, and any errors. Both reuse the existing master-token gate (per v0.8.22 routing: master tokens resolve to the relevant engine; `?tenant` selects which).
+
+### Metrics (`/metrics`, Prometheus)
+
+- `maintenance_run_duration_ms` (histogram, label `db`)
+- `maintenance_conflicts_resolved_total`, `maintenance_triggers_pruned_total`, `maintenance_consolidations_total`, `maintenance_entities_linked_total`, `maintenance_relations_upserted_total` (counters)
+- `maintenance_runs_skipped_total{reason}`, `maintenance_runs_failed_total`, `maintenance_pass_errors_total`
+- Health gauges — the write-rich/close-poor dashboard: `memory_open_conflicts`, `memory_pending_triggers` per tenant.
+
+### Backward compatibility
+
+- The `[maintenance]` block defaults `enabled = true`, so **existing deployments gain hygiene on upgrade with no config change** — but every pass it drives is idempotent and the heavy passes are opt-in, so the behavior change is "the conflicts that were already going to be resolved get resolved on a timer."
+- The engine pin v0.7.24 → v0.8.0 is additive (schema via `CREATE TABLE IF NOT EXISTS`; new public API only); 1591 engine tests green, slim build green.
+- No wire-protocol change. No change to `/v1/recall`, `/v1/remember`, `/v1/memories`.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Maintenance forks cluster state | Run only where writes are accepted (leader/standalone); propagate via normal replication. Cluster-mode integration test gates the release. |
+| Hygiene competes with ingest for the 2-core LXC | Backpressure gate skips ticks under load; `spawn_blocking` keeps it off the async reactor; per-tenant jitter avoids stampede. |
+| A bad pass wedges the cycle | Engine isolates per-pass failures into `report.errors`; the worker counts them and continues. |
+| Operators surprised by auto-mutation | `status` endpoint + metrics make every cycle visible; heavy passes opt-in; `enabled=false` is one line. |
+
+## Acceptance
+
+1. `cargo fmt` + `cargo check --workspace --tests` + `cargo test --workspace` green.
+2. Integration test: worker runs against a fixture engine, is idempotent on repeat, and does not interfere with concurrent writes.
+3. **Cluster-mode test**: maintenance on a replicated node does not fork state (runs leader-only; followers receive mutations via replication).
+4. Deployed to CT 133 + trader CT 168; `status` endpoint shows real cycle outcomes on the live corpora; algo notified via swarm.


### PR DESCRIPTION
## Summary

The **active memory server** begins — RFC 027, pillar 1 (*time*). The server now drives the engine's `run_maintenance_cycle()` on a per-tenant schedule, so closing loops — conflict burn-down, trigger prune, importance recalibration, entity backfill, auto-relate — is **structural, not voluntary**.

Addresses the write-rich/close-poor diagnosis: every close mechanism the engine has existed, but invoking them relied on a client remembering to. The engine deliberately owns no timer (*"a storage engine scheduling itself is the wrong boundary"*); the server is the host that decides cadence.

## Changes

- **Engine pin v0.7.24 → v0.8.0** — additive, backward-compatible (schema via `CREATE TABLE IF NOT EXISTS`; new public API only). No wire-protocol change.
- **`[maintenance]` config block** — `enabled` (default on), `interval_secs` (600), jittered `initial_delay_secs`, heavy-pass opt-in. Existing deployments gain hygiene on upgrade with no config change.
- **`MaintenanceWorker`** in the existing `WorkerRegistry` — per-tenant loop with two gates:
  - **Cluster-safety**: runs `run_maintenance_cycle()` only where writes are accepted (standalone or leader). On a follower it skips — the cycle mutates state and would otherwise fork the state machine (the v0.8.18 class of bug). Mutations propagate via the normal replication path.
  - **Backpressure**: reuses the enrichment-pressure rule; skips a tick when the engine is behind on its delta tier.
  - `spawn_blocking`; idempotent (missed/double-run ticks converge).
- **Admin endpoints** (master-token gated):
  - `POST /v1/admin/maintenance/run` — `?tenant=` for one/all; body `{split_oversized, repair_artifacts}` enables heavy passes; **returns 409 on a node that doesn't accept writes**.
  - `GET /v1/admin/maintenance/status` — per-tenant last-cycle summary + worker liveness + write-acceptance.
- **Metrics** — per-tenant runs/conflicts_resolved/triggers_pruned/consolidations/entities_linked/relations_upserted/failures/pass_errors counters, `runs_skipped{reason}`, and the `duration_ms` summary.

## Testing

- 8 new tests, including the cluster-safety gate (`run_refused_on_follower_is_cluster_safe` → 409) and the write-accepting run path.
- **Full workspace suite green: 2,108 tests, 0 failures** — engine pin + changes regress nothing.
- `cargo fmt` clean.

## Design

Full design in [`docs/rfcs/rfc_027_active_memory_server.md`](docs/rfcs/rfc_027_active_memory_server.md) — the six pillars (time/lifecycle/trust/push/fleet/proof) and the v0.8.24→27 sequencing.