### PR TITLE
feat(yrp): Phase A2 — quarantine + quorum-authorized rejoin (Gate A complete)

### DIFF
--- a/crates/yantrikdb-server/src/yrp/bootstrap.rs
+++ b/crates/yantrikdb-server/src/yrp/bootstrap.rs
@@ -1,0 +1,504 @@
+//! YRP recovery plane — quarantine + quorum-authorized rejoin (RFC 028 v2 §5).
+//!
+//! **The CT 141 lesson, precisely scoped.** The outage was a *process* that
+//! crash-looped for 10 days: diagnostics dead, HTTP dead, operator blind. The
+//! naive cure — auto-reconstruct replication state and resume — enables
+//! double-voting (review scenario R2: reset `voted_for`, vote again in the
+//! same term). The correct split, which this module implements:
+//!
+//! - **The process always starts.** Boot inspection ([`inspect`]) never
+//!   panics and never refuses to produce a node; the worst outcome is a
+//!   [`QuarantinedNode`] that serves diagnostics (and, when data
+//!   independently verifies, explicitly-labeled stale reads).
+//! - **Consensus metadata fails closed.** Any safety-critical uncertainty —
+//!   torn `(term, vote)`, alien cluster ID, log damage, a commit frontier
+//!   beyond verifiable data — yields quarantine: non-voting, non-leading,
+//!   non-acking. Refusing to vote is not a wedge; it is the mechanism that
+//!   prevents split-brain.
+//! - **Rejoin is quorum-authorized, never self-directed.** A quarantined
+//!   node asks the current leader; the leader's authority (its leadership
+//!   is quorum-backed, proven by a committed entry in its term) authorizes
+//!   the resync. The node never picks "the most advanced reachable peer"
+//!   itself — a stale partition can be internally consistent and obsolete
+//!   (review R5).
+//! - **Recoverable incompleteness ≠ corruption evidence.** Incompleteness
+//!   auto-resyncs; corruption evidence additionally raises
+//!   [`BootstrapEffect::Alarm`] and is only replaceable from a source whose
+//!   snapshot verifies. Either way the old state is preserved first
+//!   ([`BootstrapEffect::PreserveOldState`] — the automated version of the
+//!   CT 141 manual backup).
+//!
+//! Like the replica core, everything here is pure logic driven by effects;
+//! the deterministic simulator injects torn state, alien state, and
+//! corruption, then proves the Gate A #4 invariant: quarantine fails closed.
+//!
+//! Phase B extends rejoin with quorum-managed incarnations (Proxmox
+//! clone/rollback fencing) and true membership change; in A2's fixed-voter
+//! world, a rejoining node re-enters as the same voter after resync.
+
+use super::replica::LogEntry;
+use super::types::{ClusterId, HardState, NodeId, Term};
+
+/// What the boot path recovered from disk. The driver fills this in from
+/// real storage (with real checksums); the sim injects damage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveredState {
+    /// The cluster this on-disk state claims to belong to; `None` = blank.
+    pub cluster_id: Option<ClusterId>,
+    /// `None` = unreadable/absent. `Some` = parsed (integrity says whether
+    /// its checksum verified).
+    pub hard: Option<HardState>,
+    pub log: Option<Vec<LogEntry>>,
+    /// The durably recorded applied/commit marker, if any. A marker beyond
+    /// the verifiable log is a frontier-beyond-data inconsistency.
+    pub commit_marker: u64,
+    pub integrity: Integrity,
+}
+
+/// Driver-computed integrity verdicts (production: checksummed dual-write
+/// records + log hash chain; sim: injected).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Integrity {
+    /// The hard-state record parsed AND its checksum verified.
+    pub hard_state_verified: bool,
+    /// The log's hash chain verified end to end.
+    pub log_verified: bool,
+}
+
+impl RecoveredState {
+    /// A genuinely blank disk — the fresh-node case.
+    pub fn blank() -> Self {
+        Self {
+            cluster_id: None,
+            hard: None,
+            log: None,
+            commit_marker: 0,
+            integrity: Integrity {
+                hard_state_verified: true,
+                log_verified: true,
+            },
+        }
+    }
+}
+
+/// Why a node is quarantined. Kept as data (not just a log line) because the
+/// diagnostics surface reports them and the rejoin path branches on them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuarantineReason {
+    /// Hard state present but failed verification (torn write, bit rot).
+    TornHardState,
+    /// Hard state absent while other replication state exists.
+    MissingHardState,
+    /// On-disk state belongs to a different cluster.
+    ClusterIdMismatch,
+    /// Log hash chain broken — DATA corruption evidence (alarms).
+    LogCorruption,
+    /// Commit marker beyond the verifiable log (frontier-beyond-data).
+    CommitBeyondLog,
+}
+
+impl QuarantineReason {
+    /// Corruption evidence (vs recoverable incompleteness): preserved state
+    /// must be alarmed about, and replacement requires a verified source.
+    pub fn is_corruption_evidence(&self) -> bool {
+        matches!(
+            self,
+            QuarantineReason::TornHardState | QuarantineReason::LogCorruption
+        )
+    }
+}
+
+/// The boot decision. Never an error — the process always starts as
+/// *something*.
+#[derive(Debug)]
+pub enum BootDecision {
+    /// State is coherent (or genuinely blank): construct the replica core
+    /// with exactly this state.
+    Healthy { hard: HardState, log: Vec<LogEntry> },
+    /// Fail closed: run as a [`QuarantinedNode`] until an authorized rejoin.
+    Quarantine { reasons: Vec<QuarantineReason> },
+}
+
+/// Inspect recovered state against the node's configured cluster identity.
+/// Pure; total; never panics. The full RFC §5 trigger list beyond what
+/// exists at A2 (incarnation/epoch regression, snapshot manifests,
+/// capability support) lands with the Phase B machinery that introduces
+/// those artifacts.
+pub fn inspect(expected_cluster: ClusterId, recovered: &RecoveredState) -> BootDecision {
+    // Fresh node: nothing on disk at all → healthy with defaults. (A blank
+    // disk is not "torn" — there is nothing to be torn.)
+    if recovered.cluster_id.is_none()
+        && recovered.hard.is_none()
+        && recovered.log.is_none()
+        && recovered.commit_marker == 0
+    {
+        return BootDecision::Healthy {
+            hard: HardState::default(),
+            log: Vec::new(),
+        };
+    }
+
+    let mut reasons = Vec::new();
+
+    match recovered.cluster_id {
+        Some(id) if id != expected_cluster => reasons.push(QuarantineReason::ClusterIdMismatch),
+        None => {
+            // Replication state without a cluster identity is alien by
+            // definition — we cannot prove it is ours.
+            reasons.push(QuarantineReason::ClusterIdMismatch);
+        }
+        Some(_) => {}
+    }
+
+    match (&recovered.hard, recovered.integrity.hard_state_verified) {
+        (Some(_), true) => {}
+        (Some(_), false) => reasons.push(QuarantineReason::TornHardState),
+        (None, _) => reasons.push(QuarantineReason::MissingHardState),
+    }
+
+    if !recovered.integrity.log_verified {
+        reasons.push(QuarantineReason::LogCorruption);
+    }
+
+    let log_len = recovered.log.as_ref().map_or(0, |l| l.len() as u64);
+    if recovered.commit_marker > log_len {
+        reasons.push(QuarantineReason::CommitBeyondLog);
+    }
+
+    if reasons.is_empty() {
+        BootDecision::Healthy {
+            hard: recovered.hard.expect("verified above"),
+            log: recovered.log.clone().unwrap_or_default(),
+        }
+    } else {
+        BootDecision::Quarantine { reasons }
+    }
+}
+
+/// Rejoin protocol messages. Carried on the same transport as replica
+/// messages; the sim wraps both.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RejoinMessage {
+    /// Quarantined node → (believed) leader.
+    Request { node: NodeId },
+    /// Leader → quarantined node. Authorization is quorum-backed: only a
+    /// leader that has COMMITTED an entry in its current term may grant
+    /// (its leadership certificate — a lone "I think I'm leader" claim from
+    /// a stale partition cannot produce one, review R5). The grant carries
+    /// the full authorized snapshot; `verified` asserts the source snapshot
+    /// passed its own integrity checks (required when the quarantined
+    /// node's reasons include corruption evidence).
+    Grant {
+        cluster_id: ClusterId,
+        term: Term,
+        log: Vec<LogEntry>,
+        commit: u64,
+        verified: bool,
+    },
+}
+
+/// Effects a [`QuarantinedNode`] asks of its driver.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BootstrapEffect {
+    /// Move the damaged/alien state aside, timestamped — forensics
+    /// preserved BEFORE any resync (the automated CT 141 backup).
+    PreserveOldState,
+    /// Corruption evidence found — page the operator. Auto-resync may still
+    /// proceed (from a verified source), but the signal must not be
+    /// swallowed (review: "auto-resync must not silence a corruption
+    /// signal").
+    Alarm { reasons: Vec<QuarantineReason> },
+    /// Send a rejoin message.
+    Send { to: NodeId, msg: RejoinMessage },
+    /// Durably persist the adopted snapshot, then construct a fresh
+    /// follower `ReplicaCore` from exactly this state and resume normal
+    /// operation. Quarantine ends here and only here.
+    AdoptSnapshot {
+        cluster_id: ClusterId,
+        hard: HardState,
+        log: Vec<LogEntry>,
+    },
+}
+
+/// A booted-but-not-voting node. It answers diagnostics, optionally serves
+/// labeled stale reads, and periodically retries rejoin. It has NO vote
+/// handler and NO append handler — fail-closed is enforced by absence: the
+/// type simply cannot produce a vote grant or a durable ack.
+pub struct QuarantinedNode {
+    id: NodeId,
+    cluster: ClusterId,
+    reasons: Vec<QuarantineReason>,
+    /// Whether the preserved-state effect has been issued (once).
+    preserved: bool,
+    alarmed: bool,
+}
+
+impl QuarantinedNode {
+    pub fn new(id: NodeId, cluster: ClusterId, reasons: Vec<QuarantineReason>) -> Self {
+        debug_assert!(!reasons.is_empty(), "quarantine requires a reason");
+        Self {
+            id,
+            cluster,
+            reasons,
+            preserved: false,
+            alarmed: false,
+        }
+    }
+
+    /// The diagnostics surface ("process up" is a different health dimension
+    /// from "data servable").
+    pub fn reasons(&self) -> &[QuarantineReason] {
+        &self.reasons
+    }
+
+    /// Stale reads are only offered when the DATA verified. This is the
+    /// data axis, distinct from [`QuarantineReason::is_corruption_evidence`]
+    /// (the storage-failure axis that drives alarms and the verified-source
+    /// requirement): a torn HARD-STATE record is storage-failure evidence,
+    /// but the log/payload bytes verified fine — serving them, labeled
+    /// stale, is exactly the CT 141 availability the RFC promises. Only
+    /// damage to the data itself ([`QuarantineReason::LogCorruption`])
+    /// withdraws reads.
+    pub fn stale_reads_allowed(&self) -> bool {
+        !self
+            .reasons
+            .iter()
+            .any(|r| matches!(r, QuarantineReason::LogCorruption))
+    }
+
+    /// Driver tick (retry timer): preserve-once, alarm-once, then ask the
+    /// given peer (the driver's current leader hint) for rejoin.
+    pub fn tick_rejoin(&mut self, leader_hint: NodeId) -> Vec<BootstrapEffect> {
+        let mut out = Vec::new();
+        if !self.preserved {
+            self.preserved = true;
+            out.push(BootstrapEffect::PreserveOldState);
+        }
+        if !self.alarmed && self.reasons.iter().any(|r| r.is_corruption_evidence()) {
+            self.alarmed = true;
+            out.push(BootstrapEffect::Alarm {
+                reasons: self.reasons.clone(),
+            });
+        }
+        out.push(BootstrapEffect::Send {
+            to: leader_hint,
+            msg: RejoinMessage::Request { node: self.id },
+        });
+        out
+    }
+
+    /// Handle a rejoin grant from `from`. Returns the adopt effect when
+    /// acceptable; a grant that fails authorization rules is ignored (keep
+    /// quarantined, retry later — fail closed).
+    pub fn on_grant(&mut self, from: NodeId, grant: RejoinMessage) -> Vec<BootstrapEffect> {
+        let RejoinMessage::Grant {
+            cluster_id,
+            term,
+            log,
+            commit: _,
+            verified,
+        } = grant
+        else {
+            return Vec::new();
+        };
+        // Wrong cluster: never adopt.
+        if cluster_id != self.cluster {
+            return Vec::new();
+        }
+        // Corruption evidence requires a verified source snapshot.
+        if self.reasons.iter().any(|r| r.is_corruption_evidence()) && !verified {
+            return Vec::new();
+        }
+        // Adopt as a follower with `voted_for = Some(granting leader)` —
+        // NOT `None`. The node's pre-quarantine vote in `term` is unknown
+        // (its record was torn) and may have helped elect someone; a blank
+        // vote would let it vote AGAIN in `term` — reopening exactly the R2
+        // double-vote window that quarantine exists to close. Recording the
+        // granting leader as our vote makes the node incapable of emitting
+        // any NEW grant in `term`: the leader never re-campaigns in its own
+        // term, and every other candidate is refused by the voted_for
+        // check. (A stale-but-certificated leader granting an old-term
+        // snapshot is likewise safe: the adopted term is behind, so first
+        // contact with the live cluster raises it via normal term rules;
+        // Phase B's quorum-managed incarnations subsume this construction.)
+        vec![BootstrapEffect::AdoptSnapshot {
+            cluster_id,
+            hard: HardState {
+                current_term: term,
+                voted_for: Some(from),
+            },
+            log,
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CLUSTER: ClusterId = ClusterId(7);
+
+    fn coherent() -> RecoveredState {
+        RecoveredState {
+            cluster_id: Some(CLUSTER),
+            hard: Some(HardState {
+                current_term: Term(3),
+                voted_for: Some(NodeId(2)),
+            }),
+            log: Some(vec![LogEntry {
+                term: Term(3),
+                payload: 42,
+            }]),
+            commit_marker: 1,
+            integrity: Integrity {
+                hard_state_verified: true,
+                log_verified: true,
+            },
+        }
+    }
+
+    #[test]
+    fn blank_disk_boots_healthy_fresh() {
+        match inspect(CLUSTER, &RecoveredState::blank()) {
+            BootDecision::Healthy { hard, log } => {
+                assert_eq!(hard, HardState::default());
+                assert!(log.is_empty());
+            }
+            BootDecision::Quarantine { reasons } => {
+                panic!("fresh node quarantined: {reasons:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn coherent_state_boots_healthy_with_exact_state() {
+        match inspect(CLUSTER, &coherent()) {
+            BootDecision::Healthy { hard, log } => {
+                assert_eq!(hard.voted_for, Some(NodeId(2)));
+                assert_eq!(log.len(), 1);
+            }
+            BootDecision::Quarantine { reasons } => panic!("quarantined: {reasons:?}"),
+        }
+    }
+
+    #[test]
+    fn torn_hard_state_quarantines() {
+        let mut s = coherent();
+        s.integrity.hard_state_verified = false;
+        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+            panic!("torn state booted healthy");
+        };
+        assert!(reasons.contains(&QuarantineReason::TornHardState));
+    }
+
+    #[test]
+    fn alien_cluster_quarantines() {
+        let mut s = coherent();
+        s.cluster_id = Some(ClusterId(99));
+        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+            panic!("alien state booted healthy");
+        };
+        assert!(reasons.contains(&QuarantineReason::ClusterIdMismatch));
+    }
+
+    #[test]
+    fn commit_marker_beyond_log_quarantines() {
+        let mut s = coherent();
+        s.commit_marker = 5; // log has 1 entry
+        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+            panic!("frontier-beyond-data booted healthy");
+        };
+        assert!(reasons.contains(&QuarantineReason::CommitBeyondLog));
+    }
+
+    #[test]
+    fn log_corruption_is_corruption_evidence_and_blocks_stale_reads() {
+        let mut s = coherent();
+        s.integrity.log_verified = false;
+        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+            panic!("corrupt log booted healthy");
+        };
+        let node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons);
+        assert!(!node.stale_reads_allowed());
+    }
+
+    #[test]
+    fn torn_metadata_still_allows_labeled_stale_reads() {
+        // Consensus metadata torn, data verified → diagnostics + stale
+        // reads OK, voting closed.
+        let mut s = coherent();
+        s.integrity.hard_state_verified = false;
+        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+            panic!()
+        };
+        let node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons);
+        assert!(node.stale_reads_allowed());
+    }
+
+    #[test]
+    fn corruption_requires_verified_grant() {
+        let mut s = coherent();
+        s.integrity.log_verified = false;
+        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+            panic!()
+        };
+        let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons);
+        let unverified = RejoinMessage::Grant {
+            cluster_id: CLUSTER,
+            term: Term(4),
+            log: Vec::new(),
+            commit: 0,
+            verified: false,
+        };
+        assert!(
+            node.on_grant(NodeId(1), unverified).is_empty(),
+            "unverified grant accepted"
+        );
+        let verified = RejoinMessage::Grant {
+            cluster_id: CLUSTER,
+            term: Term(4),
+            log: Vec::new(),
+            commit: 0,
+            verified: true,
+        };
+        assert!(
+            !node.on_grant(NodeId(1), verified).is_empty(),
+            "verified grant refused"
+        );
+    }
+
+    #[test]
+    fn wrong_cluster_grant_is_never_adopted() {
+        let mut s = coherent();
+        s.integrity.hard_state_verified = false;
+        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+            panic!()
+        };
+        let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons);
+        let alien = RejoinMessage::Grant {
+            cluster_id: ClusterId(99),
+            term: Term(4),
+            log: Vec::new(),
+            commit: 0,
+            verified: true,
+        };
+        assert!(node.on_grant(NodeId(1), alien).is_empty());
+    }
+
+    #[test]
+    fn preserve_happens_before_first_rejoin_request_and_alarm_fires_once() {
+        let mut s = coherent();
+        s.integrity.log_verified = false;
+        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+            panic!()
+        };
+        let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons);
+        let first = node.tick_rejoin(NodeId(1));
+        assert!(matches!(first[0], BootstrapEffect::PreserveOldState));
+        assert!(matches!(first[1], BootstrapEffect::Alarm { .. }));
+        assert!(matches!(first[2], BootstrapEffect::Send { .. }));
+        let second = node.tick_rejoin(NodeId(1));
+        assert_eq!(second.len(), 1, "preserve/alarm must fire once: {second:?}");
+        assert!(matches!(second[0], BootstrapEffect::Send { .. }));
+    }
+}

