### PR TITLE
feat: idempotency_key on /v1/remember + /batch (issue #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] — 2026-07-18
+
+**`idempotency_key` on `/v1/remember` + `/v1/remember/batch`** (issue #58, converged with yantrikdb-mcp + yantrikdb-hermes-plugin). Keyed writes commit claim + row in one engine transaction (v0.10 T07 — the RFC 028 §7 origin-ingress-and-commit-coupled contract). Same key + same payload → 200 with the original rid, zero writes; same key + divergent payload → 200 `{stored:false, idempotency_conflict:true, rid}`; invalid key → 400. Batch: per-item keys + batch-level `{key}:{index}` derivation (the shipped mcp/hermes convention), all-or-nothing on conflict. `/v1/health` advertises `capabilities: ["idempotency_key"]` for feature-probing. Cluster mode refuses keyed writes with 501 until YRP Phase B couples claims into the replicated log (agreement #6 — never silently drop a dedup guarantee). Additive only — unkeyed callers unchanged.
+
+Also on main since 0.10.0: **YRP Gate A complete** (RFC 028 v2, PRs #57/#59/#60) — the native replication safety core (election + log replication + fail-closed quarantine/rejoin) as pure sim-proven logic; not yet wired into the runtime.
+
 ## [0.10.0] — 2026-07-18
 
 **Version realignment + engine v0.10.0 adoption.** From this release, `yantrikdb-server` versions align with the engine generation: the ecosystem ships **core 0.10.0 + server 0.10.0 + mcp** on one coordinated train, so "the v0.10 generation" is unambiguous across all three repos. The server's independent 0.8.x line ends at 0.8.27; the briefly-tagged `v0.8.28` (same code, pre-realignment number, never deployed) is superseded by this tag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -426,6 +426,11 @@ async fn health(State(state): State<Arc<AppState>>) -> Json<Value> {
     let mut payload = json!({
         "status": "ok",
         "engines_loaded": state.pool.loaded_count(),
+        // Issue #58 (agreement #6): probeable capabilities so clients can
+        // feature-probe instead of discovering support by silent field
+        // drops. mcp/hermes flip their client-side key refusals to
+        // forwards when they see "idempotency_key" here.
+        "capabilities": ["idempotency_key"],
     });
     if let Some(view) = cluster_state_view(&state) {
         // PR 6.9: payload gains last_log_index, last_applied_index,
@@ -721,6 +726,25 @@ async fn remember(
     });
     let embedding = resolve_embedding(state.as_ref(), &text, client_supplied).await?;
 
+    // Issue #58: keyed writes route through the engine's atomic
+    // claim-coupled path instead of the commit_log mutation. Inside
+    // `record_with_idempotency` the claim and the row commit in ONE engine
+    // transaction (v0.10 T07) — which is exactly the "claim is
+    // origin-ingress AND commit-coupled" contract RFC 028 §7 requires. The
+    // RFC-010 mutation path cannot carry that coupling yet (the applier's
+    // `record_with_rid` has no claim parameter), so in cluster mode the key
+    // is REFUSED loudly (agreement #6: an ignored key converts
+    // "exactly-once" into "maybe-twice" invisibly — the worst failure mode
+    // this feature exists to kill). YRP Phase B moves the claim into the
+    // replicated log per RFC 028 §7.
+    if let Some(key) = body
+        .get("idempotency_key")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+    {
+        return remember_with_idempotency(&state, engine, body, text, embedding, key).await;
+    }
+
     // RFC 010 PR-6.4: route through commit_log instead of calling
     // engine.record() directly. Single-node mode: LocalSqliteSubmitter
     // applies inline. Cluster mode: RaftCommitter routes through
@@ -795,6 +819,218 @@ async fn remember(
         "rid": rid,
         "log_index": receipt.log_index,
     })))
