### PR TITLE
feat(yrp): Phase A1 — election safety core + deterministic simulator (RFC 028 v2)

### DIFF
--- a/crates/yantrikdb-server/src/main.rs
+++ b/crates/yantrikdb-server/src/main.rs
@@ -29,6 +29,7 @@ mod socratic;
 mod tenant_pool;
 mod tls;
 mod version;
+mod yrp;
 
 use parking_lot::Mutex;
 use std::path::PathBuf;

--- a/crates/yantrikdb-server/src/yrp/election.rs
+++ b/crates/yantrikdb-server/src/yrp/election.rs
@@ -1,0 +1,501 @@
+//! YRP election safety core (RFC 028 v2 §2) — pure logic, no I/O.
+//!
+//! ## The two invariants this module owns
+//!
+//! **Gate A #1 — vote safety (scenario R2).** A node must never vote for two
+//! candidates in one term, *including across crash/restart*. The classic bug:
+//! decide to grant, send the response, crash before persisting `voted_for`,
+//! restart with a blank vote, grant a different candidate in the same term →
+//! two majorities. The fix is ordering: persist `(term, voted_for)` BEFORE the
+//! response leaves the node. This module enforces the ordering **structurally**:
+//! any decision that changes [`HardState`] returns
+//! [`Effect::PersistHardState`] and *withholds* the outbound messages; they
+//! are only released by [`ElectionCore::hard_state_persisted`]. There is no
+//! API to obtain the withheld messages without asserting durability first.
+//! A crash before persist loses the (unsent) messages — safe. A crash after
+//! persist loses the response — a liveness hiccup, never a safety violation.
+//!
+//! **Gate A #3 — possibly-committed-suffix protection (scenario R3).**
+//! Election freshness uses Raft's last-`(term, index)` comparison
+//! ([`LogPosition::is_at_least_as_up_to_date_as`]), never a scalar watermark
+//! and never a locally-known committed frontier. A voter refuses any candidate
+//! whose log is less up to date than its own — which, combined with quorum
+//! intersection, guarantees every possibly-committed entry survives elections.
+//!
+//! ## What is deliberately NOT here
+//!
+//! Log replication/commit (Phase A1b), quarantine + incarnation fencing
+//! (Phase A2), membership changes (Phase B). The voter set is fixed at
+//! construction. Timers are the driver's job — the core only reacts to
+//! [`ElectionCore::on_election_timeout`]; randomization of timeouts is
+//! driver-side. Pre-vote (§2, liveness only) never mutates state.
+
+use std::collections::BTreeSet;
+
+use super::types::{quorum, HardState, LogPosition, NodeId, Term};
+
+/// Wire messages for the election layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Message {
+    /// Liveness probe before a real election (never changes voter state).
+    /// `term` is the term the candidate WOULD campaign at (current + 1).
+    PreVoteRequest {
+        term: Term,
+        candidate: NodeId,
+        last_log: LogPosition,
+    },
+    PreVoteResponse {
+        term: Term,
+        granted: bool,
+    },
+    VoteRequest {
+        term: Term,
+        candidate: NodeId,
+        last_log: LogPosition,
+    },
+    VoteResponse {
+        term: Term,
+        granted: bool,
+    },
+    /// Minimal leader beacon so the sim can prove single-leader-per-term and
+    /// step-down. The real data-plane append lands in Phase A1b.
+    Heartbeat {
+        term: Term,
+        leader: NodeId,
+    },
+}
+
+/// Instructions to the driver. Ordering contract: a
+/// [`Effect::PersistHardState`] in a batch means the driver MUST durably
+/// persist that state and then call
+/// [`ElectionCore::hard_state_persisted`] to obtain the withheld sends —
+/// the batch itself will contain no messages that depend on the new state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Effect {
+    /// Durably persist this hard state, then call `hard_state_persisted()`.
+    PersistHardState(HardState),
+    Send {
+        to: NodeId,
+        msg: Message,
+    },
+    /// Send to every voter except self (driver expands the fan-out).
+    Broadcast {
+        msg: Message,
+    },
+    BecameLeader {
+        term: Term,
+    },
+    /// Left leadership (or candidacy) for `term` — driver stops leader duties.
+    SteppedDown {
+        term: Term,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    Follower,
+    PreCandidate,
+    Candidate,
+    Leader,
+}
+
+/// Hard state waiting to be persisted, plus the messages whose transmission
+/// is gated on that durability (the R2 mechanism).
+#[derive(Debug, Clone)]
+struct PendingPersist {
+    hard: HardState,
+    held: Vec<Effect>,
+}
+
+/// The pure election state machine. See module docs for the contract.
+pub struct ElectionCore {
+    id: NodeId,
+    voters: BTreeSet<NodeId>,
+    /// Last DURABLY PERSISTED hard state — what survives a crash.
+    persisted: HardState,
+    /// In-flight persist + withheld messages. Lost on crash (by design:
+    /// the sim models crash-restart as `restore(persisted)`).
+    pending: Option<PendingPersist>,
+    role: Role,
+    /// Last position in the canonical prefix log (updated by the log layer;
+    /// static within a single election round).
+    last_log: LogPosition,
+    votes: BTreeSet<NodeId>,
+    pre_votes: BTreeSet<NodeId>,
+    /// When false, `on_election_timeout` campaigns directly (used by sim
+    /// tests that target the raw vote path). Production default: true.
+    use_pre_vote: bool,
+}
+
+impl ElectionCore {
+    /// `restored` is whatever hard state the boot path recovered. Phase A2's
+    /// quarantine decides whether construction is allowed at all — a torn
+    /// hard state must never reach this constructor (fail closed upstream).
+    pub fn new(
+        id: NodeId,
+        voters: BTreeSet<NodeId>,
+        restored: HardState,
+        last_log: LogPosition,
+        use_pre_vote: bool,
+    ) -> Self {
+        debug_assert!(voters.contains(&id), "a core's own id must be a voter");
+        Self {
+            id,
+            voters,
+            persisted: restored,
+            pending: None,
+            role: Role::Follower,
+            last_log,
+            votes: BTreeSet::new(),
+            pre_votes: BTreeSet::new(),
+            use_pre_vote,
+        }
+    }
+
+    // ── accessors ──────────────────────────────────────────────────
+
+    pub fn role(&self) -> Role {
+        self.role
+    }
+
+    /// The effective (in-memory) term: pending-if-any, else persisted.
+    pub fn current_term(&self) -> Term {
+        self.effective().current_term
+    }
+
+    pub fn persisted_hard_state(&self) -> HardState {
+        self.persisted
+    }
+
+    pub fn persist_pending(&self) -> bool {
+        self.pending.is_some()
+    }
+
+    /// Update the last log position (called by the log layer as entries
+    /// append). Static during a vote decision by construction: decisions are
+    /// synchronous within `on_message`.
+    pub fn set_last_log(&mut self, pos: LogPosition) {
+        self.last_log = pos;
+    }
+
+    fn effective(&self) -> HardState {
+        self.pending
+            .as_ref()
+            .map(|p| p.hard)
+            .unwrap_or(self.persisted)
+    }
+
+    // ── the R2 gate ────────────────────────────────────────────────
+
+    /// Stage a hard-state change. Messages that must not leave before the
+    /// state is durable go through [`Self::hold`]. Coalescing is safe: a
+    /// later, newer hard state subsumes an earlier one in the same pending
+    /// window — after the (single) persist, every held message's implied
+    /// state is ≤ the persisted state, and stale-term responses are ignored
+    /// by receivers per the term rules.
+    fn stage(&mut self, hard: HardState) -> Effect {
+        match &mut self.pending {
+            Some(p) => p.hard = hard,
+            None => {
+                self.pending = Some(PendingPersist {
+                    hard,
+                    held: Vec::new(),
+                })
+            }
+        }
+        Effect::PersistHardState(hard)
+    }
+
+    /// Withhold a message until the pending hard state is durable. Must only
+    /// be called while a persist is pending (enforced by debug assert).
+    fn hold(&mut self, eff: Effect) {
+        debug_assert!(self.pending.is_some(), "hold() requires a staged persist");
+        if let Some(p) = &mut self.pending {
+            p.held.push(eff);
+        }
+    }
+
+    /// The driver confirms the staged hard state is durable. Returns the
+    /// withheld effects — the ONLY way they can be obtained (the R2 gate).
+    pub fn hard_state_persisted(&mut self) -> Vec<Effect> {
+        match self.pending.take() {
+            Some(p) => {
+                self.persisted = p.hard;
+                p.held
+            }
+            None => Vec::new(),
+        }
+    }
+
+    // ── events ─────────────────────────────────────────────────────
+
+    /// Driver-decided election timeout (no leader contact for a randomized
+    /// interval). Followers/pre-candidates start a pre-vote round (or campaign
+    /// directly when pre-vote is disabled); candidates retry; leaders ignore.
+    pub fn on_election_timeout(&mut self) -> Vec<Effect> {
+        match self.role {
+            Role::Leader => Vec::new(),
+            _ if self.use_pre_vote => self.start_pre_vote(),
+            _ => self.start_campaign(),
+        }
+    }
+
+    fn start_pre_vote(&mut self) -> Vec<Effect> {
+        self.role = Role::PreCandidate;
+        self.pre_votes.clear();
+        self.pre_votes.insert(self.id); // we would vote for ourselves
+        let msg = Message::PreVoteRequest {
+            term: self.current_term().next(),
+            candidate: self.id,
+            last_log: self.last_log,
+        };
+        if self.pre_quorum_reached() {
+            // Single-voter cluster: pre-vote trivially passes.
+            return self.start_campaign();
+        }
+        vec![Effect::Broadcast { msg }]
+    }
+
+    /// Begin a real campaign: bump term, vote for self. Both the self-vote
+    /// and the outgoing VoteRequests are gated behind the persist — sending
+    /// a VoteRequest at term T implies "I have voted for myself in T"; if
+    /// that isn't durable, a crash could let this node vote differently in T
+    /// (self-inflicted R2).
+    fn start_campaign(&mut self) -> Vec<Effect> {
+        self.role = Role::Candidate;
+        self.votes.clear();
+        self.votes.insert(self.id);
+        let term = self.current_term().next();
+        let persist = self.stage(HardState {
+            current_term: term,
+            voted_for: Some(self.id),
+        });
+        let req = Message::VoteRequest {
+            term,
+            candidate: self.id,
+            last_log: self.last_log,
+        };
+        if self.vote_quorum_reached() {
+            // Single-voter cluster: leader immediately — but only after the
+            // self-vote is durable, so leadership is also held.
+            self.role = Role::Leader;
+            self.hold(Effect::BecameLeader { term });
+            return vec![persist];
+        }
+        self.hold(Effect::Broadcast { msg: req });
+        vec![persist]
+    }
+
+    /// Handle an incoming message. `leader_recently_seen` is driver-supplied
+    /// leader-stickiness (a voter that has recent leader contact refuses
+    /// pre-votes, damping disruption from flapping/partitioned nodes — the
+    /// .140 lesson). It plays no role in REAL vote decisions: only terms,
+    /// votes, and log freshness decide those.
+    pub fn on_message(
+        &mut self,
+        from: NodeId,
+        msg: Message,
+        leader_recently_seen: bool,
+    ) -> Vec<Effect> {
+        match msg {
+            Message::PreVoteRequest {
+                term,
+                candidate,
+                last_log,
+            } => self.on_pre_vote_request(from, term, candidate, last_log, leader_recently_seen),
+            Message::PreVoteResponse { term, granted } => {
+                self.on_pre_vote_response(from, term, granted)
+            }
+            Message::VoteRequest {
+                term,
+                candidate,
+                last_log,
+            } => self.on_vote_request(from, term, candidate, last_log),
+            Message::VoteResponse { term, granted } => self.on_vote_response(from, term, granted),
+            Message::Heartbeat { term, leader } => self.on_heartbeat(from, term, leader),
+        }
+    }
+
+    /// Pre-vote: pure read, never persists, never changes state (that is the
+    /// point — a partitioned node probing forever must not burn terms).
+    fn on_pre_vote_request(
+        &mut self,
+        from: NodeId,
+        term: Term,
+        _candidate: NodeId,
+        last_log: LogPosition,
+        leader_recently_seen: bool,
+    ) -> Vec<Effect> {
+        let grant = !leader_recently_seen
+            && term > self.current_term()
+            && last_log.is_at_least_as_up_to_date_as(&self.last_log);
+        vec![Effect::Send {
+            to: from,
+            msg: Message::PreVoteResponse {
+                term,
+                granted: grant,
+            },
+        }]
+    }
+
+    fn on_pre_vote_response(&mut self, from: NodeId, term: Term, granted: bool) -> Vec<Effect> {
+        if self.role != Role::PreCandidate || term != self.current_term().next() || !granted {
+            return Vec::new();
+        }
+        if self.voters.contains(&from) {
+            self.pre_votes.insert(from);
+        }
+        if self.pre_quorum_reached() {
+            return self.start_campaign();
+        }
+        Vec::new()
+    }
+
+    /// The real vote — where Gate A invariants 1 and 3 live.
+    fn on_vote_request(
+        &mut self,
+        from: NodeId,
+        term: Term,
+        candidate: NodeId,
+        last_log: LogPosition,
+    ) -> Vec<Effect> {
+        let mut effects = Vec::new();
+        let cur = self.current_term();
+
+        // Stale-term request: refuse immediately (no state change → no gate).
+        if term < cur {
+            return vec![Effect::Send {
+                to: from,
+                msg: Message::VoteResponse {
+                    term: cur,
+                    granted: false,
+                },
+            }];
+        }
+
+        // Newer term: step down from any candidacy/leadership. The term
+        // adoption itself is folded into the SINGLE persist below — emitting
+        // a separate PersistHardState for it would create an intermediate
+        // durable state and split one vote decision across two persist
+        // boundaries (a crash between them would adopt the term but lose the
+        // vote). One decision, one persist.
+        if term > cur {
+            if matches!(self.role, Role::Leader | Role::Candidate) {
+                effects.push(Effect::SteppedDown { term: cur });
+            }
+            self.role = Role::Follower;
+        }
+
+        // Vote decision under `term`. A newer term resets voted_for to None.
+        let voted_for_in_term = if term > cur {
+            None
+        } else {
+            self.effective().voted_for
+        };
+        let may_vote = voted_for_in_term.is_none() || voted_for_in_term == Some(candidate);
+        // Gate A #3 (R3): Raft freshness — never a watermark, never a
+        // committed frontier. Protects possibly-committed suffixes.
+        let fresh = last_log.is_at_least_as_up_to_date_as(&self.last_log);
+
+        let refusal = Effect::Send {
+            to: from,
+            msg: Message::VoteResponse {
+                term,
+                granted: false,
+            },
+        };
+
+        if may_vote && fresh {
+            // Gate A #1 (R2): the grant changes (term, voted_for) → ONE stage
+            // of the FINAL state, and HOLD the response. It cannot leave this
+            // node before the vote is durable.
+            effects.push(self.stage(HardState {
+                current_term: term,
+                voted_for: Some(candidate),
+            }));
+            self.hold(Effect::Send {
+                to: from,
+                msg: Message::VoteResponse {
+                    term,
+                    granted: true,
+                },
+            });
+        } else if term > cur {
+            // Refusing, but we still adopt the newer term — one persist of
+            // {term, None}, with the refusal held behind it so no peer sees
+            // our new term before it is durable.
+            effects.push(self.stage(HardState {
+                current_term: term,
+                voted_for: None,
+            }));
+            self.hold(refusal);
+        } else {
+            // Same term, already voted (or stale log): pure refusal, no persist.
+            effects.push(refusal);
+        }
+        effects
+    }
+
+    fn on_vote_response(&mut self, from: NodeId, term: Term, granted: bool) -> Vec<Effect> {
+        let cur = self.current_term();
+        if term > cur {
+            // Someone is ahead of us: adopt and step down.
+            let mut effects = Vec::new();
+            if matches!(self.role, Role::Leader | Role::Candidate) {
+                effects.push(Effect::SteppedDown { term: cur });
+            }
+            self.role = Role::Follower;
+            effects.push(self.stage(HardState {
+                current_term: term,
+                voted_for: None,
+            }));
+            return effects;
+        }
+        if self.role != Role::Candidate || term != cur || !granted {
+            return Vec::new();
+        }
+        if self.voters.contains(&from) {
+            self.votes.insert(from);
+        }
+        if self.vote_quorum_reached() {
+            self.role = Role::Leader;
+            return vec![
+                Effect::BecameLeader { term: cur },
+                Effect::Broadcast {
+                    msg: Message::Heartbeat {
+                        term: cur,
+                        leader: self.id,
+                    },
+                },
+            ];
+        }
+        Vec::new()
+    }
+
+    fn on_heartbeat(&mut self, _from: NodeId, term: Term, _leader: NodeId) -> Vec<Effect> {
+        let cur = self.current_term();
+        if term < cur {
+            return Vec::new(); // stale leader; data plane will reject too
+        }
+        let mut effects = Vec::new();
+        if matches!(self.role, Role::Leader | Role::Candidate) && term >= cur {
+            effects.push(Effect::SteppedDown { term: cur });
+        }
+        self.role = Role::Follower;
+        if term > cur {
+            effects.push(self.stage(HardState {
+                current_term: term,
+                voted_for: None,
+            }));
+        }
+        effects
+    }
+
+    fn pre_quorum_reached(&self) -> bool {
+        self.pre_votes.len() >= quorum(self.voters.len())
+    }
+
+    fn vote_quorum_reached(&self) -> bool {
+        self.votes.len() >= quorum(self.voters.len())
+    }
+}