--- a/crates/yantrikdb-server/src/yrp/bootstrap.rs
+++ b/crates/yantrikdb-server/src/yrp/bootstrap.rs
@@ -116,7 +116,14 @@ pub enum BootDecision {
     /// with exactly this state.
     Healthy { hard: HardState, log: Vec<LogEntry> },
     /// Fail closed: run as a [`QuarantinedNode`] until an authorized rejoin.
-    Quarantine { reasons: Vec<QuarantineReason> },
+    /// `term_hint` is the current_term parsed from the damaged hard-state
+    /// record when the bytes were readable — UNTRUSTED (its checksum
+    /// failed), usable only to REFUSE things (a rejoin grant below the
+    /// hint), never to authorize them. See `QuarantinedNode::on_grant`.
+    Quarantine {
+        reasons: Vec<QuarantineReason>,
+        term_hint: Option<Term>,
+    },
 }
 
 /// Inspect recovered state against the node's configured cluster identity.
@@ -171,7 +178,10 @@ pub fn inspect(expected_cluster: ClusterId, recovered: &RecoveredState) -> BootD
             log: recovered.log.clone().unwrap_or_default(),
         }
     } else {
-        BootDecision::Quarantine { reasons }
+        BootDecision::Quarantine {
+            reasons,
+            term_hint: recovered.hard.map(|h| h.current_term),
+        }
     }
 }
 