+}
+
+/// Issue #58: the keyed `/v1/remember` path — engine-atomic claim + row.
+///
+/// Response contract (converged with yantrikdb-mcp + yantrikdb-hermes-plugin
+/// in issue #58; hermes's byte-identical-across-backends argument won the
+/// 200-vs-4xx question):
+/// - fresh write            → 200 `{rid}`
+/// - same key + same text   → 200 `{rid}` (the ORIGINAL rid, zero writes —
+///   the silent-HIT principle; indistinguishable from fresh by design)
+/// - same key + diff text   → 200 `{stored:false, idempotency_conflict:true,
+///   rid:<existing>}` — a claim-resolution RESULT, not a protocol error
+/// - invalid key            → 400 (empty/whitespace/over-long — a caller bug)
+/// - cluster mode           → 501 (refused until YRP Phase B couples the
+///   claim into the replicated log; agreement #6 — never silently drop)
+async fn remember_with_idempotency(
+    state: &Arc<AppState>,
+    engine: EngineHandle,
+    body: Value,
+    text: String,
+    embedding: Option<Vec<f32>>,
+    key: String,
+) -> AppResult {
+    if cluster_state_view(state).is_some() {
+        return Err(app_error(
+            StatusCode::NOT_IMPLEMENTED,
+            "idempotency_key is not yet supported in cluster mode: the \
+             replicated apply path cannot couple the claim to the commit \
+             (issue #58 / RFC 028 §7). Retry without the key, or run \
+             single-node.",
+        ));
+    }
+    let memory_type: String = body
+        .get("memory_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("semantic")
+        .into();
+    let importance = body
+        .get("importance")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.5);
+    let valence = body.get("valence").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let half_life = body
+        .get("half_life")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(168.0);
+    let metadata = body.get("metadata").cloned().unwrap_or(json!({}));
+    let namespace: String = body
+        .get("namespace")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .into();
+    let certainty = body
+        .get("certainty")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(1.0);
+    let domain: String = body
+        .get("domain")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .into();
+    let source: String = body
+        .get("source")
+        .and_then(|v| v.as_str())
+        .unwrap_or("user")
+        .into();
+    let emotional_state: Option<String> = body
+        .get("emotional_state")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let outcome = tokio::task::spawn_blocking(move || match embedding {
+        Some(emb) => engine.record_with_idempotency(
+            &text,
+            &memory_type,
+            importance,
+            valence,
+            half_life,
+            &metadata,
+            &emb,
+            &namespace,
+            certainty,
+            &domain,
+            &source,
+            emotional_state.as_deref(),
+            Some(&key),
+        ),
+        // No embedder + no client vector: the engine's text path applies
+        // its own embedding policy, identical to the unkeyed route.
+        None => engine.record_text_with_idempotency(
+            &text,
+            &memory_type,
+            importance,
+            valence,
+            half_life,
+            &metadata,
+            &namespace,
+            certainty,
+            &domain,
+            &source,
+            emotional_state.as_deref(),
+            Some(&key),
+        ),
+    })
+    .await
+    .map_err(|e| {
+        app_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("join error: {e}"),
+        )
+    })?;
+
+    match outcome {
+        Ok(rid) => Ok(Json(json!({ "rid": rid }))),
+        Err(yantrikdb::YantrikDbError::IdempotencyConflict { existing_rid, .. }) => {
+            Ok(Json(json!({
+                "stored": false,
+                "idempotency_conflict": true,
+                "rid": existing_rid,
+            })))
+        }
+        Err(yantrikdb::YantrikDbError::InvalidIdempotencyKey { reason }) => Err(app_error(
+            StatusCode::BAD_REQUEST,
+            format!("invalid idempotency_key: {reason}"),
+        )),
+        Err(e) => Err(app_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("engine error: {e}"),
+        )),
+    }
+}
+
+/// Issue #58: keyed `/v1/remember/batch` — the engine's atomic batch path.
+/// Claims + rows commit in one transaction; a key conflict fails the WHOLE
+/// batch (all-or-nothing), returning the same 200-conflict shape as the
+/// single-item path. Cluster mode refuses (same reasoning as
+/// [`remember_with_idempotency`]).
+async fn remember_batch_with_idempotency(
+    state: &Arc<AppState>,
+    engine: EngineHandle,
+    memories: Vec<crate::command::RememberInput>,
+    item_keys: Vec<Option<String>>,
+) -> AppResult {
+    if cluster_state_view(state).is_some() {
+        return Err(app_error(
+            StatusCode::NOT_IMPLEMENTED,
+            "idempotency_key is not yet supported in cluster mode: the \
+             replicated apply path cannot couple the claim to the commit \
+             (issue #58 / RFC 028 §7). Retry without keys, or run \
+             single-node.",
+        ));
+    }
+    // The engine batch API requires concrete vectors; by this point every
+    // item either shipped one or was pre-embedded. A remaining None means
+    // the server has no embedder — refuse honestly rather than land a
+    // NULL-embedding row behind a dedup claim.
+    let mut inputs = Vec::with_capacity(memories.len());
+    for (i, (m, key)) in memories.into_iter().zip(item_keys).enumerate() {
+        let Some(embedding) = m.embedding else {
+            return Err(app_error(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "memories[{i}]: keyed batches require embeddings \
+                     (configure a server embedder or supply 'embedding')"
+                ),
+            ));
+        };
+        inputs.push(yantrikdb::types::RecordInput {
+            text: m.text,
+            memory_type: m.memory_type,
+            importance: m.importance,
+            valence: m.valence,
+            half_life: m.half_life,
+            metadata: m.metadata,
+            embedding,
+            namespace: m.namespace,
+            certainty: m.certainty,
+            domain: m.domain,
+            source: m.source,
+            emotional_state: m.emotional_state,
+            idempotency_key: key,
+        });
+    }
+    let outcome = tokio::task::spawn_blocking(move || engine.record_batch(&inputs))
+        .await
+        .map_err(|e| {
+            app_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("join error: {e}"),
+            )
+        })?;
+    match outcome {
+        Ok(rids) => {
+            let count = rids.len();
+            Ok(Json(json!({ "rids": rids, "count": count })))
+        }
+        Err(yantrikdb::YantrikDbError::IdempotencyConflict { existing_rid, .. }) => {
+            Ok(Json(json!({
+                "stored": false,
+                "idempotency_conflict": true,
+                "rid": existing_rid,
+            })))
+        }
+        Err(yantrikdb::YantrikDbError::InvalidIdempotencyKey { reason }) => Err(app_error(
+            StatusCode::BAD_REQUEST,
+            format!("invalid idempotency_key: {reason}"),
+        )),
+        Err(e) => Err(app_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("engine error: {e}"),
+        )),
+    }
 }
 
 /// Issue #19 helper: resolve the embedding for a `/v1/remember`-style