--- a/crates/yantrikdb-server/src/yrp/mod.rs
+++ b/crates/yantrikdb-server/src/yrp/mod.rs
@@ -1,0 +1,34 @@
+//! YRP — YantrikDB Replication Protocol (RFC 028 v2).
+//!
+//! Purpose-built clustering for the cognitive memory substrate. Per the RFC's
+//! reframe: YRP rejects openraft's *operational posture* (wedge-on-confusion
+//! boot, library-owned snapshot format, integration weight), **not Raft's
+//! safety mathematics**. The safety core below is Raft-shaped, by the book,
+//! and deliberately boring; the purpose-built parts (memory-native oplog
+//! payloads, engine-checkpoint snapshots, quarantine-not-wedge recovery,
+//! quorum-managed incarnations) layer on top in later phases.
+//!
+//! Phase A1 (this module): the **election safety core** as *pure logic* — no
+//! I/O, no clocks, no tasks. A driver (production runtime or the deterministic
+//! simulator in tests) feeds events in and executes the returned effects. The
+//! pure shape is what makes Gate A provable: the simulator can crash a node at
+//! any effect boundary and assert the invariants hold.
+//!
+//! Gate A invariants covered here (RFC 028 v2 §11):
+//! 1. **Vote safety** — no node votes for two candidates in one term,
+//!    including across crash/restart (review scenario R2).
+//! 3. **Possibly-committed-suffix protection** — election freshness uses
+//!    Raft's last-`(term, index)` rule, never a scalar watermark (R3).
+//!
+//! The structural trick for R2: [`election::ElectionCore`] *cannot* produce a
+//! granted-vote response directly. Deciding to grant returns a
+//! [`election::Effect::PersistHardState`]; only when the driver confirms
+//! durability via [`election::ElectionCore::hard_state_persisted`] does the
+//! response message materialize. Persist-before-respond is enforced by the
+//! API's shape, not by driver discipline.
+
+pub mod election;
+pub mod types;
+
+#[cfg(test)]
+mod sim;

