### PR TITLE
feat: v0.8.25 — session lifecycle (boot digest + capture) + engine v0.9.0 (RFC 027 pillar 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.25] — 2026-06-28
+
+**Session lifecycle (RFC 027, pillar 2: the server owns the agent's wake/sleep ritual).** Plus the engine bump to v0.9.0. The server now offers a one-call boot briefing and end-of-session capture, so continuity is ambient rather than dependent on a fresh agent's query-writing skill — the structural fix for substrate-underuse drift.
+
+### Changed — engine pin v0.8.0 → v0.9.0
+
+Engine v0.9.0 ("close the memory gaps" — tiering, demand, conversation, tasks) is additive and backward-compatible. Validated on the bump: `cargo check --workspace --tests` clean + full suite **2,106 tests, 0 failures**. v0.8.25 wires its session-lifecycle surface (`session_digest`, `draft_memories_from_summary`); the new demand (`knowledge_gaps`), conversation (working-memory ring), and tasks surfaces are sequenced for later epics. v0.9.0 also fixes the pyo3 worker-pool wedge at `delta_max=256`.
+
+### Added — `GET /v1/session/digest`
+
+One-call boot briefing (tenant-scoped). Returns the narrative chain head + live high-importance decisions + open conflicts + pending triggers + the last maintenance summary, assembled from existing engine primitives. Query params: `?namespace=` (narrative chain), `?max_decisions=` (8), `?max_conflicts=` (5), `?max_triggers=` (5), `?snippet_chars=` (240). Replaces "N recalls a fresh agent may forget to make" with one cheap call.
+
+### Added — `POST /v1/session/end`
+
+End-of-session capture (tenant-scoped). Body `{summary, namespace?, domain?}` → segments the summary into atomic, provisional candidate facts via `draft_memories_from_summary`, returns `{drafted: [rids], count}`. Sessions stop leaving no trace. **Cluster-safe**: a direct engine write, so it returns 409 on a node that doesn't accept writes (run on the leader).
+
+### Trust metadata on recall hits
+
+Confirmed end-to-end: the engine stamps trust signals (⚠ aged-and-rarely-confirmed, ⚠ superseded-by-newer-record) into each recall hit's `why_retrieved`, and `/v1/recall` already surfaces that array — so staleness is visible at the moment of use with no client change.
+
 ## [0.8.24] — 2026-06-11
 
 **The active memory server begins — autonomous hygiene (RFC 027, pillar 1: time).** The server now drives the engine's maintenance cycle on a per-tenant schedule, so closing loops (conflict burn-down, trigger prune, importance recalibration, entity backfill, auto-relate) is **structural, not voluntary**. The engine deliberately owns no timer ("a storage engine scheduling itself is the wrong boundary"); the server is the host that decides cadence. Addresses the write-rich/close-poor diagnosis: hygiene becomes a property of the deployment, not of client discipline.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2720,7 +2720,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2757,7 +2757,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4914,8 +4914,8 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb"
-version = "0.8.0"
-source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#da3caabbfed93a0a9c016e8691a6495ae9e5bf26"
+version = "0.9.0"
+source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#74e9c89ece70c757003dbe6a339d9c7dd681c9c1"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.8.24"
+version = "0.8.25"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"
@@ -17,10 +17,12 @@ name = "yantrikdb"
 path = "src/main.rs"
 
 [dependencies]
-# Engine v0.8.0 — the "World's Best Memory System" program. Additive and
-# backward-compatible with the v0.7.x line (schema additions via CREATE TABLE
-# IF NOT EXISTS; new public API only). v0.8.24 pins it to drive the autonomous
-# maintenance cycle from the server host:
+# Engine v0.9.0 — "close the memory gaps" (tiering, demand, conversation,
+# tasks). Additive and backward-compatible (validated: cargo check --workspace
+# --tests clean + full suite 2106 green on the v0.8.0→v0.9.0 bump). v0.8.25
+# wires its session-lifecycle surface (session_digest, draft_memories_from_
+# summary); the new demand/conversation/tasks surfaces are sequenced for later
+# epics. Continues to drive the autonomous maintenance cycle from the host:
 #   - run_maintenance_cycle(&MaintenanceCycleConfig) -> MaintenanceCycleReport:
 #     the unified "sleep cycle" — think (consolidation + conflict scan +
 #     trigger expiry) → entity backfill → auto-relate → conflict burn-down →
@@ -33,7 +35,7 @@ path = "src/main.rs"
 #     wired by v0.8.25 (RFC 023 / #56).
 # Carries forward the v0.7.18 compactor + v0.7.19 orphan-rollback reliability
 # arc that every deployment since v0.8.18 depends on.
-yantrikdb = { version = "0.8.0", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
+yantrikdb = { version = "0.9.0", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -2821,6 +2821,120 @@ async fn admin_maintenance_status(
     })))
 }
 
