### PR TITLE
feat(yrp): Phase B slice 1 — claim-in-log keyed proposals (RFC 028 §7)

### DIFF
--- a/crates/yantrikdb-server/src/yrp/bootstrap.rs
+++ b/crates/yantrikdb-server/src/yrp/bootstrap.rs
@@ -385,10 +385,7 @@ mod tests {
                 current_term: Term(3),
                 voted_for: Some(NodeId(2)),
             }),
-            log: Some(vec![LogEntry {
-                term: Term(3),
-                payload: 42,
-            }]),
+            log: Some(vec![LogEntry::unkeyed(Term(3), 42)]),
             commit_marker: 1,
             integrity: Integrity {
                 hard_state_verified: true,

--- a/crates/yantrikdb-server/src/yrp/replica.rs
+++ b/crates/yantrikdb-server/src/yrp/replica.rs
@@ -57,13 +57,55 @@ use super::types::{quorum, HardState, LogPosition, NodeId, Term};
 /// the §5.4.2 mechanism that lets prior-term entries commit by implication.
 pub const NOOP_PAYLOAD: u64 = 0;
 
-/// One canonical-log entry. `payload` is an opaque identifier in Phase A1b;
-/// the memory-native oplog op (embedding bytes, provenance, HLC) binds here
-/// in Phase B.
+/// One canonical-log entry. `payload` is an opaque identifier until the
+/// memory-native oplog op (embedding bytes, provenance, HLC) binds here.
+///
+/// `key` (Phase B, RFC 028 §7): the idempotency claim, carried IN the entry
+/// so claim and op are one atomic replicated unit — committed together,
+/// truncated together, snapshot together. This is what makes the two
+/// crash-scenario halves (pre-registered by the trading workspace, who
+/// converged on the identical invariant independently) hold by
+/// construction: a committed-but-unacked keyed entry survives failover and
+/// dedupes the retry (claim never lost after commit); a tentative keyed
+/// entry truncates WITH its claim, so the retry re-executes cleanly (no
+/// settled-claim-without-effect ghost).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LogEntry {
     pub term: Term,
     pub payload: u64,
+    pub key: Option<u64>,
+}
+
+impl LogEntry {
+    /// Unkeyed entry (the common case; also every pre-Phase-B test entry).
+    pub fn unkeyed(term: Term, payload: u64) -> Self {
+        Self {
+            term,
+            payload,
+            key: None,
+        }
+    }
+}
+
+/// Outcome of a keyed proposal at the leader's origin ingress (RFC 028 §7:
+/// claims are checked at ORIGIN, carried in the log, and never re-gated at
+/// apply).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeyedProposal {
+    /// Fresh claim: the entry was appended at `index`; effects carry the
+    /// persist + fan-out. The caller acks its client only when the commit
+    /// index reaches `index` (quorum-durable tier — never before).
+    Appended { index: u64, effects: Vec<Effect> },
+    /// The key already claims `index`, and that entry is COMMITTED: a
+    /// dedupe hit. The caller answers the retry with the ORIGINAL entry's
+    /// outcome immediately — this is the "committed but client never
+    /// learned" failover half.
+    DuplicateCommitted { index: u64 },
+    /// The key claims `index` but that entry is NOT yet committed (in
+    /// flight, possibly from this same client's earlier attempt). The
+    /// caller waits for commit (or its loss by truncation) — it must NOT
+    /// append a second entry, and must NOT report success yet.
+    DuplicatePending { index: u64 },
 }
 
 /// Wire messages for the replica layer.