--- a/crates/yantrikdb-server/src/yrp/sim.rs
+++ b/crates/yantrikdb-server/src/yrp/sim.rs
@@ -1,0 +1,499 @@
+//! Deterministic election simulator — the Gate A proof harness (RFC 028 v2 §11).
+//!
+//! Chaos is a detector; this is closer to a proof. The simulator drives
+//! [`ElectionCore`] instances through seeded schedules with message
+//! drops/reorders, partitions, and — the important part — **crash injection at
+//! the persist boundary**, then checks the Gate A invariants over the entire
+//! observable history:
+//!
+//! - **I1 (vote safety, R2):** across the whole run, including every
+//!   crash/restart, no node's SENT grant messages name two different
+//!   candidates in one term.
+//! - **I3 (suffix protection, R3):** no voter ever grants a candidate whose
+//!   last log position is less up to date than the voter's own at grant time.
+//! - **Single leader per term:** at most one `BecameLeader` per term, ever.
+//!
+//! Crash modeling is exact: a crash discards the in-memory core (with any
+//! pending persist and its withheld messages) and restarts from the last
+//! hard state the sim's "disk" accepted. The three interesting boundaries:
+//! before persist (held messages never sent — safe), after persist / before
+//! flush (vote durable, response lost — liveness only), after flush (normal).
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use super::election::{Effect, ElectionCore, Message, Role};
+use super::types::{HardState, LogPosition, NodeId, Term};
+
+/// Tiny deterministic PRNG (xorshift64*) — no external deps, fully seeded.
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed.max(1))
+    }
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545F4914F6CDD1D)
+    }
+    fn chance(&mut self, pct: u64) -> bool {
+        self.next() % 100 < pct
+    }
+    fn pick(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+struct InFlight {
+    from: NodeId,
+    to: NodeId,
+    msg: Message,
+}
+
+/// One simulated node: the core (None while crashed) + its durable "disk".
+struct SimNode {
+    core: Option<ElectionCore>,
+    disk: HardState,
+    last_log: LogPosition,
+}
+
+struct Sim {
+    nodes: BTreeMap<NodeId, SimNode>,
+    voters: BTreeSet<NodeId>,
+    net: VecDeque<InFlight>,
+    rng: Rng,
+    /// Partition: pairs that cannot exchange messages.
+    cut: BTreeSet<(NodeId, NodeId)>,
+    // ── invariant ledgers (observable history) ────────────────────
+    /// (voter, term) → set of candidates the voter's SENT grants named.
+    grants_sent: BTreeMap<(NodeId, Term), BTreeSet<NodeId>>,
+    /// term → set of nodes that became leader in that term.
+    leaders: BTreeMap<Term, BTreeSet<NodeId>>,
+    /// I3 ledger: recorded at grant-send time: (voter_last_log, candidate_last_log).
+    freshness_at_grant: Vec<(LogPosition, LogPosition)>,
+    /// Candidate → last_log advertised (fixed per test; lets the checker
+    /// recover the candidate's position from a grant message).
+    advertised: BTreeMap<NodeId, LogPosition>,
+}
+
+impl Sim {
+    fn new(node_logs: &[(u64, LogPosition)], seed: u64, use_pre_vote: bool) -> Self {
+        let voters: BTreeSet<NodeId> = node_logs.iter().map(|(id, _)| NodeId(*id)).collect();
+        let mut nodes = BTreeMap::new();
+        for (id, log) in node_logs {
+            let nid = NodeId(*id);
+            let disk = HardState::default();
+            let core = ElectionCore::new(nid, voters.clone(), disk, *log, use_pre_vote);
+            nodes.insert(
+                nid,
+                SimNode {
+                    core: Some(core),
+                    disk,
+                    last_log: *log,
+                },
+            );
+        }
+        let advertised = node_logs
+            .iter()
+            .map(|(id, log)| (NodeId(*id), *log))
+            .collect();
+        Sim {
+            nodes,
+            voters,
+            net: VecDeque::new(),
+            rng: Rng::new(seed),
+            cut: BTreeSet::new(),
+            grants_sent: BTreeMap::new(),
+            leaders: BTreeMap::new(),
+            freshness_at_grant: Vec::new(),
+            advertised,
+        }
+    }
+
+    /// Run one node's effect batch: persist to "disk", flush the gate,
+    /// enqueue sends, record ledgers. `crash_at` injects a crash at a
+    /// boundary: 0 = before persist, 1 = after persist / before flush.
+    fn run_effects(&mut self, id: NodeId, effects: Vec<Effect>, crash_at: Option<u8>) {
+        let mut queue: VecDeque<Effect> = effects.into();
+        while let Some(eff) = queue.pop_front() {
+            match eff {
+                Effect::PersistHardState(hs) => {
+                    if crash_at == Some(0) {
+                        self.crash(id); // pending + held messages evaporate
+                        return;
+                    }
+                    self.nodes.get_mut(&id).unwrap().disk = hs; // durable now
+                    if crash_at == Some(1) {
+                        self.crash(id); // vote durable, response lost — safe
+                        return;
+                    }
+                    let flushed = self
+                        .nodes
+                        .get_mut(&id)
+                        .unwrap()
+                        .core
+                        .as_mut()
+                        .unwrap()
+                        .hard_state_persisted();
+                    for f in flushed {
+                        queue.push_back(f);
+                    }
+                }
+                Effect::Send { to, msg } => self.record_and_route(id, to, msg),
+                Effect::Broadcast { msg } => {
+                    let peers: Vec<NodeId> =
+                        self.voters.iter().copied().filter(|p| *p != id).collect();
+                    for to in peers {
+                        self.record_and_route(id, to, msg.clone());
+                    }
+                }
+                Effect::BecameLeader { term } => {
+                    self.leaders.entry(term).or_default().insert(id);
+                }
+                Effect::SteppedDown { .. } => {}
+            }
+        }
+    }
+
+    /// Ledger every SENT message (the observable history the invariants
+    /// quantify over), then put it on the wire.
+    fn record_and_route(&mut self, from: NodeId, to: NodeId, msg: Message) {
+        if let Message::VoteResponse {
+            term,
+            granted: true,
+        } = &msg
+        {
+            // The grant names the peer it is addressed to (the candidate).
+            self.grants_sent
+                .entry((from, *term))
+                .or_default()
+                .insert(to);
+            let voter_log = self.nodes[&from].last_log;
+            if let Some(cand_log) = self.advertised.get(&to) {
+                self.freshness_at_grant.push((voter_log, *cand_log));
+            }
+        }
+        self.net.push_back(InFlight { from, to, msg });
+    }
+
+    fn crash(&mut self, id: NodeId) {
+        self.nodes.get_mut(&id).unwrap().core = None;
+    }
+
+    fn restart(&mut self, id: NodeId, use_pre_vote: bool) {
+        let node = self.nodes.get_mut(&id).unwrap();
+        let core = ElectionCore::new(
+            id,
+            self.voters.clone(),
+            node.disk, // ONLY what was durably persisted survives
+            node.last_log,
+            use_pre_vote,
+        );
+        node.core = Some(core);
+    }
+
+    fn timeout(&mut self, id: NodeId, crash_at: Option<u8>) {
+        if let Some(core) = self.nodes.get_mut(&id).unwrap().core.as_mut() {
+            let effects = core.on_election_timeout();
+            self.run_effects(id, effects, crash_at);
+        }
+    }
+
+    /// Deliver one in-flight message (respecting partitions/crashes),
+    /// optionally injecting a crash while the receiver handles it.
+    fn deliver_one(&mut self, crash_at: Option<u8>) -> bool {
+        let Some(m) = self.net.pop_front() else {
+            return false;
+        };
+        let key = (m.from.min(m.to), m.from.max(m.to));
+        if self.cut.contains(&key) {
+            return true; // dropped by partition
+        }
+        let Some(node) = self.nodes.get_mut(&m.to) else {
+            return true;
+        };
+        let Some(core) = node.core.as_mut() else {
+            return true; // crashed receiver drops the message
+        };
+        let effects = core.on_message(m.from, m.msg, false);
+        self.run_effects(m.to, effects, crash_at);
+        true
+    }
+
+    fn drain(&mut self) {
+        while self.deliver_one(None) {}
+    }
+
+    // ── invariant checkers ────────────────────────────────────────
+
+    /// Gate A #1 / R2: per (voter, term), all sent grants name ONE candidate.
+    fn check_vote_safety(&self) {
+        for ((voter, term), cands) in &self.grants_sent {
+            assert!(
+                cands.len() <= 1,
+                "VOTE SAFETY VIOLATED: voter {voter:?} granted {cands:?} in {term:?}"
+            );
+        }
+    }
+
+    /// Gate A #3 / R3: every grant went to a candidate at least as up to date.
+    fn check_suffix_protection(&self) {
+        for (voter_log, cand_log) in &self.freshness_at_grant {
+            assert!(
+                cand_log.is_at_least_as_up_to_date_as(voter_log),
+                "SUFFIX PROTECTION VIOLATED: granted candidate at {cand_log:?} \
+                 while voter was at {voter_log:?}"
+            );
+        }
+    }
+
+    /// At most one leader per term, across the whole run.
+    fn check_single_leader_per_term(&self) {
+        for (term, ls) in &self.leaders {
+            assert!(ls.len() <= 1, "TWO LEADERS IN {term:?}: {ls:?}");
+        }
+    }
+
+    fn check_all(&self) {
+        self.check_vote_safety();
+        self.check_suffix_protection();
+        self.check_single_leader_per_term();
+    }
+}
+
+// ── tests ──────────────────────────────────────────────────────────
+
+const L0: LogPosition = LogPosition { term: 0, index: 0 };
+
+/// Baseline: a healthy 3-node cluster elects exactly one leader.
+#[test]
+fn three_nodes_elect_exactly_one_leader() {
+    let mut sim = Sim::new(&[(1, L0), (2, L0), (3, L0)], 42, true);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    sim.check_all();
+    assert_eq!(
+        sim.leaders.values().map(|s| s.len()).sum::<usize>(),
+        1,
+        "exactly one leadership event expected, got {:?}",
+        sim.leaders
+    );
+}
+
+/// R2, crash BEFORE persist: the vote decision (and its held response) must
+/// evaporate — after restart the node may vote differently, but the original
+/// grant never left the node, so no double grant is observable.
+#[test]
+fn r2_crash_before_persist_never_leaks_the_grant() {
+    let mut sim = Sim::new(&[(1, L0), (2, L0), (3, L0)], 7, false);
+    // Candidate 1 campaigns; node 3 receives the request and crashes at the
+    // persist boundary (before durability).
+    sim.timeout(NodeId(1), None);
+    // route: find the VoteRequest to node 3 and deliver it with crash_at=0.
+    // Deliver messages one at a time; inject the crash on node 3's handling.
+    let mut delivered_to_3 = false;
+    while !sim.net.is_empty() {
+        let peek_to = sim.net.front().unwrap().to;
+        let inject = if peek_to == NodeId(3) && !delivered_to_3 {
+            delivered_to_3 = true;
+            Some(0u8)
+        } else {
+            None
+        };
+        sim.deliver_one(inject);
+    }
+    // Node 3 restarts from disk — which never recorded the vote.
+    sim.restart(NodeId(3), false);
+    assert_eq!(sim.nodes[&NodeId(3)].disk, HardState::default());
+    // A competing candidate 2 campaigns in the SAME term (term 1) and node 3
+    // may now grant it — legal, because the first grant never left the node.
+    sim.timeout(NodeId(2), None);
+    sim.drain();
+    sim.check_all(); // vote-safety ledger proves no double grant was SENT
+}
+
+/// R2, crash AFTER persist but before the response flushes: the vote is
+/// durable, the response is lost. After restart the node must REFUSE a
+/// different candidate in the same term — the persisted vote binds it.
+#[test]
+fn r2_crash_after_persist_binds_the_restarted_node() {
+    let mut sim = Sim::new(&[(1, L0), (2, L0), (3, L0)], 9, false);
+    sim.timeout(NodeId(1), None); // candidate 1, term 1
+    let mut injected = false;
+    while !sim.net.is_empty() {
+        let peek_to = sim.net.front().unwrap().to;
+        let inject = if peek_to == NodeId(3) && !injected {
+            injected = true;
+            Some(1u8) // crash after persist, before flush
+        } else {
+            None
+        };
+        sim.deliver_one(inject);
+    }
+    // The vote for candidate 1 IS on node 3's disk; the response was lost.
+    assert_eq!(
+        sim.nodes[&NodeId(3)].disk,
+        HardState {
+            current_term: Term(1),
+            voted_for: Some(NodeId(1)),
+        }
+    );
+    sim.restart(NodeId(3), false);
+    // Competing candidate 2 campaigns in the same term 1... its own campaign
+    // takes it to term 2 actually — so drive the SAME-term request manually:
+    // deliver a raw VoteRequest for term 1 from node 2 to node 3.
+    let effects = sim
+        .nodes
+        .get_mut(&NodeId(3))
+        .unwrap()
+        .core
+        .as_mut()
+        .unwrap()
+        .on_message(
+            NodeId(2),
+            Message::VoteRequest {
+                term: Term(1),
+                candidate: NodeId(2),
+                last_log: L0,
+            },
+            false,
+        );
+    sim.run_effects(NodeId(3), effects, None);
+    sim.drain();
+    // Ledger: node 3's term-1 grants must name at most candidate 1.
+    let grants = sim
+        .grants_sent
+        .get(&(NodeId(3), Term(1)))
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !grants.contains(&NodeId(2)),
+        "restarted node granted a second candidate in the same term: {grants:?}"
+    );
+    sim.check_all();
+}
+
+/// R3: a candidate with a stale log (lower last term, even with a longer
+/// index) must be refused by voters holding fresher entries — the
+/// possibly-committed suffix survives the election.
+#[test]
+fn r3_stale_log_candidate_is_refused_by_fresher_voters() {
+    // Node 2 and 3 hold an entry at (term 2, idx 5) — possibly committed.
+    // Node 1's log ends at (term 1, idx 9): longer, but staler.
+    let fresh = LogPosition { term: 2, index: 5 };
+    let stale = LogPosition { term: 1, index: 9 };
+    let mut sim = Sim::new(&[(1, stale), (2, fresh), (3, fresh)], 21, false);
+    sim.timeout(NodeId(1), None); // stale candidate campaigns
+    sim.drain();
+    sim.check_all();
+    // The stale candidate must NOT have become leader: 2 and 3 refuse it,
+    // and its self-vote alone is not a quorum.
+    assert!(
+        sim.leaders.values().all(|s| !s.contains(&NodeId(1))),
+        "stale-log candidate won an election: {:?}",
+        sim.leaders
+    );
+    // And a fresh candidate CAN win afterwards.
+    sim.timeout(NodeId(2), None);
+    sim.drain();
+    sim.check_all();
+    assert!(
+        sim.leaders.values().any(|s| s.contains(&NodeId(2))),
+        "fresh candidate failed to win: {:?}",
+        sim.leaders
+    );
+}
+
+/// Partition + heal: a minority-side candidate must not win; after heal the
+/// cluster converges on one leader per term (no dual leadership ever).
+#[test]
+fn partition_minority_cannot_elect_and_heal_converges() {
+    let mut sim = Sim::new(&[(1, L0), (2, L0), (3, L0)], 63, false);
+    // Partition node 1 away from 2 and 3.
+    sim.cut.insert((NodeId(1), NodeId(2)));
+    sim.cut.insert((NodeId(1), NodeId(3)));
+    sim.timeout(NodeId(1), None); // minority campaign — must fail
+    sim.timeout(NodeId(2), None); // majority campaign — must succeed
+    sim.drain();
+    sim.check_all();
+    assert!(
+        sim.leaders.values().all(|s| !s.contains(&NodeId(1))),
+        "partitioned minority elected itself: {:?}",
+        sim.leaders
+    );
+    // Heal and drain remaining traffic: invariants must still hold.
+    sim.cut.clear();
+    sim.drain();
+    sim.check_all();
+}
+
+/// Randomized soak: seeded schedules with random timeouts, crashes at random
+/// boundaries, restarts, and message shuffling. The invariants must hold for
+/// every seed. (Gate A's "deterministic simulation" in miniature — the full
+/// schedule explorer grows with the log layer in Phase A1b.)
+#[test]
+fn seeded_soak_invariants_hold() {
+    for seed in 1..40u64 {
+        let mut sim = Sim::new(&[(1, L0), (2, L0), (3, L0)], seed, seed % 2 == 0);
+        for _step in 0..200 {
+            let ids = [NodeId(1), NodeId(2), NodeId(3)];
+            match sim.rng.next() % 10 {
+                0 => {
+                    let id = ids[sim.rng.pick(3)];
+                    let alive = sim.nodes[&id].core.is_some();
+                    if alive {
+                        let inject = if sim.rng.chance(20) {
+                            Some((sim.rng.next() % 2) as u8)
+                        } else {
+                            None
+                        };
+                        sim.timeout(id, inject);
+                    }
+                }
+                1 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_some() && sim.rng.chance(15) {
+                        sim.crash(id);
+                    }
+                }
+                2 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_none() {
+                        let pv = sim.rng.chance(50);
+                        sim.restart(id, pv);
+                    }
+                }
+                _ => {
+                    let inject = if sim.rng.chance(10) {
+                        Some((sim.rng.next() % 2) as u8)
+                    } else {
+                        None
+                    };
+                    sim.deliver_one(inject);
+                }
+            }
+        }
+        sim.drain();
+        sim.check_all(); // must hold for EVERY seed
+    }
+}
+
+/// Liveness note (not a Gate A safety invariant, but worth pinning): pre-vote
+/// probing by an isolated node must not advance its persisted term — the .140
+/// flapping lesson.
+#[test]
+fn pre_vote_probe_never_burns_terms() {
+    let mut sim = Sim::new(&[(1, L0), (2, L0), (3, L0)], 5, true);
+    // Isolate node 1 fully, then let it probe repeatedly.
+    sim.cut.insert((NodeId(1), NodeId(2)));
+    sim.cut.insert((NodeId(1), NodeId(3)));
+    for _ in 0..25 {
+        sim.timeout(NodeId(1), None);
+        sim.drain();
+    }
+    // Its durable term must be untouched: pre-vote is stateless.
+    assert_eq!(sim.nodes[&NodeId(1)].disk.current_term, Term(0));
+    sim.check_all();
+}