@@ -228,18 +238,34 @@ pub struct QuarantinedNode {
     id: NodeId,
     cluster: ClusterId,
     reasons: Vec<QuarantineReason>,
+    /// Untrusted current_term parsed from the damaged record (checksum
+    /// failed, bytes readable). Used ONLY to refuse rejoin grants below it —
+    /// codex review finding 1: a grant below the node's true prior term
+    /// regresses the durable term and reopens a double-vote window in the
+    /// prior term. Refusing below-hint grants closes the replayed/stale-
+    /// grant scenario whenever the record parsed; the residual (record
+    /// unreadable or hint corrupted downward) is closed by Gate C's
+    /// quorum-managed incarnations, not by this hint — never treat the
+    /// hint as proof.
+    term_hint: Option<Term>,
     /// Whether the preserved-state effect has been issued (once).
     preserved: bool,
     alarmed: bool,
 }
 
 impl QuarantinedNode {
-    pub fn new(id: NodeId, cluster: ClusterId, reasons: Vec<QuarantineReason>) -> Self {
+    pub fn new(
+        id: NodeId,
+        cluster: ClusterId,
+        reasons: Vec<QuarantineReason>,
+        term_hint: Option<Term>,
+    ) -> Self {
         debug_assert!(!reasons.is_empty(), "quarantine requires a reason");
         Self {
             id,
             cluster,
             reasons,
+            term_hint,
             preserved: false,
             alarmed: false,
         }
@@ -309,6 +335,20 @@ impl QuarantinedNode {
         if self.reasons.iter().any(|r| r.is_corruption_evidence()) && !verified {
             return Vec::new();
         }
+        // Codex finding 1: refuse grants BELOW the untrusted term hint. A
+        // grant below our (possible) prior term would regress the durable
+        // term; a later VoteRequest at the prior term would then find a
+        // blank vote and grant — a double vote in a term where our torn
+        // record may already have granted someone. Refusal is safe in both
+        // directions: a hint corrupted UPWARD only over-refuses (liveness:
+        // we stay quarantined until a genuinely-current leader grants); a
+        // hint corrupted DOWNWARD (or unreadable) leaves the residual that
+        // Gate C incarnation fencing closes. The hint authorizes nothing.
+        if let Some(hint) = self.term_hint {
+            if term < hint {
+                return Vec::new();
+            }
+        }
         // Adopt as a follower with `voted_for = Some(granting leader)` —
         // NOT `None`. The node's pre-quarantine vote in `term` is unknown
         // (its record was torn) and may have helped elect someone; a blank
@@ -364,7 +404,7 @@ mod tests {
                 assert_eq!(hard, HardState::default());
                 assert!(log.is_empty());
             }
-            BootDecision::Quarantine { reasons } => {
+            BootDecision::Quarantine { reasons, .. } => {
                 panic!("fresh node quarantined: {reasons:?}")
             }
         }
@@ -377,7 +417,7 @@ mod tests {
                 assert_eq!(hard.voted_for, Some(NodeId(2)));
                 assert_eq!(log.len(), 1);
             }
-            BootDecision::Quarantine { reasons } => panic!("quarantined: {reasons:?}"),
+            BootDecision::Quarantine { reasons, .. } => panic!("quarantined: {reasons:?}"),
         }
     }
 
@@ -385,7 +425,7 @@ mod tests {
     fn torn_hard_state_quarantines() {
         let mut s = coherent();
         s.integrity.hard_state_verified = false;
-        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
             panic!("torn state booted healthy");
         };
         assert!(reasons.contains(&QuarantineReason::TornHardState));
@@ -395,7 +435,7 @@ mod tests {
     fn alien_cluster_quarantines() {
         let mut s = coherent();
         s.cluster_id = Some(ClusterId(99));
-        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
             panic!("alien state booted healthy");
         };
         assert!(reasons.contains(&QuarantineReason::ClusterIdMismatch));
@@ -405,7 +445,7 @@ mod tests {
     fn commit_marker_beyond_log_quarantines() {
         let mut s = coherent();
         s.commit_marker = 5; // log has 1 entry
-        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
             panic!("frontier-beyond-data booted healthy");
         };
         assert!(reasons.contains(&QuarantineReason::CommitBeyondLog));
@@ -415,10 +455,10 @@ mod tests {
     fn log_corruption_is_corruption_evidence_and_blocks_stale_reads() {
         let mut s = coherent();
         s.integrity.log_verified = false;
-        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
             panic!("corrupt log booted healthy");
         };
-        let node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons);
+        let node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons, None);
         assert!(!node.stale_reads_allowed());
     }
 
@@ -428,10 +468,10 @@ mod tests {
         // reads OK, voting closed.
         let mut s = coherent();
         s.integrity.hard_state_verified = false;
-        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
             panic!()
         };
-        let node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons);
+        let node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons, None);
         assert!(node.stale_reads_allowed());
     }
 