+#[derive(serde::Deserialize)]
+struct SessionDigestParams {
+    /// Append-only identity/narrative chain to read the head of (optional).
+    namespace: Option<String>,
+    max_decisions: Option<usize>,
+    max_conflicts: Option<usize>,
+    max_triggers: Option<usize>,
+    snippet_chars: Option<usize>,
+}
+
+/// GET /v1/session/digest — RFC 027 / v0.8.25 (pillar 2: lifecycle).
+///
+/// One-call boot briefing the host injects at session start: narrative chain
+/// head + live high-importance decisions + open conflicts + pending triggers +
+/// the last maintenance summary. Structurally fixes substrate-underuse drift —
+/// one cheap call replaces N recalls a fresh agent may not think to make.
+/// Tenant-scoped (engine resolved from the bearer token).
+async fn session_digest(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    axum::extract::Query(params): axum::extract::Query<SessionDigestParams>,
+) -> AppResult {
+    let _timer = crate::metrics::HandlerTimer::new("session_digest");
+    let (_db_id, engine) = resolve_engine(
+        &state,
+        headers.get("authorization").and_then(|v| v.to_str().ok()),
+    )?;
+    let cfg = yantrikdb::SessionDigestConfig {
+        narrative_namespace: params.namespace,
+        max_decisions: params.max_decisions.unwrap_or(8),
+        max_conflicts: params.max_conflicts.unwrap_or(5),
+        max_triggers: params.max_triggers.unwrap_or(5),
+        snippet_chars: params.snippet_chars.unwrap_or(240),
+    };
+    let digest = tokio::task::spawn_blocking(move || engine.session_digest(&cfg))
+        .await
+        .map_err(|e| {
+            app_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("join error: {e}"),
+            )
+        })?
+        .map_err(|e| {
+            app_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("session_digest failed: {e}"),
+            )
+        })?;
+    Ok(Json(serde_json::to_value(digest).unwrap_or(Value::Null)))
+}
+
+#[derive(serde::Deserialize)]
+struct SessionEndBody {
+    /// Free-text session summary to segment into atomic candidate facts.
+    summary: String,
+    /// Row-tag namespace to file the drafted facts under (default "default").
+    namespace: Option<String>,
+    /// Domain for the drafted facts (default "general").
+    domain: Option<String>,
+}
+
+/// POST /v1/session/end — RFC 027 / v0.8.25 (pillar 2: lifecycle).
+///
+/// End-of-session capture: segments a session summary into atomic, provisional
+/// candidate facts via the engine's `draft_memories_from_summary`, so sessions
+/// stop leaving no trace. Tenant-scoped. Cluster-safe: this is a direct engine
+/// write, so it refuses (409) on a node that does not accept writes — run it on
+/// the leader.
+async fn session_end_capture(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<SessionEndBody>,
+) -> AppResult {
+    let _timer = crate::metrics::HandlerTimer::new("session_end_capture");
+    let (_db_id, engine) = resolve_engine(
+        &state,
+        headers.get("authorization").and_then(|v| v.to_str().ok()),
+    )?;
+    if !node_accepts_writes(&state) {
+        return Err(app_error(
+            StatusCode::CONFLICT,
+            "this node does not accept writes (follower/learner); \
+             session capture must run on the leader",
+        ));
+    }
+    if body.summary.trim().is_empty() {
+        return Err(app_error(
+            StatusCode::BAD_REQUEST,
+            "summary must not be empty",
+        ));
+    }
+    let namespace = body.namespace.unwrap_or_else(|| "default".to_string());
+    let domain = body.domain.unwrap_or_else(|| "general".to_string());
+    let summary = body.summary;
+    let drafted = tokio::task::spawn_blocking(move || {
+        engine.draft_memories_from_summary(&summary, &namespace, &domain)
+    })
+    .await
+    .map_err(|e| {
+        app_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("join error: {e}"),
+        )
+    })?
+    .map_err(|e| {
+        app_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("draft_memories_from_summary failed: {e}"),
+        )
+    })?;
+    let count = drafted.len();
+    Ok(Json(json!({ "drafted": drafted, "count": count })))
+}
+
 async fn debug_history(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
@@ -4325,6 +4439,9 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/v1/remember/batch", post(remember_batch))
         .route("/v1/recall", post(recall))
         .route("/v1/forget", post(forget))
+        // RFC 027 / v0.8.25 (pillar 2: lifecycle) — session boot + capture.
+        .route("/v1/session/digest", get(session_digest))
+        .route("/v1/session/end", post(session_end_capture))
         // RFC 022 §1 (v0.8.11): first-class skill primitives. Thin wrappers
         // over /v1/remember + /v1/recall + scan-and-filter (v0.8.11) or
         // /v1/lookup (v0.8.12+). Schema-validated, no semantic ontology.
@@ -5104,6 +5221,36 @@ pub(crate) mod e2e_test_support {
             .expect("body bytes");
         (status, bytes)
     }
+
+    /// Helper: POST a specific JSON body against the production router.
+    pub async fn post_body(
+        state: Arc<AppState>,
+        path: &str,
+        bearer: Option<&str>,
+        json_body: &str,
+    ) -> (axum::http::StatusCode, axum::body::Bytes) {
+        use axum::body::to_bytes;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let app = super::router(state);
+        let mut builder = Request::builder()
+            .uri(path)
+            .method("POST")
+            .header("content-type", "application/json");
+        if let Some(tok) = bearer {
+            builder = builder.header("authorization", format!("Bearer {tok}"));
+        }
+        let req = builder
+            .body(axum::body::Body::from(json_body.to_string()))
+            .unwrap();
+        let res = app.oneshot(req).await.expect("oneshot");
+        let status = res.status();
+        let bytes = to_bytes(res.into_body(), 1024 * 1024)
+            .await
+            .expect("body bytes");
+        (status, bytes)
+    }
 }
 
 #[cfg(test)]