--- a/crates/yantrikdb-server/src/yrp/types.rs
+++ b/crates/yantrikdb-server/src/yrp/types.rs
@@ -1,0 +1,129 @@
+//! YRP core identifier and state types (RFC 028 v2 §2–§3).
+//!
+//! Everything here is plain data: `Copy` where possible, `serde`-able for the
+//! wire, and free of I/O. The safety-critical distinction is between
+//! [`HardState`] (MUST be durably persisted before certain messages may be
+//! sent — see `election::ElectionCore`) and everything else (soft state,
+//! reconstructible).
+
+use serde::{Deserialize, Serialize};
+
+/// A node's stable identifier within one cluster.
+///
+/// Identity alone is NOT sufficient to vote — RFC 028 v2 §3 requires the
+/// node's [`Incarnation`] to be authorized by a quorum (Proxmox clones and VM
+/// rollbacks resurrect old disk state, so the *cluster*, not the disk, is the
+/// authority on which copy of a node is real). Incarnation enforcement lands
+/// in Phase A2; the type exists now so wire shapes are stable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct NodeId(pub u64);
+
+/// Election term. Monotonically increasing; one leader at most per term.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Term(pub u64);
+
+impl Term {
+    pub const ZERO: Term = Term(0);
+    #[must_use]
+    pub fn next(self) -> Term {
+        Term(self.0 + 1)
+    }
+}
+
+/// Index into the canonical prefix log (RFC 028 v2 §2.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LogIndex(pub u64);
+
+/// A position in the canonical prefix log: the entry's term and index.
+///
+/// Election freshness compares positions with **Raft's rule** (higher term
+/// wins; equal terms → higher index wins) via the derived lexicographic
+/// `Ord` — field order `(term, index)` is therefore load-bearing. This is
+/// what protects possibly-committed suffixes (RFC 028 v2 §2.2, scenario R3):
+/// a scalar watermark cannot distinguish divergent histories, and a
+/// committed-frontier comparison discards quorum-accepted-but-not-yet-marked
+/// entries. Do NOT reorder these fields.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Default,
+)]
+pub struct LogPosition {
+    pub term: u64,
+    pub index: u64,
+}
+
+impl LogPosition {
+    pub const ZERO: LogPosition = LogPosition { term: 0, index: 0 };
+
+    /// Raft's up-to-date-ness comparison, named for auditability at call
+    /// sites. `self.is_at_least_as_up_to_date_as(other)` ⇔ a voter with last
+    /// position `other` may grant a candidate whose last position is `self`.
+    #[must_use]
+    pub fn is_at_least_as_up_to_date_as(&self, other: &LogPosition) -> bool {
+        self >= other
+    }
+}
+
+/// The durable consensus metadata. **The safety of the whole protocol rests
+/// on this struct being fsynced at the right moments** (RFC 028 v2 §2.3):
+/// a voter persists `(current_term, voted_for)` BEFORE its granted-vote
+/// response leaves the node. `ElectionCore` enforces that ordering
+/// structurally.
+///
+/// Fail-closed rule (Phase A2, §5): if this state is torn, missing, or from
+/// a different cluster/incarnation at boot, the node starts QUARANTINED
+/// (non-voting) — it never guesses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardState {
+    pub current_term: Term,
+    pub voted_for: Option<NodeId>,
+}
+
+impl Default for HardState {
+    fn default() -> Self {
+        Self {
+            current_term: Term::ZERO,
+            voted_for: None,
+        }
+    }
+}
+
+/// Quorum arithmetic for a voter set of size `n`: floor(n/2) + 1.
+///
+/// Witnesses count toward *election* quorum only — never toward data
+/// durability (RFC 028 v2 §4). That distinction lives at the call sites that
+/// assemble the voter set; the arithmetic here is deliberately dumb.
+#[must_use]
+pub fn quorum(n_voters: usize) -> usize {
+    n_voters / 2 + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// R3's foundation: the freshness comparison is Raft's, exactly.
+    #[test]
+    fn log_position_ordering_is_raft_up_to_date_rule() {
+        let old_term_long = LogPosition { term: 1, index: 7 };
+        let new_term_short = LogPosition { term: 2, index: 5 };
+        // Higher term wins regardless of index.
+        assert!(new_term_short.is_at_least_as_up_to_date_as(&old_term_long));
+        assert!(!old_term_long.is_at_least_as_up_to_date_as(&new_term_short));
+        // Equal terms: higher index wins.
+        let a = LogPosition { term: 2, index: 9 };
+        let b = LogPosition { term: 2, index: 5 };
+        assert!(a.is_at_least_as_up_to_date_as(&b));
+        assert!(!b.is_at_least_as_up_to_date_as(&a));
+        // Equality is at-least-as-up-to-date both ways.
+        assert!(b.is_at_least_as_up_to_date_as(&LogPosition { term: 2, index: 5 }));
+    }
+
+    #[test]
+    fn quorum_arithmetic() {
+        assert_eq!(quorum(1), 1);
+        assert_eq!(quorum(2), 2); // 2-voter cluster: both required — zero fault tolerance
+        assert_eq!(quorum(3), 2);
+        assert_eq!(quorum(4), 3);
+        assert_eq!(quorum(5), 3);
+    }
+}