@@ -439,10 +479,10 @@ mod tests {
     fn corruption_requires_verified_grant() {
         let mut s = coherent();
         s.integrity.log_verified = false;
-        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
             panic!()
         };
-        let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons);
+        let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons, None);
         let unverified = RejoinMessage::Grant {
             cluster_id: CLUSTER,
             term: Term(4),
@@ -471,10 +511,10 @@ mod tests {
     fn wrong_cluster_grant_is_never_adopted() {
         let mut s = coherent();
         s.integrity.hard_state_verified = false;
-        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
             panic!()
         };
-        let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons);
+        let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons, None);
         let alien = RejoinMessage::Grant {
             cluster_id: ClusterId(99),
             term: Term(4),
@@ -489,10 +529,10 @@ mod tests {
     fn preserve_happens_before_first_rejoin_request_and_alarm_fires_once() {
         let mut s = coherent();
         s.integrity.log_verified = false;
-        let BootDecision::Quarantine { reasons } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
             panic!()
         };
-        let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons);
+        let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons, None);
         let first = node.tick_rejoin(NodeId(1));
         assert!(matches!(first[0], BootstrapEffect::PreserveOldState));
         assert!(matches!(first[1], BootstrapEffect::Alarm { .. }));

--- a/crates/yantrikdb-server/src/yrp/mod.rs
+++ b/crates/yantrikdb-server/src/yrp/mod.rs
@@ -27,6 +27,7 @@
 //! 3. **Possibly-committed-suffix protection** (R3) — Raft last-`(term,
 //!    index)` election freshness, never a watermark.
 
+pub mod bootstrap;
 pub mod replica;
 pub mod types;
 

--- a/crates/yantrikdb-server/src/yrp/replica.rs
+++ b/crates/yantrikdb-server/src/yrp/replica.rs
@@ -882,6 +882,39 @@ impl ReplicaCore {
         effects
     }
 