@@ -906,7 +1142,23 @@ async fn remember_batch(
     }
 
     let mut memories = Vec::with_capacity(memories_arr.len());
+    // Issue #58: per-item idempotency keys, positionally aligned with
+    // `memories`. A batch-level key derives per-item as "{key}:{index}" —
+    // the convention yantrikdb-mcp and yantrikdb-hermes-plugin already
+    // shipped; mirroring it means retries dedupe identically across all
+    // three surfaces. An explicit per-item key wins over the derivation.
+    let mut item_keys: Vec<Option<String>> = Vec::with_capacity(memories_arr.len());
+    let batch_key: Option<String> = body
+        .get("idempotency_key")
+        .and_then(|v| v.as_str())
+        .map(String::from);
     for (i, m) in memories_arr.iter().enumerate() {
+        item_keys.push(
+            m.get("idempotency_key")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+                .or_else(|| batch_key.as_ref().map(|k| format!("{k}:{i}"))),
+        );
         let text = m
             .get("text")
             .and_then(|v| v.as_str())
@@ -1013,6 +1265,15 @@ async fn remember_batch(
                 }
             }
         }
+    }
+
+    // Issue #58: any key present routes the WHOLE batch through the
+    // engine's atomic batch path (claims + rows in one transaction,
+    // all-or-nothing on conflict — the embedded semantics mcp/hermes
+    // locked). Mixed keyed/unkeyed items ride together; unkeyed items
+    // simply carry no claim.
+    if item_keys.iter().any(|k| k.is_some()) {
+        return remember_batch_with_idempotency(&state, engine, memories, item_keys).await;
     }
 
     // RFC 010 PR-6.4: route every batch entry through commit_log. Each

