### PR TITLE
feat(yrp): Phase B slice 4 — capability activation (RFC 028 §3, codex co-designed)

### DIFF
--- a/crates/yantrikdb-server/src/yrp/bootstrap.rs
+++ b/crates/yantrikdb-server/src/yrp/bootstrap.rs
@@ -51,6 +51,9 @@ pub struct RecoveredState {
     /// its checksum verified).
     pub hard: Option<HardState>,
     pub log: Option<Vec<LogEntry>>,
+    /// Active capability bits recorded with the durable state (snapshot
+    /// frontier's view; 0 when uncompacted-and-unactivated).
+    pub active: u32,
     /// The durably recorded applied/commit marker, if any. A marker beyond
     /// the verifiable log is a frontier-beyond-data inconsistency.
     pub commit_marker: u64,
@@ -74,6 +77,7 @@ impl RecoveredState {
             cluster_id: None,
             hard: None,
             log: None,
+            active: 0,
             commit_marker: 0,
             integrity: Integrity {
                 hard_state_verified: true,
@@ -97,6 +101,12 @@ pub enum QuarantineReason {
     LogCorruption,
     /// Commit marker beyond the verifiable log (frontier-beyond-data).
     CommitBeyondLog,
+    /// Recorded active capabilities (or a retained activation entry —
+    /// committed OR NOT, codex F2: an uncommitted unsupported activation
+    /// in the suffix could win elections on freshness and then commit)
+    /// exceed this binary's supported set. The downgrade-then-restart
+    /// trigger from the RFC §5 list.
+    UnsupportedCapability,
 }
 
 impl QuarantineReason {
@@ -133,7 +143,11 @@ pub enum BootDecision {
 /// exists at A2 (incarnation/epoch regression, snapshot manifests,
 /// capability support) lands with the Phase B machinery that introduces
 /// those artifacts.
-pub fn inspect(expected_cluster: ClusterId, recovered: &RecoveredState) -> BootDecision {
+pub fn inspect(
+    expected_cluster: ClusterId,
+    supported: u32,
+    recovered: &RecoveredState,
+) -> BootDecision {
     // Fresh node: nothing on disk at all → healthy with defaults. (A blank
     // disk is not "torn" — there is nothing to be torn.)
     if recovered.cluster_id.is_none()
@@ -174,6 +188,19 @@ pub fn inspect(expected_cluster: ClusterId, recovered: &RecoveredState) -> BootD
         reasons.push(QuarantineReason::CommitBeyondLog);
     }
 
+    // Codex F2: scan BOTH the recorded active set and every retained
+    // activation entry (committed or not — an uncommitted unsupported
+    // activation could win elections on freshness and then commit).
+    let suffix_bits: u32 = recovered
+        .log
+        .iter()
+        .flatten()
+        .filter_map(|e| e.activate)
+        .fold(0, |acc, b| acc | b);
+    if supported & (recovered.active | suffix_bits) != (recovered.active | suffix_bits) {
+        reasons.push(QuarantineReason::UnsupportedCapability);
+    }
+
     if reasons.is_empty() {
         BootDecision::Healthy {
             hard: recovered.hard.expect("verified above"),
@@ -210,6 +237,8 @@ pub enum RejoinMessage {
         /// Idempotency claims through the granted frontier (RFC 028 §7 +
         /// §6: claims survive compaction by riding the snapshot).
         claims: BTreeMap<u64, u64>,
+        /// Active capability bits at the granted frontier.
+        active: u32,
         commit: u64,
         verified: bool,
     },
@@ -237,6 +266,7 @@ pub enum BootstrapEffect {
         base: LogPosition,
         log: Vec<LogEntry>,
         claims: BTreeMap<u64, u64>,
+        active: u32,
     },
 }
 
@@ -333,6 +363,7 @@ impl QuarantinedNode {
             base,
             log,
             claims,
+            active,
             commit: _,
             verified,
         } = grant
@@ -382,6 +413,7 @@ impl QuarantinedNode {
             base,
             log,
             claims,
+            active,
         }]
     }
 }
@@ -400,6 +432,7 @@ mod tests {
                 voted_for: Some(NodeId(2)),
             }),
             log: Some(vec![LogEntry::unkeyed(Term(3), 42)]),
+            active: 0,
             commit_marker: 1,
             integrity: Integrity {
                 hard_state_verified: true,
@@ -410,7 +443,7 @@ mod tests {
 
     #[test]
     fn blank_disk_boots_healthy_fresh() {
-        match inspect(CLUSTER, &RecoveredState::blank()) {
+        match inspect(CLUSTER, u32::MAX, &RecoveredState::blank()) {
             BootDecision::Healthy { hard, log } => {
                 assert_eq!(hard, HardState::default());
                 assert!(log.is_empty());
@@ -423,7 +456,7 @@ mod tests {
 
     #[test]
     fn coherent_state_boots_healthy_with_exact_state() {
-        match inspect(CLUSTER, &coherent()) {
+        match inspect(CLUSTER, u32::MAX, &coherent()) {
             BootDecision::Healthy { hard, log } => {
                 assert_eq!(hard.voted_for, Some(NodeId(2)));
                 assert_eq!(log.len(), 1);
@@ -436,7 +469,7 @@ mod tests {
     fn torn_hard_state_quarantines() {
         let mut s = coherent();
         s.integrity.hard_state_verified = false;
-        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, u32::MAX, &s) else {
             panic!("torn state booted healthy");
         };
         assert!(reasons.contains(&QuarantineReason::TornHardState));
@@ -446,7 +479,7 @@ mod tests {
     fn alien_cluster_quarantines() {
         let mut s = coherent();
         s.cluster_id = Some(ClusterId(99));
-        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, u32::MAX, &s) else {
             panic!("alien state booted healthy");
         };
         assert!(reasons.contains(&QuarantineReason::ClusterIdMismatch));
@@ -456,7 +489,7 @@ mod tests {
     fn commit_marker_beyond_log_quarantines() {
         let mut s = coherent();
         s.commit_marker = 5; // log has 1 entry
-        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, u32::MAX, &s) else {
             panic!("frontier-beyond-data booted healthy");
         };
         assert!(reasons.contains(&QuarantineReason::CommitBeyondLog));
@@ -466,7 +499,7 @@ mod tests {
     fn log_corruption_is_corruption_evidence_and_blocks_stale_reads() {
         let mut s = coherent();
         s.integrity.log_verified = false;
-        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, u32::MAX, &s) else {
             panic!("corrupt log booted healthy");
         };
         let node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons, None);
@@ -479,7 +512,7 @@ mod tests {
         // reads OK, voting closed.
         let mut s = coherent();
         s.integrity.hard_state_verified = false;
-        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, u32::MAX, &s) else {
             panic!()
         };
         let node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons, None);
@@ -490,7 +523,7 @@ mod tests {
     fn corruption_requires_verified_grant() {
         let mut s = coherent();
         s.integrity.log_verified = false;
-        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, u32::MAX, &s) else {
             panic!()
         };
         let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons, None);
@@ -500,6 +533,7 @@ mod tests {
             base: LogPosition::ZERO,
             log: Vec::new(),
             claims: BTreeMap::new(),
+            active: 0,
             commit: 0,
             verified: false,
         };
@@ -513,6 +547,7 @@ mod tests {
             base: LogPosition::ZERO,
             log: Vec::new(),
             claims: BTreeMap::new(),
+            active: 0,
             commit: 0,
             verified: true,
         };
@@ -526,7 +561,7 @@ mod tests {
     fn wrong_cluster_grant_is_never_adopted() {
         let mut s = coherent();
         s.integrity.hard_state_verified = false;
-        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, u32::MAX, &s) else {
             panic!()
         };
         let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons, None);
@@ -536,6 +571,7 @@ mod tests {
             base: LogPosition::ZERO,
             log: Vec::new(),
             claims: BTreeMap::new(),
+            active: 0,
             commit: 0,
             verified: true,
         };
@@ -546,7 +582,7 @@ mod tests {
     fn preserve_happens_before_first_rejoin_request_and_alarm_fires_once() {
         let mut s = coherent();
         s.integrity.log_verified = false;
-        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, &s) else {
+        let BootDecision::Quarantine { reasons, .. } = inspect(CLUSTER, u32::MAX, &s) else {
             panic!()
         };
         let mut node = QuarantinedNode::new(NodeId(3), CLUSTER, reasons, None);

--- a/crates/yantrikdb-server/src/yrp/replica.rs
+++ b/crates/yantrikdb-server/src/yrp/replica.rs
@@ -74,6 +74,9 @@ pub struct LogEntry {
     pub term: Term,
     pub payload: u64,
     pub key: Option<u64>,
+    /// Phase B (RFC 028 §3): capability-activation entry. Bits activate on
+    /// COMMIT (never on append), monotonically — there is no deactivation.
+    pub activate: Option<u32>,
 }
 
 impl LogEntry {
@@ -83,6 +86,7 @@ impl LogEntry {
             term,
             payload,
             key: None,
+            activate: None,
         }
     }
 }
@@ -122,6 +126,10 @@ pub enum KeyedProposal {
 pub struct Snapshot {
     pub last: LogPosition,
     pub claims: BTreeMap<u64, u64>,
+    /// Active capability bits at the frontier — part of the snapshot's
+    /// identity (codex F8): two states with identical bytes but different
+    /// active semantics are NOT interchangeable.
+    pub active: u32,
 }
 
 /// Wire messages for the replica layer.
@@ -141,6 +149,10 @@ pub enum Message {
         term: Term,
         candidate: NodeId,
         last_log: LogPosition,
+        /// Candidate's capability set: a voter refuses candidates that
+        /// cannot cover the voter's ACTIVE view (semantically incomplete
+        /// leaders, sol r2 P1-14).
+        supported: u32,
     },
     VoteResponse {
         term: Term,
@@ -171,6 +183,12 @@ pub enum Message {
         term: Term,
         success: bool,
         last_index: u64,
+        /// Refusal reason: the batch (or snapshot) contained capability
+        /// bits outside the acceptor's `supported` set. Distinguishable so
+        /// the leader can stall + alarm instead of retransmit-storming
+        /// (codex F1/F7) — a capability NACK is a config problem, not a
+        /// log-divergence problem.
+        unsupported: bool,
     },
 }
 
@@ -185,6 +203,11 @@ pub enum Effect {
         base: LogPosition,
         log: Vec<LogEntry>,
         claims: BTreeMap<u64, u64>,
+        /// Committed-active capability bits. Sound to persist eagerly:
+        /// `active` only ever contains committed bits, and committed bits
+        /// never revert — restoring them early merely shrinks the
+        /// stale-low window (codex F5).
+        active: u32,
     },
     Send {
         to: NodeId,
@@ -210,6 +233,14 @@ pub enum Effect {
     /// are gone; the state arrives wholesale, like A2's rejoin adoption).
     InstallState {
         last_index: u64,
+    },
+    /// A peer NACKed replication for capability reasons: it cannot store
+    /// bits the log now carries. The leader has STOPPED sending to it
+    /// (no retransmit storm); the driver must alarm the operator — the
+    /// peer needs a binary upgrade (then a new capability exchange clears
+    /// the stall via set_peer_caps). Codex F1/F7.
+    PeerIncompatible {
+        peer: NodeId,
     },
 }
 
@@ -268,6 +299,21 @@ pub struct ReplicaCore {
     /// witness elect a leader" (the design review's P1-7 scenario) can lose
     /// only tentative entries — never acknowledged-durable ones.
     witnesses: BTreeSet<NodeId>,
+    /// This node's capability set (binary version). Static per process.
+    supported: u32,
+    /// Cluster-active bits: derived from COMMITTED activation entries +
+    /// the snapshot base. Monotone. Stale-low after restart until commit
+    /// re-advances — safe for election gating (freshness closes the gap;
+    /// codex Q1/F5), but the DRIVER must wait for a current-term commit
+    /// barrier before serving capability-dependent surfaces.
+    active: u32,
+    /// Peer capability advertisements (driver-fed from the session-start
+    /// capability exchange, #53). May be stale — the append-time NACK is
+    /// the backstop.
+    peer_caps: BTreeMap<NodeId, u32>,
+    /// Peers that NACKed on capability grounds: sends suspended until a
+    /// fresh exchange updates peer_caps (no retransmit storm).
+    stalled: BTreeSet<NodeId>,
 }
 
 impl ReplicaCore {
@@ -308,6 +354,74 @@ impl ReplicaCore {
             pre_votes: BTreeSet::new(),
             use_pre_vote,
             witnesses: BTreeSet::new(),
+            supported: u32::MAX,
+            active: 0,
+            peer_caps: BTreeMap::new(),
+            stalled: BTreeSet::new(),
+        }
+    }
+
+    /// Declare this node's capability set (binary version).
+    pub fn set_supported(&mut self, supported: u32) {
+        self.supported = supported;
+    }
+
+    /// Feed peer capability advertisements (the #53 session-start
+    /// exchange). Clears capability stalls — a new exchange means a new
+    /// binary may have arrived.
+    pub fn set_peer_caps(&mut self, caps: BTreeMap<NodeId, u32>) {
+        self.peer_caps = caps;
+        self.stalled.clear();
+    }
+
+    /// Cluster-active capability bits (committed view).
+    pub fn active_caps(&self) -> u32 {
+        self.active
+    }
+
+    /// Propose activating capability `bits` (RFC 028 §3). Leader-only;
+    /// refused unless EVERY voter — witnesses included, they store the
+    /// log — advertises support (codex Q4). Advertisements can be stale;
+    /// the append-time NACK + stall is the backstop, and activation
+    /// remains monotone regardless. When membership changes land, this
+    /// check must bind to the exact config epoch (codex F3 — documented
+    /// constraint for that slice).
+    pub fn propose_activation(&mut self, bits: u32) -> Option<Vec<Effect>> {
+        if self.role != Role::Leader || bits == 0 {
+            return None;
+        }
+        if self.supported & bits != bits {
+            return None;
+        }
+        for v in self.voters.iter() {
+            if *v == self.id {
+                continue;
+            }
+            let caps = self.peer_caps.get(v).copied().unwrap_or(0);
+            if caps & bits != bits {
+                return None;
+            }
+        }
+        let term = self.current_term();
+        self.log.push(LogEntry {
+            term,
+            payload: NOOP_PAYLOAD,
+            key: None,
+            activate: Some(bits),
+        });
+        let mut out = vec![self.stage_log()];
+        self.append_effects_for_followers(&mut out);
+        Some(out)
+    }
+
+    /// Fold newly committed activation entries into `active` — called
+    /// wherever the commit index advances. Compacted ranges are covered by
+    /// snapshot.active.
+    fn apply_committed_caps(&mut self, from: u64, to: u64) {
+        for i in from.max(self.base.index + 1)..=to {
+            if let Some(bits) = self.entry(i).and_then(|e| e.activate) {
+                self.active |= bits;
+            }
         }
     }
 
@@ -316,6 +430,17 @@ impl ReplicaCore {
     /// witness id must be in `voters` (it IS a voter for elections).
     pub fn set_witnesses(&mut self, witnesses: BTreeSet<NodeId>) {
         debug_assert!(witnesses.iter().all(|w| self.voters.contains(w)));
+        // Codex F4: with ONE witness, every election quorum still contains
+        // enough data nodes to intersect every data-commit quorum (proven
+        // by enumeration for D≤4, pattern holds generally). TWO OR MORE
+        // witnesses break that intersection — an incompatible/stale data
+        // node + witnesses could elect without touching any commit-quorum
+        // member. Multi-witness needs certified committed-watermark
+        // machinery we deliberately do not have; refuse the topology.
+        debug_assert!(
+            witnesses.len() <= 1,
+            "multi-witness topologies break election/data quorum intersection"
+        );
         debug_assert!(
             !witnesses.contains(&self.id) || self.role == Role::Follower,
             "a witness cannot already hold a data role"
@@ -336,11 +461,13 @@ impl ReplicaCore {
         base: LogPosition,
         restored_log: Vec<LogEntry>,
         snapshot_claims: BTreeMap<u64, u64>,
+        snapshot_active: u32,
         use_pre_vote: bool,
     ) -> Self {
         let mut core = Self::new(id, voters, restored_hard, Vec::new(), use_pre_vote);
         core.base = base;
         core.claims = snapshot_claims;
+        core.active = snapshot_active;
         // The state below base is adopted wholesale (checkpoint semantics).
         core.commit = base.index;
         for e in restored_log {
@@ -368,7 +495,7 @@ impl ReplicaCore {
     /// coverage or a verified snapshot — an uncommitted entry has neither).
     /// Returns the snapshot the driver persists alongside the suffix; the
     /// claims table travels in it (sol P1-9).
-    pub fn compact(&mut self, up_to: u64) -> Option<Snapshot> {
+    pub fn compact(&mut self, up_to: u64) -> Option<(Snapshot, Vec<Effect>)> {
         if up_to <= self.base.index || up_to > self.commit {
             return None;
         }
@@ -380,10 +507,21 @@ impl ReplicaCore {
             index: up_to,
         };
         self.durable_len = self.durable_len.saturating_sub(drop as u64);
-        Some(Snapshot {
-            last: self.base,
-            claims: self.claims.clone(),
-        })
+        // The shape change (base + dropped prefix + active-at-base) must be
+        // durable atomically — stage a persist like every other durable
+        // decision. (Caught by the activation-survives-restart test: an
+        // unpersisted compaction left disk in the old shape, which is SAFE
+        // but loses the eager active/claims durability the snapshot form
+        // provides.)
+        let persist = self.stage_log();
+        Some((
+            Snapshot {
+                last: self.base,
+                claims: self.claims.clone(),
+                active: self.active,
+            },
+            vec![persist],
+        ))
     }
 
     // ── accessors ──────────────────────────────────────────────────
@@ -463,6 +601,7 @@ impl ReplicaCore {
             base: self.base,
             log: self.log.clone(),
             claims: self.claims.clone(),
+            active: self.active,
         }
     }
 
@@ -553,6 +692,7 @@ impl ReplicaCore {
             term,
             payload,
             key: Some(key),
+            activate: None,
         });
         let index = self.last_index();
         self.claims.insert(key, index);
@@ -586,6 +726,9 @@ impl ReplicaCore {
     }
 
     fn send_append_to(&mut self, peer: NodeId, out: &mut Vec<Effect>) {
+        if self.stalled.contains(&peer) {
+            return; // capability-stalled: waiting for a new exchange
+        }
         let term = self.current_term();
         let next = *self.next_index.get(&peer).unwrap_or(&1);
         // Straggler below our compaction base: entries are gone — ship the
@@ -598,6 +741,7 @@ impl ReplicaCore {
                 snapshot: Snapshot {
                     last: self.base,
                     claims: self.claims.clone(),
+                    active: self.active,
                 },
             };
             self.hold_or(Effect::Send { to: peer, msg }, out);
@@ -669,7 +813,8 @@ impl ReplicaCore {
                 term,
                 candidate,
                 last_log,
-            } => self.on_vote_request(from, term, candidate, last_log),
+                supported,
+            } => self.on_vote_request(from, term, candidate, last_log, supported),
             Message::VoteResponse { term, granted } => self.on_vote_response(from, term, granted),
             Message::AppendEntries {
                 term,
@@ -682,7 +827,8 @@ impl ReplicaCore {
                 term,
                 success,
                 last_index,
-            } => self.on_append_response(from, term, success, last_index),
+                unsupported,
+            } => self.on_append_response(from, term, success, last_index, unsupported),
             Message::InstallSnapshot {
                 term,
                 leader: _,
@@ -729,6 +875,7 @@ impl ReplicaCore {
                 term,
                 candidate: self.id,
                 last_log: self.last_log(),
+                supported: self.supported,
             },
         });
         vec![persist]
@@ -773,6 +920,7 @@ impl ReplicaCore {
         term: Term,
         candidate: NodeId,
         last_log: LogPosition,
+        candidate_supported: u32,
     ) -> Vec<Effect> {
         let mut effects = Vec::new();
         let cur = self.current_term();
@@ -807,7 +955,14 @@ impl ReplicaCore {
         let may_vote = prior_vote.is_none() || prior_vote == Some(candidate);
         // Gate A #3 (R3): Raft freshness over the candidate's log.
         let fresh = last_log.is_at_least_as_up_to_date_as(&self.last_log());
-        if may_vote && fresh {
+        // Capability gate (sol P1-14 / codex Q1): a candidate that cannot
+        // cover OUR active view is semantically incomplete — refuse. Note
+        // freshness usually catches this first (an incompatible node's log
+        // cannot contain the committed activation entry), but active-view
+        // gating closes the belt-and-braces gap when our own active is
+        // ahead of the candidate's advertisement.
+        let capable = candidate_supported & self.active == self.active;
+        if may_vote && fresh && capable {
             // Gate A #1 (R2): the grant changes voted_for → stage + HOLD.
             effects.push(self.stage(HardState {
                 current_term: term,
@@ -885,6 +1040,7 @@ impl ReplicaCore {
                     term: cur,
                     success: false,
                     last_index: self.base.index + self.durable_len,
+                    unsupported: false,
                 },
             }];
         }
@@ -918,6 +1074,7 @@ impl ReplicaCore {
                     term,
                     success: true,
                     last_index: self.base.index,
+                    unsupported: false,
                 },
             };
             if newer {
@@ -944,6 +1101,34 @@ impl ReplicaCore {
                     success: false,
                     last_index: (self.base.index + self.durable_len)
                         .min(prev.index.saturating_sub(1)),
+                    unsupported: false,
+                },
+            };
+            if newer {
+                effects.push(self.stage(adopted));
+                self.hold(refusal);
+            } else {
+                self.hold_or(refusal, &mut effects);
+            }
+            return effects;
+        }
+
+        // Capability gate (codex F1 backstop): if any entry in the batch
+        // activates bits we cannot support, refuse the WHOLE batch with a
+        // distinguishable NACK — our log must never contain an activation
+        // we cannot honor (that is what makes the freshness argument for
+        // incompatible candidates sound).
+        if entries
+            .iter()
+            .any(|e| e.activate.is_some_and(|b| self.supported & b != b))
+        {
+            let refusal = Effect::Send {
+                to: from,
+                msg: Message::AppendResponse {
+                    term,
+                    success: false,
+                    last_index: self.base.index + self.durable_len,
+                    unsupported: true,
                 },
             };
             if newer {
@@ -974,6 +1159,7 @@ impl ReplicaCore {
                                 term,
                                 success: false,
                                 last_index: self.base.index + self.durable_len,
+                                unsupported: false,
                             },
                         };
                         if newer {
@@ -1028,6 +1214,7 @@ impl ReplicaCore {
                     } else {
                         (self.base.index + self.durable_len).min(covered)
                     },
+                    unsupported: false,
                 },
             });
         } else {
@@ -1039,6 +1226,7 @@ impl ReplicaCore {
                     term,
                     success: true,
                     last_index: (self.base.index + self.durable_len).min(covered),
+                    unsupported: false,
                 },
             };
             self.hold_or(ack, &mut effects);
@@ -1047,7 +1235,9 @@ impl ReplicaCore {
         // Adopt the leader's commit proof, bounded by what we hold.
         let new_commit = leader_commit.min(covered);
         if new_commit > self.commit {
+            let from_idx = self.commit + 1;
             self.commit = new_commit;
+            self.apply_committed_caps(from_idx, new_commit);
             // Sequence apply behind the persist: apply never outruns
             // durability.
             let advanced = Effect::CommitAdvanced { to: new_commit };
@@ -1062,6 +1252,7 @@ impl ReplicaCore {
         term: Term,
         success: bool,
         last_index: u64,
+        unsupported: bool,
     ) -> Vec<Effect> {
         let cur = self.current_term();
         if term > cur {
@@ -1071,6 +1262,14 @@ impl ReplicaCore {
             return Vec::new();
         }
         let mut out = Vec::new();
+        if !success && unsupported {
+            // Capability NACK: retrying is useless until the peer upgrades
+            // (codex F7). Suspend sends, surface the incompatibility.
+            if self.stalled.insert(from) {
+                out.push(Effect::PeerIncompatible { peer: from });
+            }
+            return out;
+        }
         // Codex finding 2: delayed/duplicate responses must not regress
         // next_index below match_index + 1. match_index is monotonic (max);
         // matched entries are confirmed-durable-matching, so probing below
@@ -1111,6 +1310,7 @@ impl ReplicaCore {
                     term: cur,
                     success: false,
                     last_index: self.base.index + self.durable_len,
+                    unsupported: false,
                 },
             }];
         }
@@ -1127,6 +1327,47 @@ impl ReplicaCore {
         } else {
             self.effective()
         };
+        // Preflight (codex F6): refuse an install whose active set we
+        // cannot support (quarantine-bypass) or that would REGRESS our
+        // active view (monotonicity — a legitimately higher snapshot's
+        // active is always a superset of ours).
+        if self.supported & snapshot.active != snapshot.active {
+            let refusal = Effect::Send {
+                to: from,
+                msg: Message::AppendResponse {
+                    term,
+                    success: false,
+                    last_index: self.base.index + self.durable_len,
+                    unsupported: true,
+                },
+            };
+            if newer {
+                effects.push(self.stage(adopted));
+                self.hold(refusal);
+            } else {
+                self.hold_or(refusal, &mut effects);
+            }
+            return effects;
+        }
+        if snapshot.active & self.active != self.active {
+            // Active-regressing snapshot: forged or badly stale — refuse.
+            let refusal = Effect::Send {
+                to: from,
+                msg: Message::AppendResponse {
+                    term,
+                    success: false,
+                    last_index: self.base.index + self.durable_len,
+                    unsupported: false,
+                },
+            };
+            if newer {
+                effects.push(self.stage(adopted));
+                self.hold(refusal);
+            } else {
+                self.hold_or(refusal, &mut effects);
+            }
+            return effects;
+        }
         if snapshot.last.index <= self.commit {
             // Stale snapshot: our committed state is already ahead.
             let ack = Effect::Send {
@@ -1135,6 +1376,7 @@ impl ReplicaCore {
                     term,
                     success: true,
                     last_index: self.base.index + self.durable_len,
+                    unsupported: false,
                 },
             };
             if newer {
@@ -1150,6 +1392,7 @@ impl ReplicaCore {
         self.base = snapshot.last;
         self.log.clear();
         self.claims = snapshot.claims;
+        self.active |= snapshot.active;
         self.commit = last_index;
         effects.push(self.stage(adopted));
         self.hold(Effect::InstallState { last_index });
@@ -1159,6 +1402,7 @@ impl ReplicaCore {
                 term,
                 success: true,
                 last_index,
+                unsupported: false,
             },
         });
         effects
@@ -1183,7 +1427,9 @@ impl ReplicaCore {
                     .filter(|v| self.match_index.get(v).copied().unwrap_or(0) >= n)
                     .count();
                 if acks >= quorum(data_voters().count()) {
+                    let from_idx = self.commit + 1;
                     self.commit = n;
+                    self.apply_committed_caps(from_idx, n);
                     let advanced = Effect::CommitAdvanced { to: n };
                     self.hold_or(advanced, out);
                     // Share the new commit index promptly.
@@ -1257,9 +1503,17 @@ impl ReplicaCore {
     /// Returns `(term, base, durable_suffix, claims, commit)` — the full
     /// durable picture, snapshot-aware: `base` + `claims` carry compacted
     /// history, `durable_suffix` the live entries above it.
+    #[allow(clippy::type_complexity)]
     pub fn rejoin_grant(
         &self,
-    ) -> Option<(Term, LogPosition, Vec<LogEntry>, BTreeMap<u64, u64>, u64)> {
+    ) -> Option<(
+        Term,
+        LogPosition,
+        Vec<LogEntry>,
+        BTreeMap<u64, u64>,
+        u32,
+        u64,
+    )> {
         if self.role != Role::Leader {
             return None;
         }
@@ -1279,7 +1533,14 @@ impl ReplicaCore {
             .copied()
             .collect();
         let commit = self.commit.min(self.base.index + self.durable_len);
-        Some((cur, self.base, durable, self.claims.clone(), commit))
+        Some((
+            cur,
+            self.base,
+            durable,
+            self.claims.clone(),
+            self.active,
+            commit,
+        ))
     }
 
     fn pre_quorum_reached(&self) -> bool {

--- a/crates/yantrikdb-server/src/yrp/sim.rs
+++ b/crates/yantrikdb-server/src/yrp/sim.rs
@@ -81,6 +81,7 @@ struct SimNode {
     disk_base: LogPosition,
     disk_log: Vec<LogEntry>,
     disk_claims: BTreeMap<u64, u64>,
+    disk_active: u32,
     torn_hard: bool,
     corrupt_log: bool,
     /// Highest index this node has applied (ledgered via CommitAdvanced).
@@ -113,6 +114,8 @@ struct Sim {
     keyed_committed: BTreeMap<u64, (u64, u64)>,
     /// Witness subset (applied to every constructed core, incl. restarts).
     witnesses: BTreeSet<NodeId>,
+    /// Capability-incompatibility alarms: (leader, stalled peer).
+    incompat_alarms: Vec<(NodeId, NodeId)>,
 }
 
 impl Sim {
@@ -146,6 +149,7 @@ impl Sim {
                         .enumerate()
                         .filter_map(|(i, e)| e.key.map(|k| (k, i as u64 + 1)))
                         .collect(),
+                    disk_active: 0,
                     torn_hard: false,
                     corrupt_log: false,
                     applied: 0,
@@ -167,6 +171,7 @@ impl Sim {
             alarms: Vec::new(),
             keyed_committed: BTreeMap::new(),
             witnesses: BTreeSet::new(),
+            incompat_alarms: Vec::new(),
         }
     }
 
@@ -202,6 +207,7 @@ impl Sim {
                     base,
                     log,
                     claims,
+                    active,
                 } => {
                     if crash_at == Some(0) {
                         self.crash(id);
@@ -213,6 +219,7 @@ impl Sim {
                         node.disk_base = base;
                         node.disk_log = log;
                         node.disk_claims = claims;
+                        node.disk_active = active;
                     }
                     if crash_at == Some(1) {
                         self.crash(id);
@@ -247,6 +254,9 @@ impl Sim {
                     // Checkpoint adoption: applied state arrives wholesale.
                     let node = self.nodes.get_mut(&id).unwrap();
                     node.applied = node.applied.max(last_index);
+                }
+                Effect::PeerIncompatible { peer } => {
+                    self.incompat_alarms.push((id, peer));
                 }
             }
         }
@@ -299,6 +309,7 @@ impl Sim {
                 term,
                 candidate,
                 last_log,
+                ..
             } => {
                 self.advertised.insert((*candidate, *term), *last_log);
             }
@@ -359,13 +370,14 @@ impl Sim {
             cluster_id: Some(CLUSTER),
             hard: Some(node.disk_hard),
             log: Some(node.disk_log.clone()),
+            active: node.disk_active,
             commit_marker: 0, // volatile in A2's model
             integrity: Integrity {
                 hard_state_verified: !node.torn_hard,
                 log_verified: !node.corrupt_log,
             },
         };
-        match inspect(CLUSTER, &recovered) {
+        match inspect(CLUSTER, u32::MAX, &recovered) {
             BootDecision::Healthy { hard, log } => {
                 let mut core = ReplicaCore::new(id, voters, hard, log, false);
                 core.set_witnesses(self.witnesses.clone());
@@ -411,6 +423,7 @@ impl Sim {
                     base,
                     log,
                     claims,
+                    active,
                 } => {
                     // Persist the adopted snapshot, clear damage flags, and
                     // resume as a live follower. Quarantine ends here only.
@@ -425,11 +438,13 @@ impl Sim {
                     node.disk_base = base;
                     node.disk_log = log.clone();
                     node.disk_claims = claims.clone();
+                    node.disk_active = active;
                     node.torn_hard = false;
                     node.corrupt_log = false;
                     node.quarantined = None;
-                    let mut core =
-                        ReplicaCore::new_from_durable(id, voters, hard, base, log, claims, false);
+                    let mut core = ReplicaCore::new_from_durable(
+                        id, voters, hard, base, log, claims, active, false,
+                    );
                     core.set_witnesses(w);
                     node.core = Some(core);
                     node.applied = node
@@ -454,6 +469,7 @@ impl Sim {
             node.disk_base,
             node.disk_log.clone(),
             node.disk_claims.clone(),
+            node.disk_active,
             use_pre_vote,
         );
         core.set_witnesses(self.witnesses.clone());
@@ -525,7 +541,7 @@ impl Sim {
                     .get(&m.to)
                     .and_then(|n| n.core.as_ref())
                     .and_then(|c| c.rejoin_grant());
-                if let Some((term, base, log, claims, commit)) = grant {
+                if let Some((term, base, log, claims, active, commit)) = grant {
                     self.net.push_back(InFlight {
                         from: m.to,
                         to: asker,
@@ -535,6 +551,7 @@ impl Sim {
                             base,
                             log,
                             claims,
+                            active,
                             commit,
                             // The leader's snapshot is live state: verified.
                             verified: true,
@@ -725,6 +742,7 @@ fn r2_crash_after_persist_binds_the_restarted_node() {
                 term: Term(1),
                 candidate: NodeId(2),
                 last_log: LogPosition::ZERO,
+                supported: u32::MAX,
             },
             false,
         );
@@ -1275,6 +1293,7 @@ fn codex_duplicate_response_does_not_regress_next_index() {
                 term: Term(1),
                 success: true,
                 last_index: 1,
+                unsupported: false,
             },
             false,
         );
@@ -1303,6 +1322,7 @@ fn codex_duplicate_response_does_not_regress_next_index() {
                 term: Term(1),
                 success: false,
                 last_index: 0,
+                unsupported: false,
             },
             false,
         );
@@ -1784,13 +1804,14 @@ fn compaction_preserves_claims_no_replay_window() {
             .as_mut()
             .unwrap();
         let commit = core.commit_index();
-        let snap = core.compact(commit).expect("compaction through commit");
+        let (snap, effects) = core.compact(commit).expect("compaction through commit");
         assert_eq!(snap.last.index, commit);
         assert!(
             snap.claims.contains_key(&121),
             "claim must ride the snapshot"
         );
         assert!(core.entry(orig_index).is_none(), "entry compacted away");
+        sim.run_effects(NodeId(1), effects, None);
     }
     // The retry after compaction: STILL a dedupe hit at the original index.
     let retry = sim.propose_keyed(NodeId(1), 121, 1210).expect("leader");
@@ -1864,7 +1885,8 @@ fn straggler_beyond_gc_recovers_via_snapshot_install() {
             .as_mut()
             .unwrap();
         let commit = core.commit_index();
-        core.compact(commit).expect("compact");
+        let (_snap, effects) = core.compact(commit).expect("compact");
+        sim.run_effects(NodeId(1), effects, None);
     }
     // More live entries above the base.
     assert!(sim.propose(NodeId(1), 144));
@@ -1925,6 +1947,7 @@ fn stale_snapshot_never_regresses() {
                 snapshot: Snapshot {
                     last: LogPosition { term: 1, index: 1 },
                     claims: BTreeMap::new(),
+                    active: 0,
                 },
             },
             false,
@@ -1980,9 +2003,18 @@ fn seeded_soak_with_compaction_invariants_hold() {
                     // the persist of the compacted shape rides the next
                     // staged persist; force one via a heartbeat after.
                     let id = ids[sim.rng.pick(3)];
-                    if let Some(core) = sim.nodes.get_mut(&id).unwrap().core.as_mut() {
-                        let c = core.commit_index();
-                        let _ = core.compact(c);
+                    let effects = sim
+                        .nodes
+                        .get_mut(&id)
+                        .unwrap()
+                        .core
+                        .as_mut()
+                        .and_then(|core| {
+                            let c = core.commit_index();
+                            core.compact(c).map(|(_s, e)| e)
+                        });
+                    if let Some(effects) = effects {
+                        sim.run_effects(id, effects, None);
                     }
                     sim.heartbeat(id);
                 }
@@ -2009,4 +2041,237 @@ fn seeded_soak_with_compaction_invariants_hold() {
         sim.drain();
         sim.check_all();
     }
+}
+
+// ── tests: Phase B — capability activation (RFC 028 §3, codex-reviewed) ──
+
+impl Sim {
+    fn set_node_caps(&mut self, id: NodeId, supported: u32) {
+        if let Some(core) = self.nodes.get_mut(&id).unwrap().core.as_mut() {
+            core.set_supported(supported);
+        }
+    }
+    fn feed_peer_caps(&mut self, id: NodeId, caps: &[(u64, u32)]) {
+        if let Some(core) = self.nodes.get_mut(&id).unwrap().core.as_mut() {
+            core.set_peer_caps(caps.iter().map(|(n, c)| (NodeId(*n), *c)).collect());
+        }
+    }
+    fn propose_activation(&mut self, id: NodeId, bits: u32) -> bool {
+        let Some(core) = self.nodes.get_mut(&id).unwrap().core.as_mut() else {
+            return false;
+        };
+        match core.propose_activation(bits) {
+            Some(effects) => {
+                self.run_effects(id, effects, None);
+                true
+            }
+            None => false,
+        }
+    }
+    /// Boot path with an explicit supported set (the downgrade case).
+    fn restart_via_bootstrap_with(&mut self, id: NodeId, supported: u32) {
+        let voters = self.voters.clone();
+        let w = self.witnesses.clone();
+        let node = self.nodes.get_mut(&id).unwrap();
+        let recovered = RecoveredState {
+            cluster_id: Some(CLUSTER),
+            hard: Some(node.disk_hard),
+            log: Some(node.disk_log.clone()),
+            active: node.disk_active,
+            commit_marker: 0,
+            integrity: Integrity {
+                hard_state_verified: !node.torn_hard,
+                log_verified: !node.corrupt_log,
+            },
+        };
+        match inspect(CLUSTER, supported, &recovered) {
+            BootDecision::Healthy { hard, log } => {
+                let mut core = ReplicaCore::new(id, voters, hard, log, false);
+                core.set_witnesses(w);
+                core.set_supported(supported);
+                node.core = Some(core);
+                node.quarantined = None;
+            }
+            BootDecision::Quarantine { reasons, term_hint } => {
+                node.core = None;
+                node.quarantined = Some(QuarantinedNode::new(id, CLUSTER, reasons, term_hint));
+            }
+        }
+    }
+}
+
+const CAP_X: u32 = 0b0001;
+
+/// Activation is refused unless EVERY voter advertises support — a leader
+/// with an incomplete or missing peer_caps map cannot activate.
+#[test]
+fn activation_requires_unanimous_support() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 113, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    // No peer_caps fed at all → refused.
+    assert!(!sim.propose_activation(NodeId(1), CAP_X));
+    // One peer lacks the bit → refused.
+    sim.feed_peer_caps(NodeId(1), &[(2, CAP_X), (3, 0)]);
+    assert!(!sim.propose_activation(NodeId(1), CAP_X));
+    // Unanimous → accepted.
+    sim.feed_peer_caps(NodeId(1), &[(2, CAP_X), (3, CAP_X)]);
+    assert!(sim.propose_activation(NodeId(1), CAP_X));
+    sim.drain();
+    sim.check_all();
+    for id in [1u64, 2, 3] {
+        assert_eq!(
+            sim.nodes[&NodeId(id)].core.as_ref().unwrap().active_caps(),
+            CAP_X,
+            "node {id} did not activate on commit"
+        );
+    }
+}
+
+/// Codex F1/F7: a stale advertisement lets the activation commit on the
+/// supporting quorum, but the incompatible follower NACKs (its log never
+/// contains the entry), the leader STALLS sends to it (no retransmit
+/// storm) and raises exactly one PeerIncompatible alarm — visible
+/// degradation, not silent.
+#[test]
+fn stale_advertisement_stalls_incompatible_follower_visibly() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 127, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    // Node 3 actually lacks CAP_X, but the leader was told otherwise.
+    sim.set_node_caps(NodeId(3), 0);
+    sim.feed_peer_caps(NodeId(1), &[(2, CAP_X), (3, CAP_X)]);
+    assert!(sim.propose_activation(NodeId(1), CAP_X));
+    sim.drain();
+    // Commit proceeded via the supporting data quorum {1,2}.
+    assert_eq!(
+        sim.nodes[&NodeId(1)].core.as_ref().unwrap().active_caps(),
+        CAP_X
+    );
+    // The incompatible follower never stored it and got alarmed exactly once.
+    let n3 = sim.nodes[&NodeId(3)].core.as_ref().unwrap();
+    assert_eq!(n3.active_caps(), 0);
+    assert_eq!(
+        sim.incompat_alarms,
+        vec![(NodeId(1), NodeId(3))],
+        "expected exactly one alarm"
+    );
+    // Retries don't storm: further heartbeats add no new alarms.
+    sim.heartbeat(NodeId(1));
+    sim.drain();
+    assert_eq!(sim.incompat_alarms.len(), 1);
+    // And the incompatible node can never become leader: its log lacks the
+    // committed activation (freshness) AND voters gate on capability.
+    sim.crash(NodeId(1));
+    sim.timeout(NodeId(3), None);
+    sim.drain();
+    assert!(
+        sim.leaders.values().all(|s| !s.contains(&NodeId(3))),
+        "incompatible node won an election"
+    );
+    sim.check_all();
+}
+
+/// Codex F2 (the sharpest catch): a node retaining an activation entry in
+/// its suffix — committed or not — that its (downgraded) binary cannot
+/// support must QUARANTINE at boot, not pass an active-only check and
+/// win elections on freshness.
+#[test]
+fn codex_f2_downgraded_node_with_retained_activation_quarantines() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 131, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    sim.feed_peer_caps(NodeId(1), &[(2, CAP_X), (3, CAP_X)]);
+    assert!(sim.propose_activation(NodeId(1), CAP_X));
+    sim.drain();
+    // Node 2 restarts with a DOWNGRADED binary lacking CAP_X. Its disk
+    // retains the activation entry (and disk_active records it).
+    sim.crash(NodeId(2));
+    sim.restart_via_bootstrap_with(NodeId(2), 0);
+    let n2 = &sim.nodes[&NodeId(2)];
+    let q = n2
+        .quarantined
+        .as_ref()
+        .expect("downgraded node must quarantine");
+    assert!(q
+        .reasons()
+        .contains(&QuarantineReason::UnsupportedCapability));
+    // Re-upgrade: boots healthy again.
+    sim.restart_via_bootstrap_with(NodeId(2), CAP_X);
+    assert!(sim.nodes[&NodeId(2)].quarantined.is_none());
+    sim.heartbeat(NodeId(1));
+    sim.drain();
+    sim.check_all();
+}
+
+/// Codex F6: a snapshot whose active set exceeds the receiver's supported
+/// set is refused before any state mutation (quarantine-bypass closed).
+#[test]
+fn unsupported_snapshot_install_refused() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 137, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    sim.set_node_caps(NodeId(2), 0); // node 2 supports nothing extra
+    let before_base = sim.nodes[&NodeId(2)].core.as_ref().unwrap().base();
+    let effects = sim
+        .nodes
+        .get_mut(&NodeId(2))
+        .unwrap()
+        .core
+        .as_mut()
+        .unwrap()
+        .on_message(
+            NodeId(1),
+            Message::InstallSnapshot {
+                term: Term(1),
+                leader: NodeId(1),
+                snapshot: Snapshot {
+                    last: LogPosition { term: 1, index: 9 },
+                    claims: BTreeMap::new(),
+                    active: CAP_X,
+                },
+            },
+            false,
+        );
+    sim.run_effects(NodeId(2), effects, None);
+    let n2 = sim.nodes[&NodeId(2)].core.as_ref().unwrap();
+    assert_eq!(n2.base(), before_base, "unsupported snapshot was adopted");
+    assert_eq!(n2.active_caps(), 0);
+    sim.check_all();
+}
+
+/// Activation survives compaction + restart: active rides Persist and the
+/// snapshot, so a restarted node knows its capabilities without replaying
+/// compacted entries.
+#[test]
+fn activation_survives_compaction_and_restart() {
+    let mut sim = Sim::new(&[(1, empty()), (2, empty()), (3, empty())], 0, 139, false);
+    sim.timeout(NodeId(1), None);
+    sim.drain();
+    sim.feed_peer_caps(NodeId(1), &[(2, CAP_X), (3, CAP_X)]);
+    assert!(sim.propose_activation(NodeId(1), CAP_X));
+    sim.drain();
+    // Compact the activation entry away, then bounce the leader.
+    {
+        let core = sim
+            .nodes
+            .get_mut(&NodeId(1))
+            .unwrap()
+            .core
+            .as_mut()
+            .unwrap();
+        let c = core.commit_index();
+        let (_snap, effects) = core.compact(c).expect("compact");
+        sim.run_effects(NodeId(1), effects, None);
+    }
+    sim.heartbeat(NodeId(1));
+    sim.drain();
+    sim.crash(NodeId(1));
+    sim.restart(NodeId(1), false);
+    assert_eq!(
+        sim.nodes[&NodeId(1)].core.as_ref().unwrap().active_caps(),
+        CAP_X,
+        "active lost across compaction + restart"
+    );
+    sim.check_all();
 }


### PR DESCRIPTION
## Summary
The **last pure-protocol slice**: capability activation as monotone, quorum-committed cluster state — co-designed with codex (8-finding red-team **before** implementation, per the standing collaboration directive).

## Breaking-change ledger (agreement #2)
None — internal pure-logic module, unwired.

## Codex findings → design
| Finding | Resolution |
|---|---|
| F1/F7 stale advertisements → silent wedge / retransmit storm | distinguishable `unsupported` NACK → leader stalls peer + one `PeerIncompatible` alarm; cleared by fresh exchange |
| **F2 downgraded node with retained (even uncommitted) activation wins on freshness** | boot scan covers active bits AND every retained activation entry → `UnsupportedCapability` quarantine |
| F4 multi-witness breaks quorum intersection | single-witness constraint enforced with the intersection argument documented |
| F5/F6/F8 stale-low window, install bypass, snapshot identity | `supported` in VoteRequest; install preflights (⊆ supported, monotone-superset); `active` rides Persist + snapshot |
| F3 membership binding | documented hard constraint for the future membership slice |

Bonus fix surfaced by tests: `compact()` now stages its persist — shape changes are durable atomically.

**47/47 yrp tests green · full workspace green.** The pure YRP protocol is now COMPLETE: election, replication, quarantine/rejoin, claims, witnesses, snapshots/GC, capabilities — all sim-proven. Next: runtime integration (the driver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)