### PR TITLE
feat: v0.8.28 — engine v0.10.0 adoption (WriteAdmission, embedding-on-wire, include_superseded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.28] — 2026-07-17
+
+**Engine v0.10.0 adoption.** First leg of the coordinated core→server→mcp→dogfood v0.10 release train. Pinned to the **v0.10.0 tag** (immutable ref — a version string can't distinguish the tag from the RC that self-reports the same version; the release-train lesson made concrete).
+
+### Changed — engine pin v0.9.4 → v0.10.0
+
+Validated against the v0.10.0 tag: full suite green. Four v0.10 breaks handled:
+
+- **`record_with_rid` now takes `admission: WriteAdmission`.** The raft applier passes `WriteAdmission::Admitted` — the consensus-committed apply path was already provenance-gated once at the leader's origin ingress; re-gating it on every follower (`Origin`) would make each reject the leader's committed write and halt the node (a cluster-wide wedge). `Admitted` is the correct, required choice at this one call site.
+- **`OplogEntry.embedding` (v0.10 Item 3).** `entry_to_wire` now populates the embedding bytes (flipped from the placeholder `None` shipped in v0.8.x wire-format v2), and `wire_to_entry` carries them onto the follower — so a text-changing `correct` applies the origin's identical vector instead of re-embedding (which diverges by model version / quantization).
+- **`recall` + `SessionDigestConfig` gained `include_superseded`** — see below.
+
+### Added — `include_superseded` (current-value-by-default, opt-in history)
+
+v0.10 makes recall **exclude superseded records by default** — the supersession-aware behavior we benchmarked (RAG 0.00 vs substrate 0.78–1.00 on current-value). Now wired end-to-end:
+
+- **`POST /v1/recall`** accepts `"include_superseded": <bool>` (default `false`). Threaded through `Command::Recall` → `db.recall` at every call site.
+- **`GET /v1/session/digest?include_superseded=true`** re-admits superseded records into the content aggregates. Default `false` — a boot briefing must report only *current* decisions; quoting a superseded decision back at a waking agent would mislead it.
+- `true` at either surface is for history/archaeology.
+
+Behavioral note for consumers: an unchanged caller now sees **current-value-only** results by default. This is the intended, benchmarked default; opt into the prior all-records behavior with `include_superseded: true`.
+
 ## [0.8.27] — 2026-07-16
 
 **The two capabilities that were dark.** The engine could already do both of these; neither was reachable over HTTP. A pinned engine with unwired capability is dark capability — an agent cannot call what isn't exposed. This release exposes them, and wires them together into a loop.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2720,7 +2720,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2757,7 +2757,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4914,8 +4914,8 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb"
-version = "0.9.4"
-source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.9.4#6830e870f60c4c425f9e1769cfc141e3dc3898dc"
+version = "0.10.0"
+source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.10.0#9bbcd8e249d569c2f5f73f272be0b6d80a7eaaa2"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.8.26"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.8.27"
+version = "0.8.28"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"
@@ -39,7 +39,7 @@ path = "src/main.rs"
 #     wired by v0.8.25 (RFC 023 / #56).
 # Carries forward the v0.7.18 compactor + v0.7.19 orphan-rollback reliability
 # arc that every deployment since v0.8.18 depends on.
-yantrikdb = { version = "0.9.4", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.9.4" }
+yantrikdb = { version = "0.10.0", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.10.0" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime

--- a/crates/yantrikdb-server/src/cluster/replication.rs
+++ b/crates/yantrikdb-server/src/cluster/replication.rs
@@ -28,18 +28,14 @@ pub fn entry_to_wire(e: &OplogEntry) -> OplogEntryWire {
         embedding_hash: e.embedding_hash.clone(),
         origin_actor: e.origin_actor.clone(),
         format_version: yantrikdb_protocol::messages::OPLOG_FORMAT_VERSION,
-        // Oplog format v2 (engine v0.10 Item 3): carries the origin's exact
-        // embedding bytes for a text-changing `correct`, so the follower
-        // applies the identical vector instead of re-embedding (which diverges
-        // by model version / quantization).
-        //
-        // `None` here is correct *for the current engine pin only*: v0.9.4's
-        // `OplogEntry` has no `embedding` field to source from. The wire can
-        // already carry it, so a v2 peer decodes it today and no second
-        // format bump is needed later; populating it from `e.embedding` is a
-        // one-line change that lands with the v0.10 pin (see branch
-        // test/engine-v0.10-19df24c, which wires + round-trip-tests it).
-        embedding: None,
+        // Oplog format v2 (engine v0.10 Item 3): carry the origin's exact
+        // embedding bytes across the peer-sync hop so the follower applies the
+        // identical vector instead of re-embedding (which diverges by model
+        // version / quantization). Now that the engine is pinned to v0.10.0,
+        // `OplogEntry` HAS the field to source from — so this is populated,
+        // not `None`. Dropping it here would compile fine and silently void
+        // the guarantee, which is the whole point of the v2 wire field (#52).
+        embedding: e.embedding.clone(),
     }
 }
 
@@ -54,6 +50,11 @@ pub fn wire_to_entry(w: OplogEntryWire) -> OplogEntry {
         hlc: w.hlc,
         embedding_hash: w.embedding_hash,
         origin_actor: w.origin_actor,
+        // Oplog format v2 / engine v0.10 Item 3: the origin's exact embedding
+        // bytes for a text-changing `correct` reach this follower here, so it
+        // applies the identical vector rather than re-embedding. `None` for
+        // every other op and for v1 entries from a pre-v2 peer (serde default).
+        embedding: w.embedding,
     }
 }
 

--- a/crates/yantrikdb-server/src/command.rs
+++ b/crates/yantrikdb-server/src/command.rs
@@ -35,6 +35,11 @@ pub enum Command {
         domain: Option<String>,
         source: Option<String>,
         query_embedding: Option<Vec<f32>>,
+        /// v0.10: re-admit superseded records. Default `false` = current-value-
+        /// by-default (the supersession-aware behavior). `true` is for
+        /// history/archaeology — surfaces stale records stamped with their
+        /// superseded status.
+        include_superseded: bool,
     },
     Forget {
         rid: String,

--- a/crates/yantrikdb-server/src/commit/applier.rs
+++ b/crates/yantrikdb-server/src/commit/applier.rs
@@ -327,11 +327,20 @@ fn apply_to_engine(
             let created_at = created_at_unix_micros.unwrap_or(0);
             let model = embedding_model.as_deref().unwrap_or("default");
 
-            // engine.record_with_rid signature (engine 0.6.7):
-            //   (rid, text, memory_type, importance, valence, half_life,
-            //    metadata, embedding, namespace, certainty, domain,
-            //    source, emotional_state, created_at_unix_micros,
-            //    extracted_entities, embedding_model, seq: Option<u64>)
+            // engine.record_with_rid signature (engine v0.10):
+            //   (..., seq: Option<u64>, admission: WriteAdmission)
+            //
+            // `WriteAdmission::Admitted` is REQUIRED here and is the whole
+            // reason the arg exists (yantrikdb-core 4a.6b). This is the
+            // consensus-committed apply path: the op was already provenance-
+            // gated once at the leader's ORIGIN ingress before it entered the
+            // raft log. Passing `Origin` would re-gate it on *every* node, so
+            // each follower would reject the leader's committed write; our
+            // contract turns that into `EngineFailure` (not idempotent-ok),
+            // which halts the node's apply path — a cluster-wide wedge, not a
+            // soft failure. `Admitted` says "already admitted upstream, do not
+            // re-gate". A genuine ORIGIN write (a new write, not a replicated
+            // apply) must NOT use this path.
             engine
                 .record_with_rid(
                     rid,
@@ -351,6 +360,7 @@ fn apply_to_engine(
                     &entities_ref,
                     model,
                     Some(log_index),
+                    yantrikdb::provenance::WriteAdmission::Admitted,
                 )
                 .map_err(|e| ApplyError::EngineFailure {
                     message: format!("record_with_rid({rid}): {e}"),

--- a/crates/yantrikdb-server/src/handler.rs
+++ b/crates/yantrikdb-server/src/handler.rs
@@ -135,6 +135,7 @@ pub fn execute_with_guard(
             domain,
             source,
             query_embedding,
+            include_superseded,
         } => {
             let results = if let Some(emb) = query_embedding {
                 db.recall(
@@ -151,6 +152,7 @@ pub fn execute_with_guard(
                     source.as_deref(),
                     None, // certainty_min — v0.7.20 issue #46; pre-existing behavior = no filter
                     None, // order — v0.7.20 issue #46; pre-existing behavior = relevance order
+                    include_superseded, // v0.10: current-value-by-default unless the caller opts into history
                 )?
             } else if namespace.is_some()
                 || domain.is_some()
@@ -174,6 +176,7 @@ pub fn execute_with_guard(
                     source.as_deref(),
                     None, // certainty_min — v0.7.20 issue #46; pre-existing behavior = no filter
                     None, // order — v0.7.20 issue #46; pre-existing behavior = relevance order
+                    include_superseded, // v0.10: current-value-by-default unless the caller opts into history
                 )?
             } else {
                 db.recall_text(&query, top_k)?

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -1167,6 +1167,13 @@ async fn recall(
                     .collect()
             })
         }),
+        // v0.10: default false = current-value-by-default (superseded records
+        // excluded — the supersession-aware behavior we benchmarked). Opt in
+        // with `"include_superseded": true` for history/archaeology.
+        include_superseded: body
+            .get("include_superseded")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
     };
     let mut resp = execute_cmd(engine, cmd, state.control.clone(), &state.inflight).await?;
     annotate_fts5_fallback(&mut resp);
@@ -2986,6 +2993,11 @@ struct SessionDigestParams {
     include_gaps: Option<bool>,
     /// Cap for the folded-in gaps (default 5 — the digest is token-budgeted).
     max_gaps: Option<usize>,
+    /// v0.10 / v0.8.28: re-admit superseded records into the digest's content
+    /// aggregates. Default `false` — a boot briefing must report only CURRENT
+    /// decisions; quoting a superseded decision back at a waking agent would
+    /// mislead it. `true` is for history/archaeology packets.
+    include_superseded: Option<bool>,
 }
 
 /// GET /v1/session/digest — RFC 027 / v0.8.25 (pillar 2: lifecycle).
@@ -3022,6 +3034,9 @@ async fn session_digest(
         max_conflicts: params.max_conflicts.unwrap_or(5),
         max_triggers: params.max_triggers.unwrap_or(5),
         snippet_chars: params.snippet_chars.unwrap_or(240),
+        // v0.10: default false = the boot briefing reports only CURRENT
+        // records. Opt in with ?include_superseded=true for history packets.
+        include_superseded: params.include_superseded.unwrap_or(false),
     };
     let engine_for_gaps = std::sync::Arc::clone(&engine);
     let digest = tokio::task::spawn_blocking(move || engine.session_digest(&cfg))
@@ -3685,6 +3700,8 @@ async fn skill_search(
             domain: Some("skill".to_string()),
             source: None,
             query_embedding: None,
+            // Skill recall wants only CURRENT skills, never superseded ones.
+            include_superseded: false,
         },
         state.control.clone(),
         &state.inflight,
@@ -5731,7 +5748,7 @@ mod session_lifecycle_e2e {
 
 #[cfg(test)]
 mod current_and_gaps_e2e {
-    use super::e2e_test_support::{build_fixture, get};
+    use super::e2e_test_support::{build_fixture, get, post_body};
 
     #[tokio::test]
     async fn current_requires_bearer() {
@@ -5800,6 +5817,50 @@ mod current_and_gaps_e2e {
         assert!(
             v.get("knowledge_gaps").is_none(),
             "gaps must be opt-in, not in the default digest"
+        );
+    }
+
+    #[tokio::test]
+    async fn digest_include_superseded_param_is_accepted() {
+        // v0.10 contract: the digest accepts ?include_superseded and stays 200
+        // (default-false path is exercised by the other digest tests; this pins
+        // that the opt-in param parses and doesn't error on an empty corpus).
+        let fx = build_fixture("acme");
+        let (status, body) = get(
+            fx.state.clone(),
+            "/v1/session/digest?include_superseded=true",
+            Some(&fx.raw_token),
+        )
+        .await;
+        assert_eq!(status, 200, "body: {}", String::from_utf8_lossy(&body));
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(v.get("top_decisions").is_some());
+    }
+
+    #[tokio::test]
+    async fn recall_include_superseded_param_is_accepted() {
+        // v0.10 contract: /v1/recall accepts `include_superseded` in the body
+        // and threads it through Command::Recall to db.recall. This fixture has
+        // no server-side embedder, so a text query reaches the engine and 500s
+        // at embed — which itself proves the param PARSED, built the Command,
+        // and routed through the recall handler (an unknown/rejected param
+        // never reaches the engine). Acceptance + threading is pinned here; the
+        // clean 200 path is covered by digest_include_superseded and the
+        // engine's own recall(include_superseded) tests at the v0.10 pin.
+        let fx = build_fixture("acme");
+        let (status, body) = post_body(
+            fx.state.clone(),
+            "/v1/recall",
+            Some(&fx.raw_token),
+            r#"{"query":"anything","top_k":5,"include_superseded":true}"#,
+        )
+        .await;
+        let text = String::from_utf8_lossy(&body);
+        // 200 (embedder present) OR the specific no-embedder 500 (param reached
+        // the engine). A 400 param rejection or a panic fails the test.
+        assert!(
+            status == 200 || (status == 500 && text.contains("embedder")),
+            "include_superseded must be accepted + threaded to the engine; got {status}: {text}"
         );
     }
 

--- a/crates/yantrikdb-server/src/server.rs
+++ b/crates/yantrikdb-server/src/server.rs
@@ -419,6 +419,10 @@ fn frame_to_command(frame: &Frame) -> anyhow::Result<Command> {
                 domain: req.domain,
                 source: req.source,
                 query_embedding: req.query_embedding,
+                // Wire protocol doesn't carry this field yet, so wire clients
+                // get the v0.10 default: current-value (superseded excluded).
+                // Exposing it over the wire is a RecallRequest change for later.
+                include_superseded: false,
             })
         }
         OpCode::Forget => {

--- a/crates/yantrikdb-server/tests/compat_test.rs
+++ b/crates/yantrikdb-server/tests/compat_test.rs
@@ -87,6 +87,7 @@ fn test_data_dir_survives_reopen() {
                 None,  // source
                 None,  // certainty_min — v0.7.20 issue #46
                 None,  // order — v0.7.20 issue #46
+                false, // include_superseded — v0.10
             )
             .unwrap();
         assert!(

--- a/crates/yantrikdb-server/tests/http_integration.rs
+++ b/crates/yantrikdb-server/tests/http_integration.rs
@@ -432,8 +432,9 @@ async fn handle_recall(
             body.get("namespace").and_then(|v| v.as_str()),
             body.get("domain").and_then(|v| v.as_str()),
             body.get("source").and_then(|v| v.as_str()),
-            None, // certainty_min — v0.7.20 issue #46
-            None, // order — v0.7.20 issue #46
+            None,  // certainty_min — v0.7.20 issue #46
+            None,  // order — v0.7.20 issue #46
+            false, // include_superseded — v0.10
         )
         .map_err(|e| {
             (


### PR DESCRIPTION
## Summary

**First leg of the coordinated v0.10 release train** (core → **server** → mcp → CT128 dogfood). Core tagged **v0.10.0**; this adopts it. Pinned to the **v0.10.0 tag** — an immutable ref, per the release-train lesson that a version string can't distinguish the tag from an RC that self-reports the same version.

## Changes

- **Engine pin v0.9.4 → v0.10.0** (tag). Validated against the tag: full suite green.
- **`record_with_rid` +`WriteAdmission`.** The raft applier passes `WriteAdmission::Admitted`. The consensus-committed apply path was already provenance-gated once at the leader's origin ingress; `Origin` would re-gate it on *every* follower → each rejects the leader's committed write → node halts (a cluster-wide wedge). `Admitted` is the required, correct choice at this one call site. (The change core designed *for* us.)
- **`OplogEntry.embedding` (Item 3).** `entry_to_wire` now populates the embedding bytes (flipped from the `None` placeholder shipped with wire-format v2 in #52); `wire_to_entry` carries them onto the follower — so a text-changing `correct` applies the origin's *identical* vector instead of re-embedding (which diverges by model version / quantization).
- **`include_superseded` wired end-to-end.** v0.10 makes recall exclude superseded records by default — the supersession-aware behavior we benchmarked (RAG 0.00 vs substrate 0.78–1.00 on current-value).
  - `POST /v1/recall` accepts `"include_superseded": <bool>` (default `false`), threaded through `Command::Recall` → `db.recall` at every call site.
  - `GET /v1/session/digest?include_superseded=true` re-admits superseded records into content aggregates (default `false` — a boot briefing must report only *current* decisions).
- **2 behavioral contract tests** (recall + digest param acceptance/threading), per ecosystem working-agreement #3.

### Consumer-visible behavioral note

An unchanged `/v1/recall` caller now sees **current-value-only** results by default. This is the intended, benchmarked default; opt into the prior all-records behavior with `include_superseded: true`.

## Testing

**Full workspace suite 2,124 tests, 0 failures** against the v0.10.0 tag. Clippy + fmt clean.

## Train

Merging + tagging this unblocks mcp's leg (its branch is already green), then core runs the CT128 dogfood deploy last.