--- a/crates/yantrikdb-server/tests/compat_test.rs
+++ b/crates/yantrikdb-server/tests/compat_test.rs
@@ -200,3 +200,191 @@ mod helper {
         SimpleControlDb { conn }
     }
 }
+
+// ── Issue #58: /v1/remember idempotency_key contract (engine semantics the
+// gateway maps 1:1 — same-key+same-payload = original rid + zero writes;
+// same-key+divergent-payload = typed IdempotencyConflict carrying the
+// existing rid (gateway → 200 {stored:false, idempotency_conflict:true,
+// rid}); batch per-item keys are all-or-nothing on conflict; invalid keys
+// are refused loudly, never coerced. ──
+
+fn idem_test_db() -> (TempDir, yantrikdb::YantrikDB) {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("idem.db");
+    let db = yantrikdb::YantrikDB::new(db_path.to_str().unwrap(), 8).unwrap();
+    (tmp, db)
+}
+
+fn idem_vec() -> Vec<f32> {
+    (0..8).map(|i| ((i as f32) * 0.3).sin()).collect()
+}
+
+#[test]
+fn idempotency_same_key_same_payload_returns_original_rid_zero_writes() {
+    let (_tmp, db) = idem_test_db();
+    let emb = idem_vec();
+    let meta = serde_json::json!({});
+    let rid1 = db
+        .record_with_idempotency(
+            "keyed fact",
+            "semantic",
+            0.5,
+            0.0,
+            168.0,
+            &meta,
+            &emb,
+            "ns",
+            1.0,
+            "work",
+            "user",
+            None,
+            Some("key-1"),
+        )
+        .unwrap();
+    let rid2 = db
+        .record_with_idempotency(
+            "keyed fact",
+            "semantic",
+            0.5,
+            0.0,
+            168.0,
+            &meta,
+            &emb,
+            "ns",
+            1.0,
+            "work",
+            "user",
+            None,
+            Some("key-1"),
+        )
+        .unwrap();
+    assert_eq!(rid1, rid2, "retry must return the ORIGINAL rid");
+    let stats = db.stats(None).unwrap();
+    assert_eq!(
+        stats.active_memories, 1,
+        "idempotent retry must write nothing"
+    );
+}
+
+#[test]
+fn idempotency_same_key_divergent_payload_conflicts_with_existing_rid() {
+    let (_tmp, db) = idem_test_db();
+    let emb = idem_vec();
+    let meta = serde_json::json!({});
+    let rid1 = db
+        .record_with_idempotency(
+            "original text",
+            "semantic",
+            0.5,
+            0.0,
+            168.0,
+            &meta,
+            &emb,
+            "ns",
+            1.0,
+            "work",
+            "user",
+            None,
+            Some("key-2"),
+        )
+        .unwrap();
+    let err = db
+        .record_with_idempotency(
+            "DIFFERENT text",
+            "semantic",
+            0.5,
+            0.0,
+            168.0,
+            &meta,
+            &emb,
+            "ns",
+            1.0,
+            "work",
+            "user",
+            None,
+            Some("key-2"),
+        )
+        .unwrap_err();
+    match err {
+        yantrikdb::YantrikDbError::IdempotencyConflict { existing_rid, .. } => {
+            assert_eq!(existing_rid, rid1, "conflict must carry the existing rid");
+        }
+        other => panic!("expected IdempotencyConflict, got: {other}"),
+    }
+    let stats = db.stats(None).unwrap();
+    assert_eq!(stats.active_memories, 1, "conflict must write nothing");
+}
+
+#[test]
+fn idempotency_batch_per_item_keys_all_or_nothing() {
+    let (_tmp, db) = idem_test_db();
+    let emb = idem_vec();
+    let mk = |text: &str, key: Option<&str>| yantrikdb::types::RecordInput {
+        text: text.into(),
+        memory_type: "semantic".into(),
+        importance: 0.5,
+        valence: 0.0,
+        half_life: 168.0,
+        metadata: serde_json::json!({}),
+        embedding: emb.clone(),
+        namespace: "ns".into(),
+        certainty: 1.0,
+        domain: "work".into(),
+        source: "user".into(),
+        emotional_state: None,
+        idempotency_key: key.map(String::from),
+    };
+    // First batch: two keyed items (the "{caller_key}:{index}" derivation
+    // the gateway applies for a batch-level key produces exactly this).
+    let rids1 = db
+        .record_batch(&[mk("item a", Some("bk:0")), mk("item b", Some("bk:1"))])
+        .unwrap();
+    assert_eq!(rids1.len(), 2);
+    // Full retry: same rids back, zero new rows.
+    let rids2 = db
+        .record_batch(&[mk("item a", Some("bk:0")), mk("item b", Some("bk:1"))])
+        .unwrap();
+    assert_eq!(rids1, rids2, "batch retry must return original rids");
+    assert_eq!(db.stats(None).unwrap().active_memories, 2);
+    // Divergent payload under a claimed key fails the WHOLE batch.
+    let err = db
+        .record_batch(&[mk("item a", Some("bk:0")), mk("MUTATED b", Some("bk:1"))])
+        .unwrap_err();
+    assert!(
+        matches!(err, yantrikdb::YantrikDbError::IdempotencyConflict { .. }),
+        "expected IdempotencyConflict, got: {err}"
+    );
+    assert_eq!(
+        db.stats(None).unwrap().active_memories,
+        2,
+        "failed batch must be all-or-nothing"
+    );
+}
+
+#[test]
+fn idempotency_invalid_key_is_refused_loudly() {
+    let (_tmp, db) = idem_test_db();
+    let emb = idem_vec();
+    let meta = serde_json::json!({});
+    let err = db
+        .record_with_idempotency(
+            "text",
+            "semantic",
+            0.5,
+            0.0,
+            168.0,
+            &meta,
+            &emb,
+            "ns",
+            1.0,
+            "work",
+            "user",
+            None,
+            Some("   "),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, yantrikdb::YantrikDbError::InvalidIdempotencyKey { .. }),
+        "whitespace key must be refused, not coerced: {err}"
+    );
+}


