### PR TITLE
feat(yrp): Phase B slice 3 — snapshots, log compaction, GC (RFC 028 §6)

### DIFF
--- a/crates/yantrikdb-server/src/yrp/bootstrap.rs
+++ b/crates/yantrikdb-server/src/yrp/bootstrap.rs
@@ -36,8 +36,10 @@
 //! clone/rollback fencing) and true membership change; in A2's fixed-voter
 //! world, a rejoining node re-enters as the same voter after resync.
 
+use std::collections::BTreeMap;
+
 use super::replica::LogEntry;
-use super::types::{ClusterId, HardState, NodeId, Term};
+use super::types::{ClusterId, HardState, LogPosition, NodeId, Term};
 
 /// What the boot path recovered from disk. The driver fills this in from
 /// real storage (with real checksums); the sim injects damage.
@@ -201,7 +203,13 @@ pub enum RejoinMessage {
     Grant {
         cluster_id: ClusterId,
         term: Term,
+        /// Compaction base of the granted state (ZERO when uncompacted).
+        base: LogPosition,
+        /// Log suffix above `base`.
         log: Vec<LogEntry>,
+        /// Idempotency claims through the granted frontier (RFC 028 §7 +
+        /// §6: claims survive compaction by riding the snapshot).
+        claims: BTreeMap<u64, u64>,
         commit: u64,
         verified: bool,
     },
@@ -226,7 +234,9 @@ pub enum BootstrapEffect {
     AdoptSnapshot {
         cluster_id: ClusterId,
         hard: HardState,
+        base: LogPosition,
         log: Vec<LogEntry>,
+        claims: BTreeMap<u64, u64>,
     },
 }
 
@@ -320,7 +330,9 @@ impl QuarantinedNode {
         let RejoinMessage::Grant {
             cluster_id,
             term,
+            base,
             log,
+            claims,
             commit: _,
             verified,
         } = grant
@@ -367,7 +379,9 @@ impl QuarantinedNode {
                 current_term: term,
                 voted_for: Some(from),
             },
+            base,
             log,
+            claims,
         }]
     }
 }
