### PR TITLE
chore: realign server version to 0.10.0 (ecosystem generation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.28] — 2026-07-17
+## [0.10.0] — 2026-07-18
 
-**Engine v0.10.0 adoption.** First leg of the coordinated core→server→mcp→dogfood v0.10 release train. Pinned to the **v0.10.0 tag** (immutable ref — a version string can't distinguish the tag from the RC that self-reports the same version; the release-train lesson made concrete).
+**Version realignment + engine v0.10.0 adoption.** From this release, `yantrikdb-server` versions align with the engine generation: the ecosystem ships **core 0.10.0 + server 0.10.0 + mcp** on one coordinated train, so "the v0.10 generation" is unambiguous across all three repos. The server's independent 0.8.x line ends at 0.8.27; the briefly-tagged `v0.8.28` (same code, pre-realignment number, never deployed) is superseded by this tag.
+
+This is the first leg of the coordinated core→server→mcp→dogfood v0.10 release train. Pinned to the engine's **v0.10.0 tag** (immutable ref — a version string can't distinguish the tag from an RC that self-reports the same version; the release-train lesson made concrete).
 
 ### Changed — engine pin v0.9.4 → v0.10.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.8.28"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.8.28"
+version = "0.10.0"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Per Pranab's call: the engine v0.10 adoption is a major upgrade, so the server realigns to the ecosystem generation — **core 0.10.0 + server 0.10.0 + mcp** on one coordinated train. The server's independent 0.8.x line ends at 0.8.27; the briefly-tagged `v0.8.28` (same code, never deployed) will be deleted and superseded by `v0.10.0` on this commit. Version bump + CHANGELOG only — no code change; the v0.10 adoption itself was validated in #54 (2,124 tests green).