+    /// Rejoin authorization (RFC 028 v2 §5): produce a snapshot grant for a
+    /// quarantined node — but only when this node holds a **quorum-backed
+    /// leadership certificate**: it is leader AND has committed an entry in
+    /// its CURRENT term (the election no-op guarantees one exists once a
+    /// quorum has confirmed the reign). A stale partitioned "leader" cannot
+    /// satisfy that (its current-term entries never commit — Gate A #2), so
+    /// it can never authorize a resync — review scenario R5's fix.
+    ///
+    /// Returns `(term, log, commit)` for the driver to wrap into a
+    /// `bootstrap::RejoinMessage::Grant`; `None` = not authorized (the
+    /// quarantined node stays quarantined and retries — fail closed).
+    pub fn rejoin_grant(&self) -> Option<(Term, Vec<LogEntry>, u64)> {
+        if self.role != Role::Leader {
+            return None;
+        }
+        let cur = self.current_term();
+        let committed_in_current_term =
+            self.commit > 0 && self.entry(self.commit).map(|e| e.term) == Some(cur);
+        if !committed_in_current_term {
+            return None;
+        }
+        // Grant only the DURABLE prefix: a snapshot must never carry entries
+        // our own disk could forget in a crash.
+        let durable: Vec<LogEntry> = self
+            .log
+            .iter()
+            .take(self.durable_len as usize)
+            .copied()
+            .collect();
+        let commit = self.commit.min(self.durable_len);
+        Some((cur, durable, commit))
+    }
+
     fn pre_quorum_reached(&self) -> bool {
         self.pre_votes.len() >= quorum(self.voters.len())
     }

--- a/crates/yantrikdb-server/src/yrp/replica.rs
+++ b/crates/yantrikdb-server/src/yrp/replica.rs
@@ -227,6 +227,11 @@ impl ReplicaCore {
         self.commit
     }
 
+    /// Leader's next send index for `peer` (observability + tests).
+    pub fn next_index_of(&self, peer: NodeId) -> Option<u64> {
+        self.next_index.get(&peer).copied()
+    }
+
     pub fn log_len(&self) -> u64 {
         self.log.len() as u64
     }
@@ -781,19 +786,26 @@ impl ReplicaCore {
             return Vec::new();
         }
         let mut out = Vec::new();
+        // Codex finding 2: delayed/duplicate responses must not regress
+        // next_index below match_index + 1. match_index is monotonic (max);
+        // matched entries are confirmed-durable-matching, so probing below
+        // match+1 is never needed — a stale success or an out-of-date
+        // failure clamped to the floor costs nothing, while an unclamped
+        // one triggers spurious full-suffix retransmissions.
         if success {
             let m = self.match_index.entry(from).or_insert(0);
             *m = (*m).max(last_index);
-            self.next_index.insert(from, last_index + 1);
+            let floor = *m + 1;
+            self.next_index.insert(from, floor);
             self.try_advance_commit(&mut out);
         } else {
-            // Back up toward the follower's durable frontier and retry.
+            let floor = self.match_index.get(&from).copied().unwrap_or(0) + 1;
             let next = self
                 .next_index
                 .get(&from)
                 .copied()
                 .unwrap_or(self.log_len() + 1);
-            let backed = next.saturating_sub(1).clamp(1, last_index + 1);
+            let backed = next.saturating_sub(1).clamp(1, last_index + 1).max(floor);
             self.next_index.insert(from, backed);
             self.send_append_to(from, &mut out);
         }

--- a/crates/yantrikdb-server/src/yrp/sim.rs
+++ b/crates/yantrikdb-server/src/yrp/sim.rs
@@ -308,9 +308,9 @@ impl Sim {
                 node.quarantined = None;
                 node.applied = node.applied.min(node.disk_log.len() as u64);
             }
-            BootDecision::Quarantine { reasons } => {
+            BootDecision::Quarantine { reasons, term_hint } => {
                 node.core = None;
-                node.quarantined = Some(QuarantinedNode::new(id, CLUSTER, reasons));
+                node.quarantined = Some(QuarantinedNode::new(id, CLUSTER, reasons, term_hint));
             }
         }
     }
@@ -1108,4 +1108,133 @@ fn seeded_soak_with_quarantine_invariants_hold() {
         // a term sent no grants while quarantined — enforced structurally,
         // re-checked here via the global ledgers in check_all().
     }
+}
+
+// ── tests: codex code-review fixes ─────────────────────────────────
+
+/// Codex finding 1 (SAFETY): a stale-but-certificated leader's grant BELOW
+/// the quarantined node's (untrusted) term hint is refused — adopting it
+/// would regress the durable term and reopen a double-vote window in the
+/// node's true prior term. The genuinely current leader's grant is adopted,
+/// and the vote ledger stays clean.
+#[test]
+fn codex_stale_grant_below_term_hint_is_refused() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 47, false);
+    // Node 1 becomes leader of term 1 with a committed no-op (certificate).
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    assert_eq!(sim.current_leader(), Some(NodeId(1)));
+    // Partition node 1 away; it keeps its stale term-1 certificate.
+    sim.cut.insert((NodeId(1), NodeId(2)));
+    sim.cut.insert((NodeId(1), NodeId(3)));
+    // Majority elects node 2 in term 2 — node 3 votes for node 2, so its
+    // durable hard state is {term 2, voted node 2}.
+    sim.timeout(NodeId(2), None);
+    sim.drain();
+    // Node 3's record is torn; the bytes (term 2) remain readable as a hint.
+    sim.crash_torn(NodeId(3));
+    sim.restart_via_bootstrap(NodeId(3));
+    assert!(sim.nodes[&NodeId(3)].quarantined.is_some());
+    // Ask the STALE leader (node 1, term 1 certificate). Partition does not
+    // block them — but the grant term (1) is below the hint (2): refused.
+    sim.cut.clear();
+    sim.tick_rejoin(NodeId(3), NodeId(1));
+    sim.drain();
+    assert!(
+        sim.nodes[&NodeId(3)].quarantined.is_some(),
+        "below-hint grant was adopted — term regression"
+    );
+    // The real leader's grant (term 2) is adopted.
+    sim.heartbeat(NodeId(2));
+    sim.drain(); // node 1 gets fenced by term-2 traffic
+    sim.tick_rejoin(NodeId(3), NodeId(2));
+    sim.drain();
+    assert!(sim.nodes[&NodeId(3)].quarantined.is_none());
+    // Vote safety held throughout: node 3's term-2 grants name only node 2.
+    let grants = sim
+        .grants_sent
+        .get(&(NodeId(3), Term(2)))
+        .cloned()
+        .unwrap_or_default();
+    assert!(grants.len() <= 1 && !grants.contains(&NodeId(1)));
+    sim.check_all();
+}
+
+/// Codex finding 2 (CORRECTNESS): a delayed duplicate success response must
+/// not regress next_index below match_index + 1.
+#[test]
+fn codex_duplicate_response_does_not_regress_next_index() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 53, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    for p in [601, 602, 603] {
+        assert!(sim.propose(NodeId(1), p));
+    }
+    sim.drain();
+    // Follower 2 is fully matched (no-op + 3 entries = index 4).
+    let next_before = sim.nodes[&NodeId(1)]
+        .core
+        .as_ref()
+        .unwrap()
+        .next_index_of(NodeId(2))
+        .unwrap();
+    assert_eq!(next_before, 5);
+    // Deliver a DELAYED duplicate: an old success covering only index 1.
+    let effects = sim
+        .nodes
+        .get_mut(&NodeId(1))
+        .unwrap()
+        .core
+        .as_mut()
+        .unwrap()
+        .on_message(
+            NodeId(2),
+            Message::AppendResponse {
+                term: Term(1),
+                success: true,
+                last_index: 1,
+            },
+            false,
+        );
+    sim.run_effects(NodeId(1), effects, None);
+    let next_after = sim.nodes[&NodeId(1)]
+        .core
+        .as_ref()
+        .unwrap()
+        .next_index_of(NodeId(2))
+        .unwrap();
+    assert_eq!(
+        next_after, 5,
+        "duplicate old success regressed next_index to {next_after}"
+    );
+    // And a stale FAILURE cannot drag next below match+1 either.
+    let effects = sim
+        .nodes
+        .get_mut(&NodeId(1))
+        .unwrap()
+        .core
+        .as_mut()
+        .unwrap()
+        .on_message(
+            NodeId(2),
+            Message::AppendResponse {
+                term: Term(1),
+                success: false,
+                last_index: 0,
+            },
+            false,
+        );
+    sim.run_effects(NodeId(1), effects, None);
+    let next_final = sim.nodes[&NodeId(1)]
+        .core
+        .as_ref()
+        .unwrap()
+        .next_index_of(NodeId(2))
+        .unwrap();
+    assert!(
+        next_final >= 5,
+        "stale failure regressed next_index to {next_final}"
+    );
+    sim.drain();
+    sim.check_all();
 }