@@ -483,7 +497,9 @@ mod tests {
         let unverified = RejoinMessage::Grant {
             cluster_id: CLUSTER,
             term: Term(4),
+            base: LogPosition::ZERO,
             log: Vec::new(),
+            claims: BTreeMap::new(),
             commit: 0,
             verified: false,
         };
@@ -494,7 +510,9 @@ mod tests {
         let verified = RejoinMessage::Grant {
             cluster_id: CLUSTER,
             term: Term(4),
+            base: LogPosition::ZERO,
             log: Vec::new(),
+            claims: BTreeMap::new(),
             commit: 0,
             verified: true,
         };
@@ -515,7 +533,9 @@ mod tests {
         let alien = RejoinMessage::Grant {
             cluster_id: ClusterId(99),
             term: Term(4),
+            base: LogPosition::ZERO,
             log: Vec::new(),
+            claims: BTreeMap::new(),
             commit: 0,
             verified: true,
         };

--- a/crates/yantrikdb-server/src/yrp/replica.rs
+++ b/crates/yantrikdb-server/src/yrp/replica.rs
@@ -108,6 +108,22 @@ pub enum KeyedProposal {
     DuplicatePending { index: u64 },
 }
 
+/// A log-compaction snapshot (RFC 028 §6, pure-model form). The production
+/// manifest binds an engine checkpoint (content hash, membership epoch,
+/// schema/capability/generation state); the pure core carries what the
+/// PROTOCOL needs:
+/// - `last`: the exact frontier the snapshot covers (entries ≤ last.index
+///   are gone from the log);
+/// - `claims`: every idempotency claim at or below the frontier — sol
+///   P1-9's rule made structural: compaction may never create a window
+///   where a GC'd claim can be replayed, so the claims RIDE the snapshot
+///   exactly as they rode the entries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Snapshot {
+    pub last: LogPosition,
+    pub claims: BTreeMap<u64, u64>,
+}
+
 /// Wire messages for the replica layer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Message {
@@ -139,6 +155,14 @@ pub enum Message {
         entries: Vec<LogEntry>,
         commit: u64,
     },
+    /// Snapshot install (leader → straggler whose next index fell below
+    /// the leader's compaction base). Acked with a normal AppendResponse
+    /// at `snapshot.last.index` once durable.
+    InstallSnapshot {
+        term: Term,
+        leader: NodeId,
+        snapshot: Snapshot,
+    },
     /// `last_index` is the acceptor's last DURABLE matching index on
     /// success — the per-write quorum-confirmation signal. A success
     /// response for newly appended entries is sent only after they are
@@ -158,7 +182,9 @@ pub enum Effect {
     /// batch coalesce: persisting the last one seen satisfies all of them.
     Persist {
         hard: HardState,
+        base: LogPosition,
         log: Vec<LogEntry>,
+        claims: BTreeMap<u64, u64>,
     },
     Send {
         to: NodeId,
@@ -178,6 +204,12 @@ pub enum Effect {
     /// entries `(previous commit, to]` to the state machine, in order.
     CommitAdvanced {
         to: u64,
+    },
+    /// A snapshot was adopted: the driver replaces its applied state with
+    /// the checkpoint at `last_index` (no per-entry replay — the entries
+    /// are gone; the state arrives wholesale, like A2's rejoin adoption).
+    InstallState {
+        last_index: u64,
     },
 }
 
@@ -204,7 +236,11 @@ pub struct ReplicaCore {
     persisted_hard: HardState,
     /// Durable log length (entries `1..=durable_len` survive a crash).
     durable_len: u64,
-    /// The in-memory canonical log, 1-indexed (`log[0]` ↔ index 1).
+    /// Compaction base (RFC 028 §6): the last position covered by the
+    /// adopted/created snapshot. Entries ≤ base.index are compacted away;
+    /// `log[0]` holds absolute index `base.index + 1`. ZERO = uncompacted.
+    base: LogPosition,
+    /// The in-memory canonical log SUFFIX above `base`.
     log: Vec<LogEntry>,
     /// In-flight persist + withheld messages. Lost on crash.
     pending: Option<Pending>,
@@ -260,6 +296,7 @@ impl ReplicaCore {
             voters,
             persisted_hard: restored_hard,
             durable_len,
+            base: LogPosition::ZERO,
             log: restored_log,
             pending: None,
             role: Role::Follower,
@@ -284,6 +321,69 @@ impl ReplicaCore {
             "a witness cannot already hold a data role"
         );
         self.witnesses = witnesses;
+    }
+
+    /// Restore a COMPACTED node: `base` + `snapshot_claims` come from the
+    /// durable snapshot; `restored_log` is the suffix above the base. The
+    /// claims table = snapshot claims + suffix claims (a suffix entry may
+    /// re-claim a key whose original was compacted only if the original
+    /// was superseded — in practice suffix wins, matching log order).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_from_durable(
+        id: NodeId,
+        voters: BTreeSet<NodeId>,
+        restored_hard: HardState,
+        base: LogPosition,
+        restored_log: Vec<LogEntry>,
+        snapshot_claims: BTreeMap<u64, u64>,
+        use_pre_vote: bool,
+    ) -> Self {
+        let mut core = Self::new(id, voters, restored_hard, Vec::new(), use_pre_vote);
+        core.base = base;
+        core.claims = snapshot_claims;
+        // The state below base is adopted wholesale (checkpoint semantics).
+        core.commit = base.index;
+        for e in restored_log {
+            core.log.push(e);
+            if let Some(k) = e.key {
+                core.claims.insert(k, core.last_index());
+            }
+        }
+        core.durable_len = core.log.len() as u64;
+        core
+    }
+
+    /// Absolute index of the last entry (base + suffix).
+    pub fn last_index(&self) -> u64 {
+        self.base.index + self.log.len() as u64
+    }
+
+    /// The compaction base (snapshot frontier).
+    pub fn base(&self) -> LogPosition {
+        self.base
+    }
+
+    /// Compact the log through `up_to` (absolute index). Only COMMITTED
+    /// entries may compact (RFC 028 §6: every recovery path keeps log
+    /// coverage or a verified snapshot — an uncommitted entry has neither).
+    /// Returns the snapshot the driver persists alongside the suffix; the
+    /// claims table travels in it (sol P1-9).
+    pub fn compact(&mut self, up_to: u64) -> Option<Snapshot> {
+        if up_to <= self.base.index || up_to > self.commit {
+            return None;
+        }
+        let last_term = self.entry(up_to)?.term;
+        let drop = (up_to - self.base.index) as usize;
+        self.log.drain(..drop);
+        self.base = LogPosition {
+            term: last_term.0,
+            index: up_to,
+        };
+        self.durable_len = self.durable_len.saturating_sub(drop as u64);
+        Some(Snapshot {
+            last: self.base,
+            claims: self.claims.clone(),
+        })
     }
 
     // ── accessors ──────────────────────────────────────────────────
@@ -315,10 +415,10 @@ impl ReplicaCore {
 
     /// Entry at 1-based `index`, if present.
     pub fn entry(&self, index: u64) -> Option<&LogEntry> {
-        if index == 0 {
-            return None;
+        if index <= self.base.index {
+            return None; // compacted (or the 0 sentinel)
         }
-        self.log.get(index as usize - 1)
+        self.log.get((index - self.base.index) as usize - 1)
     }
 
     /// Position of the last in-memory log entry (sentinel ZERO when empty).
@@ -329,9 +429,9 @@ impl ReplicaCore {
         match self.log.last() {
             Some(e) => LogPosition {
                 term: e.term.0,
-                index: self.log.len() as u64,
+                index: self.last_index(),
             },
-            None => LogPosition::ZERO,
+            None => self.base,
         }
     }
 
@@ -360,7 +460,9 @@ impl ReplicaCore {
         }
         Effect::Persist {
             hard,
+            base: self.base,
             log: self.log.clone(),
+            claims: self.claims.clone(),
         }
     }
 
@@ -400,7 +502,8 @@ impl ReplicaCore {
             None => return Vec::new(),
         };
         if self.role == Role::Leader {
-            self.match_index.insert(self.id, self.durable_len);
+            self.match_index
+                .insert(self.id, self.base.index + self.durable_len);
             self.try_advance_commit(&mut out);
         }
         out
@@ -451,7 +554,7 @@ impl ReplicaCore {
             payload,
             key: Some(key),
         });
-        let index = self.log_len();
+        let index = self.last_index();
         self.claims.insert(key, index);
         let mut effects = vec![self.stage_log()];
         self.append_effects_for_followers(&mut effects);
@@ -485,19 +588,39 @@ impl ReplicaCore {
     fn send_append_to(&mut self, peer: NodeId, out: &mut Vec<Effect>) {
         let term = self.current_term();
         let next = *self.next_index.get(&peer).unwrap_or(&1);
+        // Straggler below our compaction base: entries are gone — ship the
+        // snapshot instead (the stale-rejoin-beyond-GC path, §6). Claims
+        // ride along, so the GC'd claim can never be replay-lost (P1-9).
+        if next <= self.base.index {
+            let msg = Message::InstallSnapshot {
+                term,
+                leader: self.id,
+                snapshot: Snapshot {
+                    last: self.base,
+                    claims: self.claims.clone(),
+                },
+            };
+            self.hold_or(Effect::Send { to: peer, msg }, out);
+            return;
+        }
         let prev_index = next.saturating_sub(1);
-        let prev = if prev_index == 0 {
-            LogPosition::ZERO
+        let prev = if prev_index == self.base.index {
+            self.base // covers the ZERO sentinel when uncompacted
         } else {
             match self.entry(prev_index) {
                 Some(e) => LogPosition {
                     term: e.term.0,
                     index: prev_index,
                 },
-                None => LogPosition::ZERO,
+                None => self.base,
             }
         };
-        let entries: Vec<LogEntry> = self.log.iter().skip(prev_index as usize).copied().collect();
+        let entries: Vec<LogEntry> = self
+            .log
+            .iter()
+            .skip((prev.index - self.base.index) as usize)
+            .copied()
+            .collect();
         let msg = Message::AppendEntries {
             term,
             leader: self.id,
@@ -560,6 +683,11 @@ impl ReplicaCore {
                 success,
                 last_index,
             } => self.on_append_response(from, term, success, last_index),
+            Message::InstallSnapshot {
+                term,
+                leader: _,
+                snapshot,
+            } => self.on_install_snapshot(from, term, snapshot),
         }
     }
 
@@ -756,7 +884,7 @@ impl ReplicaCore {
                 msg: Message::AppendResponse {
                     term: cur,
                     success: false,
-                    last_index: self.durable_len,
+                    last_index: self.base.index + self.durable_len,
                 },
             }];
         }
@@ -780,10 +908,31 @@ impl ReplicaCore {
             self.effective()
         };
 
+        // Everything at or below our base is COMMITTED here, and committed
+        // entries are globally unique (Gate A #2) — a leader probing below
+        // our base can simply fast-forward to it.
+        if prev.index < self.base.index {
+            let ack = Effect::Send {
+                to: from,
+                msg: Message::AppendResponse {
+                    term,
+                    success: true,
+                    last_index: self.base.index,
+                },
+            };
+            if newer {
+                effects.push(self.stage(adopted));
+                self.hold(ack);
+            } else {
+                self.hold_or(ack, &mut effects);
+            }
+            return effects;
+        }
+
         // Continuity check at `prev` (the append-side of Gate A #2: a hole
         // or a term mismatch means these entries do not extend our history —
         // refuse; the leader backs up).
-        let prev_ok = prev.index == 0
+        let prev_ok = (prev.index == self.base.index && prev.term == self.base.term)
             || self
                 .entry(prev.index)
                 .is_some_and(|e| e.term.0 == prev.term);
@@ -793,7 +942,8 @@ impl ReplicaCore {
                 msg: Message::AppendResponse {
                     term,
                     success: false,
-                    last_index: self.durable_len.min(prev.index.saturating_sub(1)),
+                    last_index: (self.base.index + self.durable_len)
+                        .min(prev.index.saturating_sub(1)),
                 },
             };
             if newer {
@@ -823,7 +973,7 @@ impl ReplicaCore {
                             msg: Message::AppendResponse {
                                 term,
                                 success: false,
-                                last_index: self.durable_len,
+                                last_index: self.base.index + self.durable_len,
                             },
                         };
                         if newer {
@@ -837,14 +987,14 @@ impl ReplicaCore {
                     // The claim dies WITH its truncated entry (the atomic
                     // unit, RFC 028 §7): remove keys owned by the removed
                     // suffix so a re-proposed key can claim afresh.
-                    for removed in self.log.iter().skip(idx as usize - 1) {
+                    for removed in self.log.iter().skip((idx - self.base.index) as usize - 1) {
                         if let Some(k) = removed.key {
                             if self.claims.get(&k) >= Some(&idx) {
                                 self.claims.remove(&k);
                             }
                         }
                     }
-                    self.log.truncate(idx as usize - 1);
+                    self.log.truncate((idx - self.base.index) as usize - 1);
                     self.log.push(*e);
                     if let Some(k) = e.key {
                         self.claims.insert(k, idx);
@@ -876,7 +1026,7 @@ impl ReplicaCore {
                     last_index: if changed {
                         covered
                     } else {
-                        self.durable_len.min(covered)
+                        (self.base.index + self.durable_len).min(covered)
                     },
                 },
             });
@@ -888,7 +1038,7 @@ impl ReplicaCore {
                 msg: Message::AppendResponse {
                     term,
                     success: true,
-                    last_index: self.durable_len.min(covered),
+                    last_index: (self.base.index + self.durable_len).min(covered),
                 },
             };
             self.hold_or(ack, &mut effects);
@@ -939,12 +1089,79 @@ impl ReplicaCore {
                 .next_index
                 .get(&from)
                 .copied()
-                .unwrap_or(self.log_len() + 1);
+                .unwrap_or(self.last_index() + 1);
             let backed = next.saturating_sub(1).clamp(1, last_index + 1).max(floor);
             self.next_index.insert(from, backed);
             self.send_append_to(from, &mut out);
         }
         out
+    }
+
+    /// Adopt a leader's snapshot (we are a straggler below its compaction
+    /// base). Same discipline as every other durable decision: ONE persist,
+    /// ack + InstallState held behind it. A snapshot at or below our own
+    /// commit is stale — ack our durable frontier instead (never regress).
+    fn on_install_snapshot(&mut self, from: NodeId, term: Term, snapshot: Snapshot) -> Vec<Effect> {
+        let mut effects = Vec::new();
+        let cur = self.current_term();
+        if term < cur {
+            return vec![Effect::Send {
+                to: from,
+                msg: Message::AppendResponse {
+                    term: cur,
+                    success: false,
+                    last_index: self.base.index + self.durable_len,
+                },
+            }];
+        }
+        if matches!(self.role, Role::Leader | Role::Candidate) {
+            effects.push(Effect::SteppedDown { term: cur });
+        }
+        self.role = Role::Follower;
+        let newer = term > cur;
+        let adopted = if newer {
+            HardState {
+                current_term: term,
+                voted_for: None,
+            }
+        } else {
+            self.effective()
+        };
+        if snapshot.last.index <= self.commit {
+            // Stale snapshot: our committed state is already ahead.
+            let ack = Effect::Send {
+                to: from,
+                msg: Message::AppendResponse {
+                    term,
+                    success: true,
+                    last_index: self.base.index + self.durable_len,
+                },
+            };
+            if newer {
+                effects.push(self.stage(adopted));
+                self.hold(ack);
+            } else {
+                self.hold_or(ack, &mut effects);
+            }
+            return effects;
+        }
+        // Adopt: checkpoint replaces log prefix AND claims wholesale.
+        let last_index = snapshot.last.index;
+        self.base = snapshot.last;
+        self.log.clear();
+        self.claims = snapshot.claims;
+        self.commit = last_index;
+        effects.push(self.stage(adopted));
+        self.hold(Effect::InstallState { last_index });
+        self.hold(Effect::Send {
+            to: from,
+            msg: Message::AppendResponse {
+                term,
+                success: true,
+                last_index,
+            },
+        });
+        effects
     }
 
     /// The commit rule (Gate A #2): the largest `n` such that a quorum of
@@ -955,7 +1172,7 @@ impl ReplicaCore {
     /// data-bearing voters (witness exclusion).
     fn try_advance_commit(&mut self, out: &mut Vec<Effect>) {
         let cur = self.current_term();
-        let mut n = self.log_len();
+        let mut n = self.last_index();
         while n > self.commit {
             if self.entry(n).map(|e| e.term) == Some(cur) {
                 // Data quorum ONLY: witnesses never count toward commit
@@ -1002,14 +1219,15 @@ impl ReplicaCore {
 
     fn init_leader_state(&mut self, _term: Term) {
         self.role = Role::Leader;
-        let last = self.log_len();
+        let last = self.last_index();
         self.next_index.clear();
         self.match_index.clear();
         for v in self.voters.iter().copied() {
             self.next_index.insert(v, last + 1);
             self.match_index.insert(v, 0);
         }
-        self.match_index.insert(self.id, self.durable_len);
+        self.match_index
+            .insert(self.id, self.base.index + self.durable_len);
     }
 
     fn step_down_to(&mut self, newer: Term, cur: Term) -> Vec<Effect> {
@@ -1036,7 +1254,12 @@ impl ReplicaCore {
     /// Returns `(term, log, commit)` for the driver to wrap into a
     /// `bootstrap::RejoinMessage::Grant`; `None` = not authorized (the
     /// quarantined node stays quarantined and retries — fail closed).
-    pub fn rejoin_grant(&self) -> Option<(Term, Vec<LogEntry>, u64)> {
+    /// Returns `(term, base, durable_suffix, claims, commit)` — the full
+    /// durable picture, snapshot-aware: `base` + `claims` carry compacted
+    /// history, `durable_suffix` the live entries above it.
+    pub fn rejoin_grant(
+        &self,
+    ) -> Option<(Term, LogPosition, Vec<LogEntry>, BTreeMap<u64, u64>, u64)> {
         if self.role != Role::Leader {
             return None;
         }
@@ -1046,16 +1269,17 @@ impl ReplicaCore {
         if !committed_in_current_term {
             return None;
         }
-        // Grant only the DURABLE prefix: a snapshot must never carry entries
-        // our own disk could forget in a crash.
+        // Grant only the DURABLE suffix: a snapshot must never carry
+        // entries our own disk could forget in a crash. Base + claims are
+        // durable by construction (they only advance via persisted state).
         let durable: Vec<LogEntry> = self
             .log
             .iter()
             .take(self.durable_len as usize)
             .copied()
             .collect();
-        let commit = self.commit.min(self.durable_len);
-        Some((cur, durable, commit))
+        let commit = self.commit.min(self.base.index + self.durable_len);
+        Some((cur, self.base, durable, self.claims.clone(), commit))
     }
 
     fn pre_quorum_reached(&self) -> bool {

--- a/crates/yantrikdb-server/src/yrp/sim.rs
+++ b/crates/yantrikdb-server/src/yrp/sim.rs
@@ -27,7 +27,9 @@ use super::bootstrap::{
     inspect, BootDecision, BootstrapEffect, Integrity, QuarantineReason, QuarantinedNode,
     RecoveredState, RejoinMessage,
 };
-use super::replica::{Effect, KeyedProposal, LogEntry, Message, ReplicaCore, Role, NOOP_PAYLOAD};
+use super::replica::{
+    Effect, KeyedProposal, LogEntry, Message, ReplicaCore, Role, Snapshot, NOOP_PAYLOAD,
+};
 use super::types::{ClusterId, HardState, LogPosition, NodeId, Term};
 
 /// The sim's cluster identity (all healthy nodes share it; alien-state tests
@@ -76,7 +78,9 @@ struct SimNode {
     core: Option<ReplicaCore>,
     quarantined: Option<QuarantinedNode>,
     disk_hard: HardState,
+    disk_base: LogPosition,
     disk_log: Vec<LogEntry>,
+    disk_claims: BTreeMap<u64, u64>,
     torn_hard: bool,
     corrupt_log: bool,
     /// Highest index this node has applied (ledgered via CommitAdvanced).
@@ -135,7 +139,13 @@ impl Sim {
                     core: Some(core),
                     quarantined: None,
                     disk_hard: hard,
+                    disk_base: LogPosition::ZERO,
                     disk_log: log.clone(),
+                    disk_claims: log
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(i, e)| e.key.map(|k| (k, i as u64 + 1)))
+                        .collect(),
                     torn_hard: false,
                     corrupt_log: false,
                     applied: 0,
@@ -187,7 +197,12 @@ impl Sim {
         let mut queue: VecDeque<Effect> = effects.into();
         while let Some(eff) = queue.pop_front() {
             match eff {
-                Effect::Persist { hard, log } => {
+                Effect::Persist {
+                    hard,
+                    base,
+                    log,
+                    claims,
+                } => {
                     if crash_at == Some(0) {
                         self.crash(id);
                         return;
@@ -195,7 +210,9 @@ impl Sim {
                     {
                         let node = self.nodes.get_mut(&id).unwrap();
                         node.disk_hard = hard;
+                        node.disk_base = base;
                         node.disk_log = log;
+                        node.disk_claims = claims;
                     }
                     if crash_at == Some(1) {
                         self.crash(id);
@@ -226,6 +243,11 @@ impl Sim {
                 }
                 Effect::SteppedDown { .. } => {}
                 Effect::CommitAdvanced { to } => self.ledger_commit(id, to),
+                Effect::InstallState { last_index } => {
+                    // Checkpoint adoption: applied state arrives wholesale.
+                    let node = self.nodes.get_mut(&id).unwrap();
+                    node.applied = node.applied.max(last_index);
+                }
             }
         }
     }
@@ -386,7 +408,9 @@ impl Sim {
                 BootstrapEffect::AdoptSnapshot {
                     cluster_id: _,
                     hard,
+                    base,
                     log,
+                    claims,
                 } => {
                     // Persist the adopted snapshot, clear damage flags, and
                     // resume as a live follower. Quarantine ends here only.
@@ -395,16 +419,23 @@ impl Sim {
                         "adopt without preserving old state first"
                     );
                     let voters = self.voters.clone();
+                    let w = self.witnesses.clone();
                     let node = self.nodes.get_mut(&id).unwrap();
                     node.disk_hard = hard;
+                    node.disk_base = base;
                     node.disk_log = log.clone();
+                    node.disk_claims = claims.clone();
                     node.torn_hard = false;
                     node.corrupt_log = false;
                     node.quarantined = None;
-                    let mut core = ReplicaCore::new(id, voters, hard, log, false);
-                    core.set_witnesses(self.witnesses.clone());
+                    let mut core =
+                        ReplicaCore::new_from_durable(id, voters, hard, base, log, claims, false);
+                    core.set_witnesses(w);
                     node.core = Some(core);
-                    node.applied = node.applied.min(node.disk_log.len() as u64);
+                    node.applied = node
+                        .applied
+                        .min(node.disk_base.index + node.disk_log.len() as u64)
+                        .max(node.disk_base.index);
                 }
             }
         }
@@ -416,17 +447,22 @@ impl Sim {
         // ONLY what was durably persisted survives. `applied` is clamped to
         // the durable log (the state machine re-applies deterministically;
         // the I2 ledger verifies every re-application is identical).
-        let mut core = ReplicaCore::new(
+        let mut core = ReplicaCore::new_from_durable(
             id,
             voters,
             node.disk_hard,
+            node.disk_base,
             node.disk_log.clone(),
+            node.disk_claims.clone(),
             use_pre_vote,
         );
         core.set_witnesses(self.witnesses.clone());
         node.core = Some(core);
         node.quarantined = None;
-        node.applied = node.applied.min(node.disk_log.len() as u64);
+        node.applied = node
+            .applied
+            .min(node.disk_base.index + node.disk_log.len() as u64)
+            .max(node.disk_base.index);
     }
 
     fn timeout(&mut self, id: NodeId, crash_at: Option<u8>) {
@@ -489,14 +525,16 @@ impl Sim {
                     .get(&m.to)
                     .and_then(|n| n.core.as_ref())
                     .and_then(|c| c.rejoin_grant());
-                if let Some((term, log, commit)) = grant {
+                if let Some((term, base, log, claims, commit)) = grant {
                     self.net.push_back(InFlight {
                         from: m.to,
                         to: asker,
                         msg: Wire::B(RejoinMessage::Grant {
                             cluster_id: CLUSTER,
                             term,
+                            base,
                             log,
+                            claims,
                             commit,
                             // The leader's snapshot is live state: verified.
                             verified: true,
@@ -566,7 +604,7 @@ impl Sim {
             let Some(core) = node.core.as_ref() else {
                 continue;
             };
-            for i in 1..=node.applied {
+            for i in (core.base().index + 1)..=node.applied {
                 if let Some(expected) = self.committed_at.get(&i) {
                     let actual = core.entry(i);
                     assert_eq!(
@@ -1699,6 +1737,260 @@ fn seeded_soak_witness_topology_keyed_claims_hold() {
                     sim.heartbeat(id);
                 }
                 6 => {
+                    let a = ids[sim.rng.pick(3)];
+                    let b = ids[sim.rng.pick(3)];
+                    if a != b {
+                        let kk = (a.min(b), a.max(b));
+                        if !sim.cut.remove(&kk) {
+                            sim.cut.insert(kk);
+                        }
+                    }
+                }
+                _ => {
+                    sim.deliver_one(None);
+                }
+            }
+        }
+        sim.cut.clear();
+        sim.drain();
+        sim.check_all();
+    }
+}
+
+// ── tests: Phase B — snapshots + log compaction + GC (RFC 028 §6) ──
+
+/// sol P1-9 as a test: compaction must never open a replay window for a
+/// GC'd claim. A keyed entry commits, the leader compacts it away — and
+/// the keyed retry STILL dedupes, because the claim rode into the
+/// snapshot state.
+#[test]
+fn compaction_preserves_claims_no_replay_window() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 101, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    let out = sim.propose_keyed(NodeId(1), 121, 1210).expect("leader");
+    let orig_index = match out {
+        KeyedProposal::Appended { index, .. } => index,
+        other => panic!("fresh append expected, got {other:?}"),
+    };
+    sim.drain();
+    // Compact through the commit index (entries GONE from the log).
+    {
+        let core = sim
+            .nodes
+            .get_mut(&NodeId(1))
+            .unwrap()
+            .core
+            .as_mut()
+            .unwrap();
+        let commit = core.commit_index();
+        let snap = core.compact(commit).expect("compaction through commit");
+        assert_eq!(snap.last.index, commit);
+        assert!(
+            snap.claims.contains_key(&121),
+            "claim must ride the snapshot"
+        );
+        assert!(core.entry(orig_index).is_none(), "entry compacted away");
+    }
+    // The retry after compaction: STILL a dedupe hit at the original index.
+    let retry = sim.propose_keyed(NodeId(1), 121, 1210).expect("leader");
+    assert_eq!(
+        retry,
+        KeyedProposal::DuplicateCommitted { index: orig_index },
+        "compaction opened a claim replay window"
+    );
+    sim.check_all();
+}
+
+/// Compaction refuses to touch uncommitted entries (every recovery path
+/// keeps log coverage or a verified snapshot — an uncommitted entry has
+/// neither).
+#[test]
+fn compaction_refuses_uncommitted() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 103, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    // Partition: new proposals stay tentative.
+    sim.cut.insert((NodeId(1), NodeId(2)));
+    sim.cut.insert((NodeId(1), NodeId(3)));
+    assert!(sim.propose(NodeId(1), 131));
+    sim.drain();
+    let core = sim
+        .nodes
+        .get_mut(&NodeId(1))
+        .unwrap()
+        .core
+        .as_mut()
+        .unwrap();
+    let commit = core.commit_index();
+    let tentative_tip = core.last_index();
+    assert!(tentative_tip > commit);
+    assert!(
+        core.compact(tentative_tip).is_none(),
+        "compacted an uncommitted entry"
+    );
+    assert!(
+        core.compact(commit).is_some(),
+        "committed compaction refused"
+    );
+}
+
+/// The stale-rejoin-beyond-GC path: a follower that slept through
+/// compaction gets an InstallSnapshot (entries are gone), adopts the
+/// checkpoint + claims wholesale, and then streams the live suffix.
+#[test]
+fn straggler_beyond_gc_recovers_via_snapshot_install() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 107, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    // Node 3 goes dark; the cluster commits keyed + unkeyed entries.
+    sim.crash(NodeId(3));
+    let out = sim.propose_keyed(NodeId(1), 141, 1410).expect("leader");
+    let keyed_index = match out {
+        KeyedProposal::Appended { index, .. } => index,
+        other => panic!("{other:?}"),
+    };
+    for p in [142, 143] {
+        assert!(sim.propose(NodeId(1), p));
+    }
+    sim.drain();
+    // Leader compacts through commit: node 3's catch-up data is GONE.
+    {
+        let core = sim
+            .nodes
+            .get_mut(&NodeId(1))
+            .unwrap()
+            .core
+            .as_mut()
+            .unwrap();
+        let commit = core.commit_index();
+        core.compact(commit).expect("compact");
+    }
+    // More live entries above the base.
+    assert!(sim.propose(NodeId(1), 144));
+    sim.drain();
+    // Node 3 returns from its stale (empty) disk and the leader heartbeats:
+    // next_index falls below the base → InstallSnapshot → adoption → the
+    // live suffix streams on top.
+    sim.restart(NodeId(3), false);
+    sim.heartbeat(NodeId(1));
+    sim.drain();
+    sim.heartbeat(NodeId(1));
+    sim.drain();
+    sim.check_all();
+    let n3 = sim.nodes[&NodeId(3)].core.as_ref().unwrap();
+    assert!(
+        n3.base().index >= keyed_index,
+        "straggler did not adopt the snapshot (base {:?})",
+        n3.base()
+    );
+    assert!(
+        sim.nodes[&NodeId(3)].applied >= keyed_index,
+        "adopted state not applied"
+    );
+    // And the adopted claims dedupe correctly if node 3 ever leads: its
+    // claims table knows key 141.
+    assert!(
+        sim.committed_at.values().any(|e| e.payload == 144),
+        "post-snapshot suffix replicated"
+    );
+}
+
+/// A stale InstallSnapshot (at or below the follower's commit) must never
+/// regress state — acked with the current durable frontier, not adopted.
+#[test]
+fn stale_snapshot_never_regresses() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 109, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    for p in [151, 152] {
+        assert!(sim.propose(NodeId(1), p));
+    }
+    sim.drain();
+    let n2_commit_before = sim.nodes[&NodeId(2)].core.as_ref().unwrap().commit_index();
+    let n2_last_before = sim.nodes[&NodeId(2)].core.as_ref().unwrap().last_index();
+    // Forge a STALE snapshot (frontier at index 1 only) from the leader.
+    let effects = sim
+        .nodes
+        .get_mut(&NodeId(2))
+        .unwrap()
+        .core
+        .as_mut()
+        .unwrap()
+        .on_message(
+            NodeId(1),
+            Message::InstallSnapshot {
+                term: Term(1),
+                leader: NodeId(1),
+                snapshot: Snapshot {
+                    last: LogPosition { term: 1, index: 1 },
+                    claims: BTreeMap::new(),
+                },
+            },
+            false,
+        );
+    sim.run_effects(NodeId(2), effects, None);
+    sim.drain();
+    let n2 = sim.nodes[&NodeId(2)].core.as_ref().unwrap();
+    assert_eq!(n2.commit_index(), n2_commit_before, "commit regressed");
+    assert_eq!(n2.last_index(), n2_last_before, "log regressed");
+    sim.check_all();
+}
+
+/// Chaos with compaction in the schedule: leaders compact through commit at
+/// random; stragglers recover via snapshot; keyed retries keep both claim
+/// properties; every invariant holds.
+#[test]
+fn seeded_soak_with_compaction_invariants_hold() {
+    for seed in 1..12u64 {
+        let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, seed, false);
+        let keys = [61u64, 62, 63];
+        for _step in 0..300 {
+            let ids = [NodeId(1), NodeId(2), NodeId(3)];
+            match sim.rng.next() % 14 {
+                0 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_some() {
+                        sim.timeout(id, None);
+                    }
+                }
+                1 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_some() && sim.rng.chance(12) {
+                        sim.crash(id);
+                    }
+                }
+                2 => {
+                    let id = ids[sim.rng.pick(3)];
+                    if sim.nodes[&id].core.is_none() && sim.nodes[&id].quarantined.is_none() {
+                        sim.restart(id, false);
+                    }
+                }
+                3 | 4 => {
+                    let id = ids[sim.rng.pick(3)];
+                    let k = keys[sim.rng.pick(keys.len())];
+                    if let Some(KeyedProposal::DuplicateCommitted { .. }) =
+                        sim.propose_keyed(id, k, k * 10)
+                    {
+                        assert!(sim.keyed_committed.contains_key(&k));
+                    }
+                }
+                5 => {
+                    // Random compaction through commit on any live node —
+                    // the persist of the compacted shape rides the next
+                    // staged persist; force one via a heartbeat after.
+                    let id = ids[sim.rng.pick(3)];
+                    if let Some(core) = sim.nodes.get_mut(&id).unwrap().core.as_mut() {
+                        let c = core.commit_index();
+                        let _ = core.compact(c);
+                    }
+                    sim.heartbeat(id);
+                }
+                6 => {
+                    let id = ids[sim.rng.pick(3)];
+                    sim.heartbeat(id);
+                }
+                7 => {
                     let a = ids[sim.rng.pick(3)];
                     let b = ids[sim.rng.pick(3)];
                     if a != b {


### PR DESCRIPTION
## Summary
Log compaction + snapshot install for the YRP core. The load-bearing design decision: **the snapshot carries the claims table**, so sol P1-9 (compaction must never let a GC'd idempotency claim be replayed) holds *by construction* — claims are part of the durable unit wherever it lives: entry → truncated with it; snapshot → adopted with it.

## Breaking-change ledger (agreement #2)
None — internal pure-logic module, unwired.

## Mechanics
`base: LogPosition` compaction frontier with fully base-aware arithmetic · `compact()` committed-only (§6 retention rule) · `InstallSnapshot` for stragglers below the base, adoption = checkpoint semantics (log + claims wholesale, persist-gated, stale snapshots refused — never a regression) · leaders probing below a follower's base fast-forward (sound via Gate A #2 committed-uniqueness) · `Persist` now carries the full durable unit `(hard, base, suffix, claims)` · rejoin grants snapshot-aware end-to-end.

## Proof
5 new tests: **P1-9 named** (keyed entry compacted away → retry still dedupes) · refuse-uncommitted · straggler-beyond-GC via install · stale-snapshot-never-regresses · 11-seed chaos soak with random compaction. **42/42 yrp green — all 37 prior tests pass unchanged through the refactor. Full workspace green.**

## Next
Capability activation → runtime integration (the last pure slice, then the driver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)