@@ -173,6 +215,11 @@ pub struct ReplicaCore {
     match_index: BTreeMap<NodeId, u64>,
     /// Leader bookkeeping: next index to send per voter.
     next_index: BTreeMap<NodeId, u64>,
+    /// Phase B (RFC 028 §7): key → log index of the entry claiming it.
+    /// Maintained incrementally on append/truncate and rebuilt from the
+    /// restored log at construction — the claims table IS the log's keyed
+    /// entries, never a separate source of truth.
+    claims: BTreeMap<u64, u64>,
     votes: BTreeSet<NodeId>,
     pre_votes: BTreeSet<NodeId>,
     use_pre_vote: bool,
@@ -192,6 +239,13 @@ impl ReplicaCore {
     ) -> Self {
         debug_assert!(voters.contains(&id), "a core's own id must be a voter");
         let durable_len = restored_log.len() as u64;
+        // Rebuild the claims table from the restored log: claims live IN
+        // keyed entries, so a crash can never separate a claim from its op.
+        let claims = restored_log
+            .iter()
+            .enumerate()
+            .filter_map(|(i, e)| e.key.map(|k| (k, i as u64 + 1)))
+            .collect();
         Self {
             id,
             voters,
@@ -203,6 +257,7 @@ impl ReplicaCore {
             commit: 0,
             match_index: BTreeMap::new(),
             next_index: BTreeMap::new(),
+            claims,
             votes: BTreeSet::new(),
             pre_votes: BTreeSet::new(),
             use_pre_vote,
@@ -338,11 +393,47 @@ impl ReplicaCore {
             return None;
         }
         let term = self.current_term();
-        self.log.push(LogEntry { term, payload });
+        self.log.push(LogEntry::unkeyed(term, payload));
         let mut out = vec![self.stage_log()];
         // Fan out eagerly; success responses confirm durable acceptance.
         self.append_effects_for_followers(&mut out);
         Some(out)
+    }
+
+    /// Keyed proposal (Phase B, RFC 028 §7). The claim check happens HERE —
+    /// origin ingress — against the claims table rebuilt from the log:
+    /// a key claimed by a committed entry dedupes; a key claimed by an
+    /// in-flight entry parks the retry (no second append, no premature
+    /// success); a fresh key appends an entry that CARRIES the claim.
+    /// Leader-only; `None` = redirect to the leader.
+    ///
+    /// The caller's ack contract (the pre-registered twin properties):
+    /// report success for `index` only once `commit_index() >= index`
+    /// (never-success-without-durable-effect), and never append the same
+    /// key twice while it is claimed (never-double-write). Both halves are
+    /// proven in the simulator across failover/quarantine interleavings.
+    pub fn propose_keyed(&mut self, key: u64, payload: u64) -> Option<KeyedProposal> {
+        if self.role != Role::Leader {
+            return None;
+        }
+        if let Some(&index) = self.claims.get(&key) {
+            return Some(if index <= self.commit {
+                KeyedProposal::DuplicateCommitted { index }
+            } else {
+                KeyedProposal::DuplicatePending { index }
+            });
+        }
+        let term = self.current_term();
+        self.log.push(LogEntry {
+            term,
+            payload,
+            key: Some(key),
+        });
+        let index = self.log_len();
+        self.claims.insert(key, index);
+        let mut effects = vec![self.stage_log()];
+        self.append_effects_for_followers(&mut effects);
+        Some(KeyedProposal::Appended { index, effects })
     }
 
     /// Leader heartbeat tick (driver timer): send each follower its next
@@ -715,12 +806,28 @@ impl ReplicaCore {
                         }
                         return effects;
                     }
+                    // The claim dies WITH its truncated entry (the atomic
+                    // unit, RFC 028 §7): remove keys owned by the removed
+                    // suffix so a re-proposed key can claim afresh.
+                    for removed in self.log.iter().skip(idx as usize - 1) {
+                        if let Some(k) = removed.key {
+                            if self.claims.get(&k) >= Some(&idx) {
+                                self.claims.remove(&k);
+                            }
+                        }
+                    }
                     self.log.truncate(idx as usize - 1);
                     self.log.push(*e);
+                    if let Some(k) = e.key {
+                        self.claims.insert(k, idx);
+                    }
                     changed = true;
                 }
                 None => {
                     self.log.push(*e);
+                    if let Some(k) = e.key {
+                        self.claims.insert(k, idx);
+                    }
                     changed = true;
                 }
             }
@@ -848,10 +955,7 @@ impl ReplicaCore {
         out.push(Effect::BecameLeader { term });
         // §5.4.2 no-op: gives the new term an entry so the prior-term
         // suffix can commit by implication.
-        self.log.push(LogEntry {
-            term,
-            payload: NOOP_PAYLOAD,
-        });
+        self.log.push(LogEntry::unkeyed(term, NOOP_PAYLOAD));
         out.push(self.stage_log());
         self.append_effects_for_followers(out);
     }
@@ -862,10 +966,7 @@ impl ReplicaCore {
         debug_assert!(self.pending.is_some());
         self.init_leader_state(term);
         self.hold(Effect::BecameLeader { term });
-        self.log.push(LogEntry {
-            term,
-            payload: NOOP_PAYLOAD,
-        });
+        self.log.push(LogEntry::unkeyed(term, NOOP_PAYLOAD));
         let _ = self.stage_log(); // coalesces into the pending persist
     }
 