--- a/crates/yantrikdb-server/src/yrp/sim.rs
+++ b/crates/yantrikdb-server/src/yrp/sim.rs
@@ -23,8 +23,23 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
+use super::bootstrap::{
+    inspect, BootDecision, BootstrapEffect, Integrity, QuarantineReason, QuarantinedNode,
+    RecoveredState, RejoinMessage,
+};
 use super::replica::{Effect, LogEntry, Message, ReplicaCore, Role, NOOP_PAYLOAD};
-use super::types::{HardState, LogPosition, NodeId, Term};
+use super::types::{ClusterId, HardState, LogPosition, NodeId, Term};
+
+/// The sim's cluster identity (all healthy nodes share it; alien-state tests
+/// inject a different one).
+const CLUSTER: ClusterId = ClusterId(7);
+
+/// Both protocol planes ride one transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Wire {
+    R(Message),
+    B(RejoinMessage),
+}
 
 /// Tiny deterministic PRNG (xorshift64*) — no external deps, fully seeded.
 struct Rng(u64);
@@ -51,14 +66,19 @@ impl Rng {
 struct InFlight {
     from: NodeId,
     to: NodeId,
-    msg: Message,
+    msg: Wire,
 }
 
-/// One simulated node: the core (None while crashed) + its durable "disk".
+/// One simulated node: the core (None while crashed/quarantined) + its
+/// durable "disk". `torn_hard`/`corrupt_log` model integrity-check failures
+/// the next boot inspection will see.
 struct SimNode {
     core: Option<ReplicaCore>,
+    quarantined: Option<QuarantinedNode>,
     disk_hard: HardState,
     disk_log: Vec<LogEntry>,
+    torn_hard: bool,
+    corrupt_log: bool,
     /// Highest index this node has applied (ledgered via CommitAdvanced).
     applied: u64,
 }
@@ -81,6 +101,9 @@ struct Sim {
     advertised: BTreeMap<(NodeId, Term), LogPosition>,
     /// I3 ledger: (voter_last_log_at_send, candidate_advertised).
     freshness_at_grant: Vec<(LogPosition, LogPosition)>,
+    /// Gate A #4 ledgers: preserve-before-resync + corruption alarms.
+    preserves: Vec<NodeId>,
+    alarms: Vec<(NodeId, Vec<QuarantineReason>)>,
 }
 
 impl Sim {
@@ -105,8 +128,11 @@ impl Sim {
                 nid,
                 SimNode {
                     core: Some(core),
+                    quarantined: None,
                     disk_hard: hard,
                     disk_log: log.clone(),
+                    torn_hard: false,
+                    corrupt_log: false,
                     applied: 0,
                 },
             );
@@ -122,6 +148,8 @@ impl Sim {
             committed_at: BTreeMap::new(),
             advertised: BTreeMap::new(),
             freshness_at_grant: Vec::new(),
+            preserves: Vec::new(),
+            alarms: Vec::new(),
         }
     }
 
@@ -230,11 +258,111 @@ impl Sim {
             }
             _ => {}
         }
-        self.net.push_back(InFlight { from, to, msg });
+        self.net.push_back(InFlight {
+            from,
+            to,
+            msg: Wire::R(msg),
+        });
     }
 
     fn crash(&mut self, id: NodeId) {
         self.nodes.get_mut(&id).unwrap().core = None;
+    }
+
+    /// Crash AND tear the durable hard-state record (models a torn write /
+    /// bit rot the next boot's checksum will catch).
+    fn crash_torn(&mut self, id: NodeId) {
+        let node = self.nodes.get_mut(&id).unwrap();
+        node.core = None;
+        node.quarantined = None;
+        node.torn_hard = true;
+    }
+
+    /// Crash AND break the log hash chain (data corruption evidence).
+    fn crash_corrupt(&mut self, id: NodeId) {
+        let node = self.nodes.get_mut(&id).unwrap();
+        node.core = None;
+        node.quarantined = None;
+        node.corrupt_log = true;
+    }
+
+    /// The production boot path: recover disk state, run integrity checks,
+    /// inspect, and become either a live replica or a quarantined node. The
+    /// process ALWAYS comes up as something — that is the point.
+    fn restart_via_bootstrap(&mut self, id: NodeId) {
+        let voters = self.voters.clone();
+        let node = self.nodes.get_mut(&id).unwrap();
+        let recovered = RecoveredState {
+            cluster_id: Some(CLUSTER),
+            hard: Some(node.disk_hard),
+            log: Some(node.disk_log.clone()),
+            commit_marker: 0, // volatile in A2's model
+            integrity: Integrity {
+                hard_state_verified: !node.torn_hard,
+                log_verified: !node.corrupt_log,
+            },
+        };
+        match inspect(CLUSTER, &recovered) {
+            BootDecision::Healthy { hard, log } => {
+                node.core = Some(ReplicaCore::new(id, voters, hard, log, false));
+                node.quarantined = None;
+                node.applied = node.applied.min(node.disk_log.len() as u64);
+            }
+            BootDecision::Quarantine { reasons } => {
+                node.core = None;
+                node.quarantined = Some(QuarantinedNode::new(id, CLUSTER, reasons));
+            }
+        }
+    }
+
+    /// Drive a quarantined node's rejoin retry toward `leader_hint`.
+    fn tick_rejoin(&mut self, id: NodeId, leader_hint: NodeId) {
+        let Some(q) = self.nodes.get_mut(&id).unwrap().quarantined.as_mut() else {
+            return;
+        };
+        let effects = q.tick_rejoin(leader_hint);
+        self.run_bootstrap_effects(id, effects);
+    }
+
+    fn run_bootstrap_effects(&mut self, id: NodeId, effects: Vec<BootstrapEffect>) {
+        for eff in effects {
+            match eff {
+                BootstrapEffect::PreserveOldState => {
+                    self.preserves.push(id);
+                }
+                BootstrapEffect::Alarm { reasons } => {
+                    self.alarms.push((id, reasons));
+                }
+                BootstrapEffect::Send { to, msg } => {
+                    self.net.push_back(InFlight {
+                        from: id,
+                        to,
+                        msg: Wire::B(msg),
+                    });
+                }
+                BootstrapEffect::AdoptSnapshot {
+                    cluster_id: _,
+                    hard,
+                    log,
+                } => {
+                    // Persist the adopted snapshot, clear damage flags, and
+                    // resume as a live follower. Quarantine ends here only.
+                    assert!(
+                        self.preserves.contains(&id),
+                        "adopt without preserving old state first"
+                    );
+                    let voters = self.voters.clone();
+                    let node = self.nodes.get_mut(&id).unwrap();
+                    node.disk_hard = hard;
+                    node.disk_log = log.clone();
+                    node.torn_hard = false;
+                    node.corrupt_log = false;
+                    node.quarantined = None;
+                    node.core = Some(ReplicaCore::new(id, voters, hard, log, false));
+                    node.applied = node.applied.min(node.disk_log.len() as u64);
+                }
+            }
+        }
     }
 
     fn restart(&mut self, id: NodeId, use_pre_vote: bool) {
@@ -250,6 +378,7 @@ impl Sim {
             node.disk_log.clone(),
             use_pre_vote,
         ));