### PR DESCRIPTION
## Summary
Implements the issue #58 convergence — both HTTP consumers (mcp, hermes) refuse `remember(idempotency_key=)` client-side until the gateway carries it; this unblocks their one-line refuse→forward swaps.

## Breaking-change ledger (agreement #2)
**Additive only.** Unkeyed callers see zero change (same commit_log mutation path, byte-for-byte). New: `idempotency_key` on `/v1/remember` + `/batch` (per-item + batch-level `{key}:{index}` derivation), `capabilities: ["idempotency_key"]` on `/v1/health`.

## The ruling on the one divergence (200 vs 4xx conflict)
Hermes wanted 200+body; mcp preferred typed non-2xx. **Ruled 200 + `{stored:false, idempotency_conflict:true, rid}`**: the conflict is a claim-resolution *result* mirroring the embedded engine semantics verbatim — hermes's byte-identical-across-backends argument wins; a 4xx would turn a result into a raised exception on their taxonomy. (`InvalidIdempotencyKey` **is** a 4xx — that's a caller bug, not a result.) mcp's soft ask for an `idempotent_hit` marker is not implementable without engine support (hit and fresh both return `Ok(rid)`) and contradicts the silent-HIT principle hermes cited — noted in #58.

## Mechanics
Keyed writes route through `engine.record_with_idempotency` — claim + row in ONE engine transaction (v0.10 T07), the "origin-ingress AND commit-coupled" contract of RFC 028 §7. Cluster mode **refuses with 501** (the RFC-010 replicated apply path can't couple the claim yet; agreement #6 — an ignored key silently converts exactly-once into maybe-twice, the exact failure this feature kills). YRP Phase B moves the claim into the replicated log; mcp's wire-contract ask (keyed retry during election/quarantine/rejoin never double-writes) becomes a Phase B contract test.

## Testing
4 behavioral contract tests: dedupe zero-writes + original rid · divergent conflict carries existing rid · batch all-or-nothing with the shipped derivation convention · whitespace key refused loudly. Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)