--- a/crates/yantrikdb-server/src/yrp/sim.rs
+++ b/crates/yantrikdb-server/src/yrp/sim.rs
@@ -27,7 +27,7 @@ use super::bootstrap::{
     inspect, BootDecision, BootstrapEffect, Integrity, QuarantineReason, QuarantinedNode,
     RecoveredState, RejoinMessage,
 };
-use super::replica::{Effect, LogEntry, Message, ReplicaCore, Role, NOOP_PAYLOAD};
+use super::replica::{Effect, KeyedProposal, LogEntry, Message, ReplicaCore, Role, NOOP_PAYLOAD};
 use super::types::{ClusterId, HardState, LogPosition, NodeId, Term};
 
 /// The sim's cluster identity (all healthy nodes share it; alien-state tests
@@ -104,6 +104,9 @@ struct Sim {
     /// Gate A #4 ledgers: preserve-before-resync + corruption alarms.
     preserves: Vec<NodeId>,
     alarms: Vec<(NodeId, Vec<QuarantineReason>)>,
+    /// Phase B claim ledger: key → (index, payload) of the ONE committed
+    /// entry ever allowed to hold it (never-double-write, globally).
+    keyed_committed: BTreeMap<u64, (u64, u64)>,
 }
 
 impl Sim {
@@ -150,6 +153,7 @@ impl Sim {
             freshness_at_grant: Vec::new(),
             preserves: Vec::new(),
             alarms: Vec::new(),
+            keyed_committed: BTreeMap::new(),
         }
     }
 
@@ -223,6 +227,19 @@ impl Sim {
                     "AUTHORITY SAFETY VIOLATED: index {i} applied with two \
                      different entries ({prev:?} vs {e:?}, second by {id:?})"
                 ),
+            }
+            // Phase B never-double-write: one committed entry per key, ever.
+            if let Some(k) = e.key {
+                match self.keyed_committed.get(&k) {
+                    None => {
+                        self.keyed_committed.insert(k, (i, e.payload));
+                    }
+                    Some((pi, pp)) => assert_eq!(
+                        (*pi, *pp),
+                        (i, e.payload),
+                        "CLAIM DOUBLE-WRITE: key {k} committed at two places"
+                    ),
+                }
             }
         }
         let node = self.nodes.get_mut(&id).unwrap();
@@ -546,10 +563,7 @@ fn entries(terms: &[u64]) -> Vec<LogEntry> {
     terms
         .iter()
         .enumerate()
-        .map(|(i, t)| LogEntry {
-            term: Term(*t),
-            payload: 1000 + i as u64, // distinct, non-NOOP payloads
-        })
+        .map(|(i, t)| LogEntry::unkeyed(Term(*t), 1000 + i as u64))
         .collect()
 }
 
@@ -1237,4 +1251,242 @@ fn codex_duplicate_response_does_not_regress_next_index() {
     );
     sim.drain();
     sim.check_all();