+        node.quarantined = None;
         node.applied = node.applied.min(node.disk_log.len() as u64);
     }
 
@@ -290,14 +419,57 @@ impl Sim {
         if self.cut.contains(&key) {
             return true;
         }
-        let Some(node) = self.nodes.get_mut(&m.to) else {
-            return true;
-        };
-        let Some(core) = node.core.as_mut() else {
-            return true;
-        };
-        let effects = core.on_message(m.from, m.msg, false);
-        self.run_effects(m.to, effects, crash_at);
+        match m.msg {
+            Wire::R(msg) => {
+                let Some(node) = self.nodes.get_mut(&m.to) else {
+                    return true;
+                };
+                // Quarantined (or crashed) nodes DROP replica traffic:
+                // fail-closed is enforced by absence — there is no code
+                // path by which a quarantined node grants a vote or acks
+                // an append.
+                let Some(core) = node.core.as_mut() else {
+                    return true;
+                };
+                let effects = core.on_message(m.from, msg, false);
+                self.run_effects(m.to, effects, crash_at);
+            }
+            Wire::B(RejoinMessage::Request { node: asker }) => {
+                // Rejoin requests are answered only by a live core holding
+                // the leadership certificate (committed in current term).
+                let grant = self
+                    .nodes
+                    .get(&m.to)
+                    .and_then(|n| n.core.as_ref())
+                    .and_then(|c| c.rejoin_grant());
+                if let Some((term, log, commit)) = grant {
+                    self.net.push_back(InFlight {
+                        from: m.to,
+                        to: asker,
+                        msg: Wire::B(RejoinMessage::Grant {
+                            cluster_id: CLUSTER,
+                            term,
+                            log,
+                            commit,
+                            // The leader's snapshot is live state: verified.
+                            verified: true,
+                        }),
+                    });
+                }
+            }
+            Wire::B(grant @ RejoinMessage::Grant { .. }) => {
+                let effects = {
+                    let Some(node) = self.nodes.get_mut(&m.to) else {
+                        return true;
+                    };
+                    let Some(q) = node.quarantined.as_mut() else {
+                        return true; // no longer quarantined: stale grant ignored
+                    };
+                    q.on_grant(m.from, grant)
+                };
+                self.run_bootstrap_effects(m.to, effects);
+            }
+        }
         true
     }
 