### PR DESCRIPTION
## Summary

First code of the native replication protocol (RFC 028 v2, saga epic 61 task 233): the **election safety core as pure logic** plus the **Gate A proof harness**. Not wired into the runtime — zero behavior change. Nothing replicates until Gate A is fully green; this is the simulation-proven foundation.

## The two structural guarantees

- **R2 / Gate A #1 (vote safety across crash-restart):** enforced by API shape, not driver discipline. Any decision that changes `HardState` returns `Effect::PersistHardState` and **withholds** dependent messages; only `hard_state_persisted()` releases them. There is no way to send a granted vote before it's durable. One decision = one persist — term adoption folds into the vote's single staged state (a split persist would let a crash adopt the term but lose the vote).
- **R3 / Gate A #3 (possibly-committed-suffix protection):** election freshness is Raft's last-`(term, index)` rule via `LogPosition`'s lexicographic `Ord`. The v1 watermark rule is dead per the sol red-team.

Pre-vote is liveness-only and never mutates state (the .140 term-burning lesson).

## The simulator already caught a real bug

Deterministic seeded sim with message drop/reorder, partitions, **crash injection at both persist boundaries**, restart-from-disk-only, and invariant checkers quantifying over the entire observable history (vote safety, suffix protection, single-leader-per-term). During development it caught the split-persist bug above — before any live node existed. Working as designed.

## Tests (9/9 green)

`r2_crash_before_persist_never_leaks_the_grant` · `r2_crash_after_persist_binds_the_restarted_node` · `r3_stale_log_candidate_is_refused_by_fresher_voters` · `three_nodes_elect_exactly_one_leader` · `partition_minority_cannot_elect_and_heal_converges` · `pre_vote_probe_never_burns_terms` · `seeded_soak_invariants_hold` (39 seeds × 200 steps) · plus `LogPosition` ordering + quorum arithmetic pins.

## Next (per RFC phases)

A1b: log replication + commit (per-write quorum confirmation + fencing) · A2: quarantine + quorum-authorized rejoin · incarnation fencing.