### PR TITLE
chore: v0.8.26 — engine pin v0.9.0 → v0.9.4 (tagged) + digest isolation scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.26] — 2026-07-15
+
+**Engine pin v0.9.0 → v0.9.4** (latest tagged release) + per-tenant digest isolation. A stability-and-correctness bump: four engine releases of fixes we were behind on, plus one small additive server feature.
+
+### Changed — engine pin v0.9.0 → v0.9.4
+
+Now pinned by **tag** (`v0.9.4`) rather than tracking `branch=main`, so the dependency is reproducible and immune to main drifting into the untagged v0.10 work (the single-origin provenance gate + schema v37, which we'll adopt once core tags v0.10.0 and we validate its REST-contract changes: `correct`→200, reembed-deferral→409). The v0.9.1→v0.9.4 line brings:
+
+- **v0.9.1** — `set_embedder_named` fix with the worker pool running
+- **v0.9.2** — NaN-safe recall
+- **v0.9.3** — contract gate, isolation repair, 7.4× distance path
+- **v0.9.4** — cold-tier recall decompression fix
+
+These are behavioral/internal; they take effect through the existing recall/write paths with no API change. Validated: `cargo check --workspace --tests` clean + full suite **2,111 tests, 0 failures**.
+
+### Added — `?scope=` on `GET /v1/session/digest`
+
+Exposes v0.9.3's digest isolation scope: `?scope=<namespace>` filters the digest's content aggregates (top decisions, open conflicts + count) to one namespace, so a host composing one digest per tenant never mixes another tenant's memories in. Omit for the original whole-DB behavior. The existing `?namespace=` (narrative chain head) is unchanged — this is purely additive. (Pending triggers remain global; the engine scopes those in the v0.10 program.)
+
 ## [0.8.25] — 2026-06-28
 
 **Session lifecycle (RFC 027, pillar 2: the server owns the agent's wake/sleep ritual).** Plus the engine bump to v0.9.0. The server now offers a one-call boot briefing and end-of-session capture, so continuity is ambient rather than dependent on a fresh agent's query-writing skill — the structural fix for substrate-underuse drift.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2720,7 +2720,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2757,7 +2757,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4914,8 +4914,8 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb"
-version = "0.9.0"
-source = "git+https://github.com/yantrikos/yantrikdb.git?branch=main#74e9c89ece70c757003dbe6a339d9c7dd681c9c1"
+version = "0.9.4"
+source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.9.4#6830e870f60c4c425f9e1769cfc141e3dc3898dc"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.8.25"
+version = "0.8.26"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"
@@ -17,12 +17,16 @@ name = "yantrikdb"
 path = "src/main.rs"
 
 [dependencies]
-# Engine v0.9.0 — "close the memory gaps" (tiering, demand, conversation,
-# tasks). Additive and backward-compatible (validated: cargo check --workspace
-# --tests clean + full suite 2106 green on the v0.8.0→v0.9.0 bump). v0.8.25
-# wires its session-lifecycle surface (session_digest, draft_memories_from_
-# summary); the new demand/conversation/tasks surfaces are sequenced for later
-# epics. Continues to drive the autonomous maintenance cycle from the host:
+# Engine v0.9.4 — latest tagged release. Pinned by tag (not branch=main) for a
+# reproducible, released dependency; main is 37 commits into the untagged v0.10
+# work (single-origin provenance gate + schema v37) which we adopt once core
+# tags v0.10.0 and we validate its REST-contract changes (correct→200, reembed
+# deferral→409). The v0.9.1→v0.9.4 line over our previous v0.9.0 pin adds:
+# v0.9.1 set_embedder_named worker-pool fix; v0.9.2 NaN-safe recall; v0.9.3
+# contract gate + isolation repair + 7.4x distance path; v0.9.4 cold-tier
+# recall decompression fix. v0.9.0 base still provides the session-lifecycle
+# surface (session_digest, draft_memories_from_summary) wired in v0.8.25 and
+# the autonomous maintenance cycle (run_maintenance_cycle) driven from the host:
 #   - run_maintenance_cycle(&MaintenanceCycleConfig) -> MaintenanceCycleReport:
 #     the unified "sleep cycle" — think (consolidation + conflict scan +
 #     trigger expiry) → entity backfill → auto-relate → conflict burn-down →
@@ -35,7 +39,7 @@ path = "src/main.rs"
 #     wired by v0.8.25 (RFC 023 / #56).
 # Carries forward the v0.7.18 compactor + v0.7.19 orphan-rollback reliability
 # arc that every deployment since v0.8.18 depends on.
-yantrikdb = { version = "0.9.0", git = "https://github.com/yantrikos/yantrikdb.git", branch = "main" }
+yantrikdb = { version = "0.9.4", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.9.4" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -2825,6 +2825,12 @@ async fn admin_maintenance_status(
 struct SessionDigestParams {
     /// Append-only identity/narrative chain to read the head of (optional).
     namespace: Option<String>,
+    /// v0.9.3 isolation scope (engine v0.9.4): filter the digest's content
+    /// aggregates (top decisions, open conflicts + count) to this namespace,
+    /// so a host composing one digest per tenant never mixes another tenant's
+    /// memories in. Omit for whole-DB (single-tenant) behavior. Pending
+    /// triggers remain global regardless (engine limitation).
+    scope: Option<String>,
     max_decisions: Option<usize>,
     max_conflicts: Option<usize>,
     max_triggers: Option<usize>,
@@ -2850,6 +2856,7 @@ async fn session_digest(
     )?;
     let cfg = yantrikdb::SessionDigestConfig {
         narrative_namespace: params.namespace,
+        namespace: params.scope,
         max_decisions: params.max_decisions.unwrap_or(8),
         max_conflicts: params.max_conflicts.unwrap_or(5),
         max_triggers: params.max_triggers.unwrap_or(5),


### PR DESCRIPTION
## Summary

Stability/correctness bump. Moves the engine pin from **v0.9.0** to **v0.9.4** (latest tagged release — four releases of fixes we were behind on) and adds one small additive server feature.

## Changes

- **Engine pin v0.9.0 → v0.9.4**, now pinned by **tag** (`v0.9.4`) instead of `branch=main`. Reproducible, and immune to `main` drifting into the untagged **v0.10** work (single-origin provenance gate + schema v37) — which we adopt once core tags v0.10.0 and we validate its REST-contract changes (`correct`→200, reembed-deferral→409). The v0.9.1→v0.9.4 line: worker-pool embedder fix, **NaN-safe recall**, contract gate + 7.4× distance path, cold-tier recall decompression fix. All behavioral/internal — no API change.
- **`GET /v1/session/digest` gains `?scope=<namespace>`** (v0.9.3 digest isolation): filters the digest's content aggregates to one namespace for per-tenant digests. Purely additive — `?namespace` (narrative chain head) unchanged.

## Testing

- `cargo check --workspace --tests` clean; **full workspace suite 2,111 tests, 0 failures**; fmt clean.

Follow-up (separate release): the interesting server surfaces — `/v1/current` (chain_head, the benchmarked supersession win), `knowledge_gaps` insights, and SSE push — tracked for v0.8.27+.