@@ -739,5 +911,201 @@ fn seeded_soak_invariants_hold() {
         sim.cut.clear();
         sim.drain();
         sim.check_all();
+    }
+}
+
+// ── tests: Phase A2 — quarantine + quorum-authorized rejoin ────────
+
+/// THE CT-141 TEST. A node with torn consensus metadata BOOTS (process up,
+/// diagnostics available, stale reads offered) but fails closed as a voter;
+/// its damaged state is preserved before resync; a leader with a
+/// quorum-backed certificate authorizes rejoin; the node adopts the
+/// snapshot, resumes as a follower, and catches up. No operator surgery,
+/// no 10-day outage, no double vote.
+#[test]
+fn ct141_torn_node_quarantines_then_rejoins_via_leader() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 31, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    assert!(sim.propose(NodeId(1), 501));
+    sim.drain();
+
+    // Node 3's disk record is torn in a crash.
+    sim.crash_torn(NodeId(3));
+    sim.restart_via_bootstrap(NodeId(3));
+    {
+        let n3 = &sim.nodes[&NodeId(3)];
+        let q = n3.quarantined.as_ref().expect("torn node must quarantine");
+        assert!(q.reasons().contains(&QuarantineReason::TornHardState));
+        // Metadata-only damage: data verified → labeled stale reads OK.
+        assert!(q.stale_reads_allowed());
+        assert!(n3.core.is_none(), "quarantined node must not run a core");
+    }
+
+    // Rejoin via the leader; adopt; catch up.
+    sim.tick_rejoin(NodeId(3), NodeId(1));
+    sim.drain();
+    {
+        let n3 = &sim.nodes[&NodeId(3)];
+        assert!(n3.quarantined.is_none(), "rejoin did not complete");
+        assert!(n3.core.is_some());
+        assert!(!n3.torn_hard);
+    }
+    assert!(
+        sim.preserves.contains(&NodeId(3)),
+        "old state must be preserved before resync"
+    );
+    sim.heartbeat(NodeId(1));
+    sim.drain();
+    sim.check_all();
+    assert!(
+        sim.nodes[&NodeId(3)].applied >= 2,
+        "rejoined node failed to catch up (applied {})",
+        sim.nodes[&NodeId(3)].applied
+    );
+}
+
+/// Fail-closed proof: a quarantined node cannot contribute to ANY quorum.
+/// With one node quarantined and the other two partitioned from each other,
+/// no candidate can assemble a majority — the cluster correctly stalls
+/// rather than electing on damaged state.
+#[test]
+fn quarantined_node_cannot_vote() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 37, false);
+    sim.crash_torn(NodeId(3));
+    sim.restart_via_bootstrap(NodeId(3));
+    sim.cut.insert((NodeId(1), NodeId(2)));
+    sim.timeout(NodeId(1), None);
+    sim.timeout(NodeId(2), None);
+    sim.drain();
+    sim.check_all();
+    assert!(
+        sim.leaders.is_empty(),
+        "an election succeeded without a legal quorum: {:?}",
+        sim.leaders
+    );
+    // And the quarantined node sent zero grants, ever.
+    assert!(sim.grants_sent.keys().all(|(voter, _)| *voter != NodeId(3)));
+}
+
+/// Corruption evidence (broken log hash chain): alarms fire, stale reads
+/// are refused, and only a VERIFIED grant is adopted.
+#[test]
+fn corrupted_log_alarms_and_rejoins_from_verified_source() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 41, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    sim.crash_corrupt(NodeId(3));
+    sim.restart_via_bootstrap(NodeId(3));
+    {
+        let q = sim.nodes[&NodeId(3)].quarantined.as_ref().unwrap();
+        assert!(q.reasons().contains(&QuarantineReason::LogCorruption));
+        assert!(!q.stale_reads_allowed(), "corrupt data must not be served");
+    }
+    sim.tick_rejoin(NodeId(3), NodeId(1));
+    sim.drain();
+    assert!(
+        sim.alarms.iter().any(|(id, _)| *id == NodeId(3)),
+        "corruption evidence must alarm"
+    );
+    assert!(sim.nodes[&NodeId(3)].quarantined.is_none());
+    sim.heartbeat(NodeId(1));
+    sim.drain();
+    sim.check_all();
+}
+
+/// A rejoin request sent to a NON-leader (or a leader without a committed
+/// current-term entry) is simply not granted — the node stays quarantined
+/// and retries. Authorization requires the certificate.
+#[test]
+fn rejoin_requires_leadership_certificate() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 43, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    sim.crash_torn(NodeId(3));
+    sim.restart_via_bootstrap(NodeId(3));
+    // Ask a FOLLOWER (node 2): no grant, still quarantined.
+    sim.tick_rejoin(NodeId(3), NodeId(2));
+    sim.drain();
+    assert!(sim.nodes[&NodeId(3)].quarantined.is_some());
+    // Ask the leader: granted.
+    sim.tick_rejoin(NodeId(3), NodeId(1));
+    sim.drain();
+    assert!(sim.nodes[&NodeId(3)].quarantined.is_none());
+    sim.check_all();
+}
+
+/// Soak with damage: random torn/corrupt crashes now join the schedule;
+/// crashed-damaged nodes restart through the REAL boot path (inspect →
+/// quarantine → rejoin-retry). Every invariant holds for every seed —
+/// including that no quarantined node ever votes or acks.
+#[test]
+fn seeded_soak_with_quarantine_invariants_hold() {
+    for seed in 1..20u64 {
+        let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, seed, false);
+        let mut payload = 5000;
+        for _step in 0..300 {
+            let ids = [NodeId(1), NodeId(2), NodeId(3)];
+            match sim.rng.next() % 14 {
+                0 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_some() {
+                        sim.timeout(id, None);
+                    }
+                }
+                1 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_some() && sim.rng.chance(10) {
+                        if sim.rng.chance(50) {
+                            sim.crash_torn(id);
+                        } else {
+                            sim.crash(id);
+                        }
+                    }
+                }
+                2 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_none() && sim.nodes[&id].quarantined.is_none() {
+                        sim.restart_via_bootstrap(id);
+                    }
+                }
+                3 => {
+                    let id = ids[sim.rng.pick(3)];
+                    payload += 1;
+                    let _ = sim.propose(id, payload);
+                }
+                4 => {
+                    let id = ids[sim.rng.pick(3)];
+                    sim.heartbeat(id);
+                }
+                5 => {
+                    // Quarantined nodes retry rejoin toward a random peer.
+                    let id = ids[sim.rng.pick(3)];
+                    let hint = ids[sim.rng.pick(3)];
+                    if id != hint {
+                        sim.tick_rejoin(id, hint);
+                    }
+                }
+                6 => {
+                    let a = ids[sim.rng.pick(3)];
+                    let b = ids[sim.rng.pick(3)];
+                    if a != b {
+                        let key = (a.min(b), a.max(b));
+                        if !sim.cut.remove(&key) {
+                            sim.cut.insert(key);
+                        }
+                    }
+                }
+                _ => {
+                    sim.deliver_one(None);
+                }
+            }
+        }
+        sim.cut.clear();
+        sim.drain();
+        sim.check_all();
+        // Fail-closed held throughout: nodes that were EVER quarantined in
+        // a term sent no grants while quarantined — enforced structurally,
+        // re-checked here via the global ledgers in check_all().
     }
 }

--- a/crates/yantrikdb-server/src/yrp/types.rs
+++ b/crates/yantrikdb-server/src/yrp/types.rs
@@ -8,6 +8,12 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Immutable cluster identity (RFC 028 v2 §3). Ops, votes, and snapshots
+/// carry it; a mismatch at boot or on the wire is a quarantine trigger —
+/// state from a different cluster is alien no matter how well-formed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ClusterId(pub u64);
+
 /// A node's stable identifier within one cluster.
 ///
 /// Identity alone is NOT sufficient to vote — RFC 028 v2 §3 requires the


### PR DESCRIPTION
## Summary

**RFC 028 v2 Phase A2** — the recovery plane. With A1 (#57) and A1b (#59), **all Gate A invariants are now implemented and sim-proven**: vote safety, authority safety, suffix protection, fail-closed quarantine, and (via the ack-tier design carried in the core) honest durability semantics. This is the phase that makes CT-141 structurally unrepeatable.

## Breaking-change ledger (agreement #2)
**Surface:** none — internal module, not yet wired into the runtime (Phase B). Zero behavior change.

## The CT-141 lesson, as code

- `inspect()` is **total**: blank disk → fresh node; coherent state → exact restore; anything uncertain → `QuarantinedNode`. The process always starts.
- **Fail-closed by absence**: `QuarantinedNode` has no vote handler and no append handler — there is no code path by which it grants or acks. The sim proves a cluster with a quarantined node correctly *stalls* rather than electing on damaged state.
- **Two damage axes**: storage-failure evidence (torn hard-state, log corruption) alarms once + requires a *verified* source snapshot; the data axis governs reads — torn **metadata** with verified data still serves labeled stale reads (the availability CT-141 actually needed).
- **Preserve-before-resync**: the damaged state is moved aside first (sim-ledger-asserted) — the automated version of the CT-141 manual backup.
- **Quorum-authorized rejoin** (review R5): grants require a leadership certificate — leader AND committed-in-current-term. A stale partitioned "leader" can never satisfy it (its commits are blocked by Gate A #2). Asking a follower does nothing.
- **R2-safe adoption**: adopted state records `voted_for = granting leader`, not `None` — a blank vote would reopen the double-vote window in a term where the node's torn prior vote may have elected someone. Caught during design of the sim tests, before any code ran.

## Proof
27/27 yrp tests green: CT-141 end-to-end, quarantined-cannot-vote, corruption alarm + verified-source-only, certificate-required, 19-seed quarantine soak on top of the existing A1/A1b suites. Full workspace green.

## Next
Phase B: runtime integration (oplog payload binding, real persistence driver, HTTP transport), capability activation, snapshots/GC, incarnations, witness ack-exclusion — per RFC 028 v2 §12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)