@@ -5318,6 +5465,87 @@ mod maintenance_e2e {
         assert!(
             msg.contains("does not accept writes"),
             "409 must explain the write-acceptance gate; got: {msg}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod session_lifecycle_e2e {
+    use super::e2e_test_support::{build_fixture, build_fixture_with_cluster, get, post_body};
+    use crate::config::NodeRole;
+
+    #[tokio::test]
+    async fn digest_requires_bearer() {
+        let fx = build_fixture("acme");
+        let (status, _) = get(fx.state.clone(), "/v1/session/digest", None).await;
+        assert_eq!(status, 401);
+    }
+
+    #[tokio::test]
+    async fn digest_ok_for_tenant_token() {
+        // Boot briefing on an empty corpus: 200 with the digest shape
+        // (empty decisions/conflicts/triggers, zero counts).
+        let fx = build_fixture("acme");
+        let (status, body) = get(fx.state.clone(), "/v1/session/digest", Some(&fx.raw_token)).await;
+        assert_eq!(status, 200, "body: {}", String::from_utf8_lossy(&body));
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        // Shape contract the host injects at boot.
+        assert!(v.get("top_decisions").is_some());
+        assert!(v.get("open_conflict_count").is_some());
+        assert!(v.get("pending_trigger_count").is_some());
+        assert_eq!(v["open_conflict_count"], 0);
+    }
+
+    #[tokio::test]
+    async fn end_requires_bearer() {
+        let fx = build_fixture("acme");
+        let (status, _) = post_body(
+            fx.state.clone(),
+            "/v1/session/end",
+            None,
+            r#"{"summary":"x"}"#,
+        )
+        .await;
+        assert_eq!(status, 401);
+    }
+
+    #[tokio::test]
+    async fn end_rejects_empty_summary() {
+        let fx = build_fixture("acme");
+        let (status, _) = post_body(
+            fx.state.clone(),
+            "/v1/session/end",
+            Some(&fx.raw_token),
+            r#"{"summary":"   "}"#,
+        )
+        .await;
+        assert_eq!(status, 400);
+    }
+
+    #[tokio::test]
+    async fn end_refused_on_follower_is_cluster_safe() {
+        // Cluster-safety: end-of-session capture is a direct engine write, so
+        // a follower (Voter→Follower, not write-accepting) must refuse (409)
+        // rather than fork the state machine.
+        let fx = build_fixture_with_cluster("acme", NodeRole::Voter, "test-master");
+        let (status, body) = post_body(
+            fx.state.clone(),
+            "/v1/session/end",
+            Some(&fx.raw_token),
+            r#"{"summary":"a meaningful session summary worth capturing"}"#,
+        )
+        .await;
+        assert_eq!(
+            status,
+            409,
+            "follower must refuse capture; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let msg = v["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            msg.contains("does not accept writes"),
+            "409 must explain the write gate; got: {msg}"
         );
     }
 }


### PR DESCRIPTION
## Summary

RFC 027, **pillar 2 (lifecycle)** — the server owns the agent's wake/sleep ritual. Continuity becomes ambient instead of depending on a fresh agent's query-writing skill (the structural fix for substrate-underuse drift). Also bumps the engine to **v0.9.0**.

## Changes

- **Engine pin v0.8.0 → v0.9.0** ("close the memory gaps" — tiering, demand, conversation, tasks). Additive/backward-compatible; validated independently (`cargo check --workspace --tests` clean + full suite 2,106 green on the bare bump). The new demand/conversation/tasks surfaces are sequenced for later epics; this release wires the session-lifecycle surface.
- **`GET /v1/session/digest`** — one-call boot briefing via engine `session_digest()`: narrative chain head + live high-importance decisions + open conflicts + pending triggers + last-maintenance summary. Tenant-scoped; query-param budgets (`namespace`, `max_decisions`, `max_conflicts`, `max_triggers`, `snippet_chars`).
- **`POST /v1/session/end`** — end-of-session capture via `draft_memories_from_summary()` → `{drafted, count}`. **Cluster-safe**: a direct engine write, so it returns 409 on a non-write-accepting node. (Handler named `session_end_capture` to avoid colliding with the existing session-tracking handler on `/v1/sessions/{id}`.)
- **Trust metadata on recall** — confirmed end-to-end: the engine stamps aged/superseded ⚠ signals into each hit's `why_retrieved`, which `/v1/recall` already surfaces. No client change needed; documented.

## Testing

- 5 new session-lifecycle e2e tests (auth gate, digest shape on empty corpus, empty-summary 400, **follower-409 cluster-safety**).
- **Full workspace suite green: 2,111 tests, 0 failures.** Clippy + fmt clean.

## Design

Continues [RFC 027](docs/rfcs/rfc_027_active_memory_server.md) (v0.8.24 shipped pillar 1: autonomous hygiene).