+}
+
+// ── tests: Phase B — claim-in-log (RFC 028 §7) ─────────────────────
+
+impl Sim {
+    /// Sim driver for a keyed proposal: runs any effects, returns the
+    /// outcome. Mirrors what the production API layer will do.
+    fn propose_keyed(&mut self, id: NodeId, key: u64, payload: u64) -> Option<KeyedProposal> {
+        let core = self.nodes.get_mut(&id).unwrap().core.as_mut()?;
+        let outcome = core.propose_keyed(key, payload)?;
+        if let KeyedProposal::Appended { effects, index } = outcome {
+            self.run_effects(id, effects, None);
+            return Some(KeyedProposal::Appended {
+                index,
+                effects: Vec::new(), // consumed
+            });
+        }
+        Some(outcome)
+    }
+}
+
+/// Trading scenario (a): "fill committed but claim lost" must be
+/// impossible — a committed keyed entry SURVIVES failover, and the retry
+/// dedupes against it instead of re-executing. (The claim rides in the
+/// entry; committing the entry commits the claim.)
+#[test]
+fn keyed_commit_survives_failover_and_dedupes_retry() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 71, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    // Keyed write commits cluster-wide; the CLIENT never learns (leader
+    // crashes before responding).
+    let out = sim.propose_keyed(NodeId(1), 77, 707).expect("leader");
+    let orig_index = match out {
+        KeyedProposal::Appended { index, .. } => index,
+        other => panic!("expected fresh append, got {other:?}"),
+    };
+    sim.drain();
+    assert!(
+        sim.keyed_committed.contains_key(&77),
+        "keyed entry committed"
+    );
+    sim.crash(NodeId(1));
+    // Failover; the new leader commits the prior suffix by implication.
+    sim.timeout(NodeId(2), None);
+    sim.drain();
+    // The client retries the SAME keyed request on the new leader.
+    let retry = sim.propose_keyed(NodeId(2), 77, 707).expect("new leader");
+    match retry {
+        KeyedProposal::DuplicateCommitted { index } => {
+            assert_eq!(index, orig_index, "dedupe must return the ORIGINAL entry");
+        }
+        other => panic!("retry after committed failover must dedupe, got {other:?}"),
+    }
+    sim.check_all();
+    assert_eq!(
+        sim.keyed_committed.get(&77).map(|(i, p)| (*i, *p)),
+        Some((orig_index, 707)),
+        "exactly one committed effect for the key"
+    );
+}
+
+/// Trading scenario (b): "claim settled but commit rolled back" must be
+/// impossible — a TENTATIVE keyed entry truncates WITH its claim, so the
+/// retry re-executes cleanly on the new leader and exactly one effect
+/// commits, ever.
+#[test]
+fn keyed_tentative_loss_reexecutes_cleanly() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 73, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    // Partition the leader; its keyed write stays tentative forever.
+    sim.cut.insert((NodeId(1), NodeId(2)));
+    sim.cut.insert((NodeId(1), NodeId(3)));
+    let out = sim.propose_keyed(NodeId(1), 88, 808).expect("stale leader");
+    assert!(matches!(out, KeyedProposal::Appended { .. }));
+    sim.drain();
+    assert!(
+        !sim.keyed_committed.contains_key(&88),
+        "tentative keyed write must not commit without a quorum"
+    );
+    // Majority elects a new leader; the client retries there.
+    sim.timeout(NodeId(2), None);
+    sim.drain();
+    let retry = sim.propose_keyed(NodeId(2), 88, 808).expect("new leader");
+    let new_index = match retry {
+        KeyedProposal::Appended { index, .. } => index,
+        other => panic!("retry after tentative loss must re-execute, got {other:?}"),
+    };
+    sim.drain();
+    // Heal: the stale leader truncates its tentative entry AND its claim,
+    // then adopts the canonical keyed entry.
+    sim.cut.clear();
+    sim.heartbeat(NodeId(2));
+    sim.drain();
+    sim.heartbeat(NodeId(2));
+    sim.drain();
+    sim.check_all();
+    assert_eq!(
+        sim.keyed_committed.get(&88).map(|(i, p)| (*i, *p)),
+        Some((new_index, 808)),
+        "exactly one committed effect, at the canonical index"
+    );
+    // The healed ex-leader holds the canonical keyed entry.
+    let n1 = sim.nodes[&NodeId(1)].core.as_ref().unwrap();
+    assert_eq!(
+        n1.entry(new_index).and_then(|e| e.key),
+        Some(88),
+        "healed node holds the canonical keyed entry"
+    );
+}
+
+/// Same-leader retry semantics: a pending claim parks (no second append,
+/// no premature success); after commit the same retry dedupes.
+#[test]
+fn keyed_retry_pending_parks_then_dedupes() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 79, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    // Propose but do NOT deliver anything yet: claim is pending.
+    let core = sim
+        .nodes
+        .get_mut(&NodeId(1))
+        .unwrap()
+        .core
+        .as_mut()
+        .unwrap();
+    let out1 = core.propose_keyed(99, 909).unwrap();
+    let index = match &out1 {
+        KeyedProposal::Appended { index, .. } => *index,
+        other => panic!("fresh append expected, got {other:?}"),
+    };
+    // Immediate retry while pending: parked, same index, NO new entry.
+    let out2 = core.propose_keyed(99, 909).unwrap();
+    assert_eq!(out2, KeyedProposal::DuplicatePending { index });
+    let log_len_before = core.log_len();
+    // Run the pending effects (persist + fan-out) to completion.
+    if let KeyedProposal::Appended { effects, .. } = out1 {
+        sim.run_effects(NodeId(1), effects, None);
+    }
+    sim.drain();
+    let core = sim
+        .nodes
+        .get_mut(&NodeId(1))
+        .unwrap()
+        .core
+        .as_mut()
+        .unwrap();
+    assert_eq!(
+        core.log_len(),
+        log_len_before,
+        "no second append for the key"
+    );
+    let out3 = core.propose_keyed(99, 909).unwrap();
+    assert_eq!(out3, KeyedProposal::DuplicateCommitted { index });
+    sim.check_all();
+}
+
+/// The mcp wire-contract property + its twin, under chaos: keyed retries
+/// fired at random nodes across elections, partitions, crashes,
+/// torn-quarantines and rejoins never double-commit a key (ledger-asserted
+/// on every commit) — and every DuplicateCommitted answer refers to a key
+/// with exactly one committed effect (success implies durable effect).
+#[test]
+fn seeded_soak_keyed_claims_hold_under_chaos() {
+    for seed in 1..15u64 {
+        let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, seed, false);
+        let keys = [11u64, 22, 33, 44];
+        for _step in 0..300 {
+            let ids = [NodeId(1), NodeId(2), NodeId(3)];
+            match sim.rng.next() % 14 {
+                0 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_some() {
+                        sim.timeout(id, None);
+                    }
+                }
+                1 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_some() && sim.rng.chance(10) {
+                        if sim.rng.chance(40) {
+                            sim.crash_torn(id);
+                        } else {
+                            sim.crash(id);
+                        }
+                    }
+                }
+                2 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_none() && sim.nodes[&id].quarantined.is_none() {
+                        sim.restart_via_bootstrap(id);
+                    }
+                }
+                3 | 4 => {
+                    // The property under test: keyed retries at random nodes.
+                    let id = ids[sim.rng.pick(3)];
+                    let k = keys[sim.rng.pick(keys.len())];
+                    if let Some(KeyedProposal::DuplicateCommitted { .. }) =
+                        sim.propose_keyed(id, k, k * 10)
+                    {
+                        // Success answer implies a durable effect exists.
+                        assert!(
+                            sim.keyed_committed.contains_key(&k),
+                            "DuplicateCommitted for key {k} without a \
+                             committed effect (ghost success)"
+                        );
+                    }
+                }
+                5 => {
+                    let id = ids[sim.rng.pick(3)];
+                    sim.heartbeat(id);
+                }
+                6 => {
+                    let id = ids[sim.rng.pick(3)];
+                    let hint = ids[sim.rng.pick(3)];
+                    if id != hint {
+                        sim.tick_rejoin(id, hint);
+                    }
+                }
+                7 => {
+                    let a = ids[sim.rng.pick(3)];
+                    let b = ids[sim.rng.pick(3)];
+                    if a != b {
+                        let kk = (a.min(b), a.max(b));
+                        if !sim.cut.remove(&kk) {
+                            sim.cut.insert(kk);
+                        }
+                    }
+                }
+                _ => {
+                    sim.deliver_one(None);
+                }
+            }
+        }
+        sim.cut.clear();
+        sim.drain();
+        sim.check_all(); // includes the per-key single-commit ledger
+    }
 }


### PR DESCRIPTION
## Summary
The protocol half of the idempotency contract — claims ride **in** log entries (one atomic replicated unit), which is exactly what the `/v1/remember` cluster-mode 501 refusal awaits. Origin-ingress claim check via `propose_keyed()`: fresh → claim-carrying append; committed-claim → dedupe with original index; pending-claim → park (no second append, no premature success). Claims table is derived state — rebuilt from the log on restart, pruned with truncation.

## Breaking-change ledger (agreement #2)
None — internal pure-logic module, still unwired.

## Proof: all five pre-registered community properties, in sim
- **trading (a)** `keyed_commit_survives_failover_and_dedupes_retry` — committed-but-unacked write survives failover; retry dedupes to the ORIGINAL entry
- **trading (b)** `keyed_tentative_loss_reexecutes_cleanly` — tentative claim truncates with its entry; retry re-executes; exactly one committed effect ever
- **mcp wire-contract + trading's twin** `seeded_soak_keyed_claims_hold_under_chaos` — 14-seed chaos soak (elections, partitions, crashes, torn-quarantines, rejoins) with keyed retries at random nodes: a global ledger asserts **one committed entry per key, ever**, and every `DuplicateCommitted` answer implies a durable effect exists (no ghost success)
- `keyed_retry_pending_parks_then_dedupes` — same-leader retry semantics

**33/33 yrp tests green · full workspace green.**

## Next Phase B slices
Witness data-quorum split → snapshots/GC → capability activation → runtime integration (gateway binds `/v1/remember` keyed path to `propose_keyed`, replacing the 501).

🤖 Generated with [Claude Code](https://claude.com/claude-code)