### PR TITLE
feat(yrp): HTTP transport + gateway binding — YRP goes live on the runtime (RFC 028)

### DIFF
--- a/crates/yantrikdb-server/src/config/mod.rs
+++ b/crates/yantrikdb-server/src/config/mod.rs
@@ -33,6 +33,9 @@ pub struct ServerConfig {
     /// RFC 014-A: cluster-transport mTLS. Optional in legacy cluster
     /// mode; production gate for RFC 010 PR-4 openraft.
     pub cluster_tls: crate::security::ClusterTlsConfig,
+    /// RFC 028: native replication. Active when
+    /// `cluster.raft_mode = "yrp"`.
+    pub yrp: YrpSection,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -312,6 +315,53 @@ pub struct ClusterSection {
     /// production gate at server startup (see
     /// [`crate::raft::build_raft_cluster`]).
     pub raft_mode: crate::raft::RaftClusterMode,
+}
+
+/// RFC 028 `[yrp]` section — native-replication knobs. Only read when
+/// `cluster.raft_mode = "yrp"`. Node identity comes from
+/// `cluster.node_id`; `peers` lists EVERY cluster member including this
+/// node (self is matched by node_id).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct YrpSection {
+    /// Immutable cluster identity (RFC 028 §3). Must be identical and
+    /// non-zero on every member; alien state quarantines at boot.
+    pub cluster_id: u64,
+    /// Driver tick period. All election/heartbeat timing is counted in
+    /// these ticks.
+    pub tick_ms: u64,
+    /// Randomized election timeout range, in ticks.
+    pub election_ticks_min: u32,
+    pub election_ticks_max: u32,
+    /// Leader heartbeat cadence, in ticks.
+    pub heartbeat_ticks: u32,
+    /// All cluster members (including this node).
+    pub peers: Vec<YrpPeerConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct YrpPeerConfig {
+    pub node_id: u64,
+    /// HTTP base url peers reach this member at (e.g. "http://10.0.0.2:7438").
+    /// YRP wire messages ride the HTTP plane (`POST /v1/yrp/msg`).
+    pub addr: String,
+    /// Witness: votes in elections, never stores data, never counts
+    /// toward commit durability (RFC 028 §4). At most one per cluster.
+    #[serde(default)]
+    pub witness: bool,
+}
+
+impl Default for YrpSection {
+    fn default() -> Self {
+        Self {
+            cluster_id: 0,
+            tick_ms: 50,
+            election_ticks_min: 10,
+            election_ticks_max: 20,
+            heartbeat_ticks: 2,
+            peers: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -113,6 +113,35 @@ fn cluster_state_view(state: &AppState) -> Option<ClusterStateView> {
             role_label: Some(role_label),
         });
     }
+    if let Some(ref yrp) = state.yrp {
+        let quarantined = yrp.quarantine_reasons().is_some();
+        let s = *yrp.status.borrow();
+        let (leader, leader_addr) = yrp.leader_hint();
+        let role_label: &'static str = if quarantined {
+            "quarantined"
+        } else {
+            match s.role {
+                crate::yrp::replica::Role::Leader => "leader",
+                crate::yrp::replica::Role::Follower => "follower",
+                crate::yrp::replica::Role::Candidate
+                | crate::yrp::replica::Role::PreCandidate => "candidate",
+            }
+        };
+        return Some(ClusterStateView {
+            node_id: yrp.node_id.0,
+            role: role_label.to_string(),
+            term: s.term,
+            leader,
+            leader_addr,
+            accepts_writes: !quarantined && s.role == crate::yrp::replica::Role::Leader,
+            healthy: !quarantined && leader.is_some(),
+            raft_mode: "yrp",
+            last_log_index: Some(s.commit),
+            last_applied_index: Some(s.applied),
+            replication_lag_log_entries: Some(s.commit.saturating_sub(s.applied)),
+            role_label: Some(role_label),
+        });
+    }
     if let Some(ref cluster) = state.cluster {
         return Some(ClusterStateView {
             node_id: cluster.node_id() as u64,
@@ -453,6 +482,15 @@ async fn health(State(state): State<Arc<AppState>>) -> Json<Value> {
             "role_label": view.role_label,
         });
     }
+    // RFC 028 §5: the honest quarantine surface. "Process up" and "data
+    // servable" are different health dimensions — a quarantined node
+    // answers this endpoint (that is the whole point) but says so loudly.
+    if let Some(yrp) = &state.yrp {
+        if let Some(reasons) = yrp.quarantine_reasons() {
+            payload["status"] = json!("quarantined");
+            payload["yrp_quarantine_reasons"] = json!(reasons);
+        }
+    }
     Json(payload)
 }
 
@@ -742,6 +780,14 @@ async fn remember(
         .and_then(|v| v.as_str())
         .map(String::from)
     {
+        // RFC 028 §7: in yrp mode the claim rides IN the replicated log
+        // (checked at origin ingress, committed with its op, truncated
+        // with its op) — the coupling the engine-atomic path provides on
+        // single-node. This replaces the historical cluster-mode 501.
+        if let Some(yrp) = state.yrp.clone() {
+            return remember_with_idempotency_yrp(&state, db_id, yrp, body, text, embedding, key)
+                .await;
+        }
         return remember_with_idempotency(&state, engine, body, text, embedding, key).await;
     }
 
@@ -752,13 +798,41 @@ async fn remember(
     // node. RID is allocated server-side (deterministic per-mutation,
     // not per-replica) and carried in the mutation body.
     let rid = uuid7::uuid7().to_string();
+    let mutation = upsert_mutation_from_body(&body, text, embedding, &rid);
+
+    let receipt = state
+        .commit_log
+        .commit(
+            crate::commit::TenantId::new(db_id),
+            mutation,
+            crate::commit::CommitOptions::default(),
+        )
+        .await
+        .map_err(commit_error_to_app_error)?;
+
+    let _ = engine; // engine handle is held only for quota check
+    Ok(Json(json!({
+        "rid": rid,
+        "log_index": receipt.log_index,
+    })))
+}
+
+/// Build the deterministic `UpsertMemory` mutation for a `/v1/remember`
+/// body. The rid is allocated by the CALLER before this (server-side,
+/// per-mutation — never per-replica) and the server timestamp is
+/// materialized here, so every node applies identical bytes.
+fn upsert_mutation_from_body(
+    body: &Value,
+    text: String,
+    embedding: Option<Vec<f32>>,
+    rid: &str,
+) -> crate::commit::MemoryMutation {
     let now_micros = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_micros() as i64)
         .unwrap_or(0);
-
-    let mutation = crate::commit::MemoryMutation::UpsertMemory {
-        rid: rid.clone(),
+    crate::commit::MemoryMutation::UpsertMemory {
+        rid: rid.to_string(),
         text,
         memory_type: body
             .get("memory_type")
@@ -802,23 +876,7 @@ async fn remember(
         extracted_entities: vec![],
         created_at_unix_micros: Some(now_micros),
         embedding_model: Some("default".into()),
-    };
-
-    let receipt = state
-        .commit_log
-        .commit(
-            crate::commit::TenantId::new(db_id),
-            mutation,
-            crate::commit::CommitOptions::default(),
-        )
-        .await
-        .map_err(commit_error_to_app_error)?;
-
-    let _ = engine; // engine handle is held only for quota check
-    Ok(Json(json!({
-        "rid": rid,
-        "log_index": receipt.log_index,
-    })))
+    }
 }
 
 /// Issue #58: the keyed `/v1/remember` path — engine-atomic claim + row.
@@ -949,6 +1007,127 @@ async fn remember_with_idempotency(
             format!("engine error: {e}"),
         )),
     }
+}
+
+/// RFC 028 §7: the keyed `/v1/remember` path in yrp mode — claim-in-log.
+///
+/// The claim is checked at the leader's origin ingress (the driver's
+/// `propose_keyed`), carried inside the committed entry, and never
+/// re-gated at apply. The response contract is byte-identical to the
+/// single-node engine path (issue #58 convergence with yantrikdb-mcp +
+/// hermes): fresh → `{rid}`; same key + same text → `{rid}` (original,
+/// silent HIT); same key + different text → 200 conflict shape; invalid
+/// key → 400. Retries during ANY replication state resolve through the
+/// claims table + durable outcome store — never a double-write.
+async fn remember_with_idempotency_yrp(
+    state: &Arc<AppState>,
+    db_id: i64,
+    yrp: Arc<crate::yrp::runtime::YrpHandle>,
+    body: Value,
+    text: String,
+    embedding: Option<Vec<f32>>,
+    key: String,
+) -> AppResult {
+    if key.trim().is_empty() || key.len() > 512 {
+        return Err(app_error(
+            StatusCode::BAD_REQUEST,
+            "invalid idempotency_key: must be non-blank and at most 512 bytes",
+        ));
+    }
+    // Replicated mutations must carry a materialized embedding — a None
+    // here would fail-stop the apply worker on every node. Refuse loudly.
+    let Some(embedding) = embedding else {
+        return Err(app_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "keyed writes in yrp mode require an embedding (server embedder \
+             unavailable and no client vector supplied)",
+        ));
+    };
+
+    let tenant = crate::commit::TenantId::new(db_id);
+    let rid = uuid7::uuid7().to_string();
+    let op = crate::yrp::op::YrpOp {
+        tenant_id: tenant,
+        op_id: crate::commit::OpId::new_random(),
+        mutation: upsert_mutation_from_body(&body, text.clone(), Some(embedding), &rid),
+        idempotency_key: Some(key.clone()),
+    };
+    let claim = crate::yrp::op::claim_key_for_idempotency(tenant, &key);
+
+    let outcome = match yrp.propose_and_wait(claim, &op).await {
+        Ok(o) => o,
+        Err(e) => {
+            return Err(commit_error_to_app_error(
+                crate::yrp::runtime::propose_err_to_commit(e, op.op_id),
+            ))
+        }
+    };
+
+    // Digest-collision guard: the durable outcome stores the FULL key
+    // string; a mismatch means two distinct keys share a 64-bit digest.
+    // Refuse rather than mis-dedupe (fail closed; astronomically rare).
+    if outcome.key_str.as_deref() != Some(key.as_str()) {
+        return Err(app_error(
+            StatusCode::CONFLICT,
+            "idempotency_key digest collision with a different stored key; \
+             use a different key",
+        ));
+    }
+    let original_rid = outcome.rid.clone().unwrap_or_default();
+    if original_rid == rid {
+        // Our entry won the claim: a fresh write.
+        return Ok(Json(json!({ "rid": rid })));
+    }
+
+    // Deduped against an earlier committed entry. Distinguish silent-HIT
+    // (same text) from conflict (different text) against the ORIGINAL
+    // mutation in the local commit log (materialized at apply).
+    let original_text = state
+        .commit_log
+        .read_range(tenant, outcome.tenant_log_index, 1)
+        .await
+        .ok()
+        .and_then(|entries| entries.into_iter().next())
+        .and_then(|e| match e.mutation {
+            crate::commit::MemoryMutation::UpsertMemory { text, .. } => Some(text),
+            _ => None,
+        });
+    match original_text {
+        Some(t) if t == text => Ok(Json(json!({ "rid": original_rid }))),
+        _ => Ok(Json(json!({
+            "stored": false,
+            "idempotency_conflict": true,
+            "rid": original_rid,
+        }))),
+    }
+}
+
+/// RFC 028: peer wire route — YRP messages ride the HTTP plane as a
+/// bincode envelope (see `yrp::transport`). Authenticated by the shared
+/// cluster secret when configured; malformed envelopes are a 400.
+async fn yrp_msg(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> AppResult {
+    let Some(yrp) = &state.yrp else {
+        return Err(app_error(StatusCode::NOT_FOUND, "yrp mode not enabled"));
+    };
+    if let Some(secret) = &yrp.cluster_secret {
+        let presented = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "));
+        if presented != Some(secret.as_str()) {
+            return Err(app_error(
+                StatusCode::UNAUTHORIZED,
+                "invalid cluster secret",
+            ));
+        }
+    }
+    yrp.deliver_inbound(&body)
+        .map_err(|e| app_error(StatusCode::BAD_REQUEST, e))?;
+    Ok(Json(json!({ "ok": true })))
 }
 
 /// Issue #58: keyed `/v1/remember/batch` — the engine's atomic batch path.
@@ -4922,6 +5101,8 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/v1/databases", get(list_databases))
         .route("/v1/cluster", get(cluster_status))
         .route("/v1/cluster/promote", post(cluster_promote))
+        // RFC 028: YRP peer wire (bincode envelope; cluster-secret gated)
+        .route("/v1/yrp/msg", post(yrp_msg))
         // v0.8.3 #24: openraft membership management
         .route("/v1/cluster/initialize", post(cluster_initialize))
         .route("/v1/cluster/add-learner", post(cluster_add_learner))
@@ -5614,6 +5795,7 @@ pub(crate) mod e2e_test_support {
             control_runtime: None,
             commit_log,
             raft: None,
+            yrp: None,
             fault_registry: crate::debug::FaultRegistry::new(),
             jobs,
             data_dir,

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -123,8 +123,9 @@ fn cluster_state_view(state: &AppState) -> Option<ClusterStateView> {
             match s.role {
                 crate::yrp::replica::Role::Leader => "leader",
                 crate::yrp::replica::Role::Follower => "follower",
-                crate::yrp::replica::Role::Candidate
-                | crate::yrp::replica::Role::PreCandidate => "candidate",
+                crate::yrp::replica::Role::Candidate | crate::yrp::replica::Role::PreCandidate => {
+                    "candidate"
+                }
             }
         };
         return Some(ClusterStateView {

--- a/crates/yantrikdb-server/src/main.rs
+++ b/crates/yantrikdb-server/src/main.rs
@@ -2079,9 +2079,8 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
                     election_ticks: (cfg.yrp.election_ticks_min, cfg.yrp.election_ticks_max),
                     heartbeat_ticks: cfg.yrp.heartbeat_ticks,
                 };
-                let handle =
-                    crate::yrp::runtime::spawn(runtime_cfg, local.clone(), applier)
-                        .map_err(|e| anyhow::anyhow!("YRP assembly failed: {e}"))?;
+                let handle = crate::yrp::runtime::spawn(runtime_cfg, local.clone(), applier)
+                    .map_err(|e| anyhow::anyhow!("YRP assembly failed: {e}"))?;
                 tracing::info!(
                     node_id = cfg.cluster.node_id,
                     cluster_id = cfg.yrp.cluster_id,

--- a/crates/yantrikdb-server/src/main.rs
+++ b/crates/yantrikdb-server/src/main.rs
@@ -1891,8 +1891,13 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
         }
     }
 
-    // Initialize cluster context if clustering is enabled
-    let cluster_ctx = if cfg.cluster.is_clustered() {
+    // Initialize cluster context if clustering is enabled. YRP mode
+    // (RFC 028) deliberately does NOT build the legacy raft-lite context:
+    // its heartbeat/election/sync loops would fight the YRP driver for
+    // write acceptance. YRP runs its own transport on the HTTP plane.
+    let cluster_ctx = if cfg.cluster.is_clustered()
+        && cfg.cluster.raft_mode != crate::raft::RaftClusterMode::Yrp
+    {
         let raft_path = cfg.server.data_dir.join("raft.json");
         let node_state = Arc::new(cluster::NodeState::new(
             cfg.cluster.node_id,
@@ -2009,9 +2014,10 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
         // it. Misconfig (openraft mode without cluster_tls) fails fast here
         // — server refuses to start, which is the production-safety
         // guarantee from `build_raft_cluster`.
-        let (commit_log, raft_assembly): (
+        let (commit_log, raft_assembly, yrp_handle): (
             Arc<dyn crate::commit::MutationCommitter>,
             Option<Arc<crate::raft::RaftAssembly>>,
+            Option<Arc<crate::yrp::runtime::YrpHandle>>,
         ) = match cfg.cluster.raft_mode {
             crate::raft::RaftClusterMode::Disabled => {
                 // RFC 010 PR-6.4 — single-node also needs an Applier so
@@ -2033,7 +2039,59 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
                     local_committer.clone(),
                     applier,
                 ));
-                (submitter as Arc<dyn crate::commit::MutationCommitter>, None)
+                (
+                    submitter as Arc<dyn crate::commit::MutationCommitter>,
+                    None,
+                    None,
+                )
+            }
+            crate::raft::RaftClusterMode::Yrp => {
+                // RFC 028: native replication. The driver owns consensus;
+                // the apply sink lands committed ops in commit-log +
+                // engine on every node; YrpCommitter funnels all handler
+                // writes through the replicated log. Boot inspection
+                // decides healthy-vs-quarantine — the process starts
+                // either way (quarantine serves diagnostics, refuses
+                // writes, retries rejoin).
+                let engine_resolver = Arc::new(crate::tenant_pool::TenantPoolEngineResolver::new(
+                    pool.clone(),
+                    control.clone(),
+                )) as Arc<dyn crate::commit::EngineResolver>;
+                let applier: Arc<dyn crate::commit::Applier> =
+                    Arc::new(crate::commit::EngineApplier::new(engine_resolver));
+                let local: Arc<dyn crate::commit::MutationCommitter> = local_committer.clone();
+                let runtime_cfg = crate::yrp::runtime::YrpRuntimeConfig {
+                    node_id: cfg.cluster.node_id as u64,
+                    cluster_id: cfg.yrp.cluster_id,
+                    peers: cfg
+                        .yrp
+                        .peers
+                        .iter()
+                        .map(|p| crate::yrp::runtime::YrpPeer {
+                            node_id: p.node_id,
+                            addr: p.addr.clone(),
+                            witness: p.witness,
+                        })
+                        .collect(),
+                    data_dir: cfg.server.data_dir.clone(),
+                    cluster_secret: cfg.cluster.cluster_secret.clone(),
+                    tick_ms: cfg.yrp.tick_ms,
+                    election_ticks: (cfg.yrp.election_ticks_min, cfg.yrp.election_ticks_max),
+                    heartbeat_ticks: cfg.yrp.heartbeat_ticks,
+                };
+                let handle =
+                    crate::yrp::runtime::spawn(runtime_cfg, local.clone(), applier)
+                        .map_err(|e| anyhow::anyhow!("YRP assembly failed: {e}"))?;
+                tracing::info!(
+                    node_id = cfg.cluster.node_id,
+                    cluster_id = cfg.yrp.cluster_id,
+                    peers = cfg.yrp.peers.len(),
+                    "YRP assembled — YrpCommitter now driving writes (RFC 028)"
+                );
+                let committer: Arc<dyn crate::commit::MutationCommitter> = Arc::new(
+                    crate::yrp::runtime::YrpCommitter::new(handle.clone(), local),
+                );
+                (committer, None, Some(handle))
             }
             crate::raft::RaftClusterMode::OpenRaft => {
                 let raft_log_path = cfg.server.data_dir.join("raft_log.sqlite");
@@ -2150,7 +2208,7 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
                 let committer: Arc<dyn crate::commit::MutationCommitter> =
                     Arc::new(assembly.committer.clone());
                 let assembly_arc = Arc::new(assembly);
-                (committer, Some(assembly_arc))
+                (committer, Some(assembly_arc), None)
             }
         };
 
@@ -2183,10 +2241,14 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
         let write_gate = {
             let raft = raft_assembly.clone();
             let cluster = cluster_ctx.clone();
+            let yrp = yrp_handle.clone();
             background::WriteAcceptanceGate::from_fn(move || {
                 if let Some(ref assembly) = raft {
                     let m = assembly.raft.metrics().borrow().clone();
                     return matches!(m.state, openraft::ServerState::Leader);
+                }
+                if let Some(ref h) = yrp {
+                    return h.is_leader();
                 }
                 if let Some(ref c) = cluster {
                     return c.state.accepts_writes();
@@ -2207,6 +2269,7 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
             control_runtime: control_runtime_handle.clone(),
             commit_log,
             raft: raft_assembly,
+            yrp: yrp_handle.clone(),
             fault_registry,
             jobs,
             data_dir: cfg.server.data_dir.clone(),

--- a/crates/yantrikdb-server/src/raft/assembly.rs
+++ b/crates/yantrikdb-server/src/raft/assembly.rs
@@ -56,6 +56,12 @@ pub enum RaftClusterMode {
     /// 3+ node cluster via openraft. Requires fully-specified
     /// `cluster_tls` (or `dev_mode = true` with a warning log).
     OpenRaft,
+    /// RFC 028: YantrikDB's native replication protocol. Configured by
+    /// the `[yrp]` section; boots through `yrp::bootstrap::inspect`
+    /// (quarantine-not-wedge) and drives writes through
+    /// `yrp::runtime::YrpCommitter`. Slated to replace `OpenRaft`
+    /// (Phase D removes the openraft path).
+    Yrp,
 }
 
 impl Default for RaftClusterMode {

--- a/crates/yantrikdb-server/src/server.rs
+++ b/crates/yantrikdb-server/src/server.rs
@@ -51,6 +51,11 @@ pub struct AppState {
     /// `/v1/raft/*` (peer-to-peer RPC receive routes), and by the
     /// metrics recorder.
     pub raft: Option<std::sync::Arc<crate::raft::RaftAssembly>>,
+    /// RFC 028: YRP native-replication handle when cluster runs in
+    /// `RaftClusterMode::Yrp`. `None` otherwise. The gateway uses it for
+    /// the `/v1/yrp/msg` peer route, the keyed write path, health, and
+    /// leader redirects.
+    pub yrp: Option<std::sync::Arc<crate::yrp::runtime::YrpHandle>>,
     /// RFC 010 PR-5: in-memory fault-injection registry. Empty in
     /// production builds; populated by Jepsen runners via
     /// `/v1/debug/fault/inject`. The cluster transport layer (RFC 010

--- a/crates/yantrikdb-server/src/yrp/bootstrap.rs
+++ b/crates/yantrikdb-server/src/yrp/bootstrap.rs
@@ -433,7 +433,10 @@ mod tests {
                 current_term: Term(3),
                 voted_for: Some(NodeId(2)),
             }),
-            log: Some(vec![LogEntry::unkeyed(Term(3), 42)]),
+            log: Some(vec![LogEntry::unkeyed(
+                Term(3),
+                super::super::replica::Payload::Test(42),
+            )]),
             active: 0,
             commit_marker: 1,
             integrity: Integrity {

--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -137,8 +137,15 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
     // 3. Silent HIT: identical retry answers the ORIGINAL rid.
     let (st, resp) = post_json(&leader.base, &leader.token, "/v1/remember", &body1).await;
     assert_eq!(st, reqwest::StatusCode::OK);
-    assert_eq!(resp["rid"].as_str(), Some(rid.as_str()), "retry must dedupe to the original rid");
-    assert!(resp.get("idempotency_conflict").is_none(), "same text must be a silent HIT: {resp}");
+    assert_eq!(
+        resp["rid"].as_str(),
+        Some(rid.as_str()),
+        "retry must dedupe to the original rid"
+    );
+    assert!(
+        resp.get("idempotency_conflict").is_none(),
+        "same text must be a silent HIT: {resp}"
+    );
 
     // 4. Same key + different text → 200 conflict shape, original rid.
     let body_conflict = json!({
@@ -148,7 +155,11 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
     });
     let (st, resp) = post_json(&leader.base, &leader.token, "/v1/remember", &body_conflict).await;
     assert_eq!(st, reqwest::StatusCode::OK);
-    assert_eq!(resp["idempotency_conflict"], json!(true), "conflict shape expected: {resp}");
+    assert_eq!(
+        resp["idempotency_conflict"],
+        json!(true),
+        "conflict shape expected: {resp}"
+    );
     assert_eq!(resp["stored"], json!(false));
     assert_eq!(resp["rid"].as_str(), Some(rid.as_str()));
 
@@ -164,7 +175,10 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
     let (st, resp) = post_json(&leader.base, &leader.token, "/v1/remember", &body_unkeyed).await;
     assert_eq!(st, reqwest::StatusCode::OK, "unkeyed write failed: {resp}");
     let rid2 = resp["rid"].as_str().expect("rid").to_string();
-    assert!(resp["log_index"].as_u64().is_some(), "receipt log_index missing: {resp}");
+    assert!(
+        resp["log_index"].as_u64().is_some(),
+        "receipt log_index missing: {resp}"
+    );
     wait_for_recall(&follower, &emb2, &rid2).await;
 
     // 7. Writes against the follower are refused with leader info — the
@@ -190,12 +204,7 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
         assert_eq!(v["cluster"]["raft_mode"], json!("yrp"), "health: {v}");
     }
     assert_eq!(
-        leader
-            .state
-            .yrp
-            .as_ref()
-            .unwrap()
-            .quarantine_reasons(),
+        leader.state.yrp.as_ref().unwrap().quarantine_reasons(),
         None
     );
 }
@@ -247,9 +256,10 @@ async fn spawn_node_inner(node_id: u64, peers: Vec<YrpPeer>, port: u16) -> Node 
     let admission = crate::admission::AdmissionState::new(Default::default());
     let jobs: Arc<dyn crate::jobs::JobQueue> =
         Arc::new(crate::jobs::LocalSqliteJobQueue::open_in_memory().expect("jobs"));
-    let auth_provider: Arc<dyn crate::auth::AuthProvider> = Arc::new(
-        ControlDbAuthProvider::new(Arc::clone(&control), Some(SECRET.to_string())),
-    );
+    let auth_provider: Arc<dyn crate::auth::AuthProvider> = Arc::new(ControlDbAuthProvider::new(
+        Arc::clone(&control),
+        Some(SECRET.to_string()),
+    ));
 
     let local: Arc<dyn crate::commit::MutationCommitter> = Arc::new(
         crate::commit::LocalSqliteCommitter::open(data_dir.join("commit_log.sqlite"))

--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -1,0 +1,351 @@
+//! 2-node YRP cluster over REAL localhost HTTP — the runtime-integration
+//! slice's acceptance test (handoff steps 7+8).
+//!
+//! Two full servers (production router, real engines, real tempdir
+//! stores) form a 2-voter cluster whose YRP wire messages ride actual
+//! `POST /v1/yrp/msg` requests. Asserts, in order:
+//!
+//! 1. An election happens over HTTP and exactly one node leads.
+//! 2. A keyed `/v1/remember` on the leader commits and answers `{rid}`.
+//! 3. The identical retry answers the SAME rid (silent HIT) — the
+//!    issue-#58 contract, now replicated (the historical 501 is gone).
+//! 4. Same key + different text answers the 200 conflict shape with the
+//!    original rid.
+//! 5. **nuron's live-recall axis**: the FOLLOWER's live `/v1/recall`
+//!    (in-memory index, not just SQLite) surfaces the replicated memory —
+//!    the durable-green/live-red failure class.
+//! 6. An unkeyed write also replicates (the YrpCommitter funnel).
+//! 7. A write against the follower is refused with the leader's address
+//!    (503 via check_writable) — never silently accepted.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde_json::{json, Value};
+
+use crate::auth::ControlDbAuthProvider;
+use crate::control::ControlDb;
+use crate::server::AppState;
+use crate::yrp::runtime::{spawn as spawn_yrp, YrpCommitter, YrpPeer, YrpRuntimeConfig};
+
+struct Node {
+    state: Arc<AppState>,
+    handle: Arc<crate::yrp::runtime::YrpHandle>,
+    base: String,
+    token: String,
+    _tmp: tempfile::TempDir,
+}
+
+const CLUSTER_ID: u64 = 7;
+const SECRET: &str = "yrp-test-cluster-secret";
+const TENANT: &str = "yrpcluster";
+
+async fn post_json(
+    base: &str,
+    token: &str,
+    path: &str,
+    body: &Value,
+) -> (reqwest::StatusCode, Value) {
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let resp = client
+        .post(format!("{base}{path}"))
+        .bearer_auth(token)
+        .json(body)
+        .send()
+        .await
+        .expect("request");
+    let status = resp.status();
+    let text = resp.text().await.expect("body");
+    let val: Value = serde_json::from_str(&text).unwrap_or(json!({ "raw": text }));
+    (status, val)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("yantrikdb=info")
+        .with_test_writer()
+        .try_init();
+    // Pre-bind both HTTP ports so the peer lists can be exchanged before
+    // either server exists.
+    let l1 = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let l2 = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let p1 = l1.local_addr().unwrap().port();
+    let p2 = l2.local_addr().unwrap().port();
+    drop((l1, l2));
+    let peers = vec![
+        YrpPeer {
+            node_id: 1,
+            addr: format!("http://127.0.0.1:{p1}"),
+            witness: false,
+        },
+        YrpPeer {
+            node_id: 2,
+            addr: format!("http://127.0.0.1:{p2}"),
+            witness: false,
+        },
+    ];
+
+    // Spawn both nodes on the advertised ports.
+    let mut n1 = spawn_node_on(1, peers.clone(), p1).await;
+    let mut n2 = spawn_node_on(2, peers.clone(), p2).await;
+
+    // 1. Election over real HTTP.
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+    let leader_is_n1 = loop {
+        if n1.handle.is_leader() {
+            break true;
+        }
+        if n2.handle.is_leader() {
+            break false;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "no leader elected over HTTP transport"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    };
+    if !leader_is_n1 {
+        std::mem::swap(&mut n1, &mut n2);
+    }
+    let (leader, follower) = (n1, n2);
+
+    // The engine's default embedding dim is 384 — synthesize two
+    // distinct full-width vectors.
+    let embedding = |seed: f32| -> Value {
+        json!((0..384)
+            .map(|i| (i as f32).mul_add(0.001, seed).sin())
+            .collect::<Vec<f32>>())
+    };
+    let emb1 = embedding(0.25);
+    let emb2 = embedding(2.5);
+
+    // 2. Keyed write on the leader — the endpoint that returned 501 in
+    // cluster mode until this slice.
+    let body1 = json!({
+        "text": "yrp replicated memory alpha",
+        "embedding": emb1,
+        "idempotency_key": "yrp-e2e-key-1",
+    });
+    let (st, resp) = post_json(&leader.base, &leader.token, "/v1/remember", &body1).await;
+    assert_eq!(st, reqwest::StatusCode::OK, "keyed write failed: {resp}");
+    let rid = resp["rid"].as_str().expect("rid in response").to_string();
+
+    // 3. Silent HIT: identical retry answers the ORIGINAL rid.
+    let (st, resp) = post_json(&leader.base, &leader.token, "/v1/remember", &body1).await;
+    assert_eq!(st, reqwest::StatusCode::OK);
+    assert_eq!(resp["rid"].as_str(), Some(rid.as_str()), "retry must dedupe to the original rid");
+    assert!(resp.get("idempotency_conflict").is_none(), "same text must be a silent HIT: {resp}");
+
+    // 4. Same key + different text → 200 conflict shape, original rid.
+    let body_conflict = json!({
+        "text": "DIFFERENT text under the same key",
+        "embedding": emb1,
+        "idempotency_key": "yrp-e2e-key-1",
+    });
+    let (st, resp) = post_json(&leader.base, &leader.token, "/v1/remember", &body_conflict).await;
+    assert_eq!(st, reqwest::StatusCode::OK);
+    assert_eq!(resp["idempotency_conflict"], json!(true), "conflict shape expected: {resp}");
+    assert_eq!(resp["stored"], json!(false));
+    assert_eq!(resp["rid"].as_str(), Some(rid.as_str()));
+
+    // 5. Follower LIVE recall reflects the replicated apply (nuron's
+    // live-recall axis: in-memory index coherence, not just durable rows).
+    wait_for_recall(&follower, &emb1, &rid).await;
+
+    // 6. Unkeyed writes ride the same replicated funnel (YrpCommitter).
+    let body_unkeyed = json!({
+        "text": "yrp replicated memory beta (unkeyed)",
+        "embedding": emb2,
+    });
+    let (st, resp) = post_json(&leader.base, &leader.token, "/v1/remember", &body_unkeyed).await;
+    assert_eq!(st, reqwest::StatusCode::OK, "unkeyed write failed: {resp}");
+    let rid2 = resp["rid"].as_str().expect("rid").to_string();
+    assert!(resp["log_index"].as_u64().is_some(), "receipt log_index missing: {resp}");
+    wait_for_recall(&follower, &emb2, &rid2).await;
+
+    // 7. Writes against the follower are refused with leader info — the
+    // key is never silently dropped and never double-executed.
+    let (st, resp) = post_json(&follower.base, &follower.token, "/v1/remember", &body1).await;
+    assert_eq!(
+        st,
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "follower must refuse writes: {resp}"
+    );
+
+    // Health surfaces yrp mode honestly on both nodes.
+    let client = reqwest::Client::new();
+    for n in [&leader, &follower] {
+        let v: Value = client
+            .get(format!("{}/v1/health", n.base))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(v["cluster"]["raft_mode"], json!("yrp"), "health: {v}");
+    }
+    assert_eq!(
+        leader
+            .state
+            .yrp
+            .as_ref()
+            .unwrap()
+            .quarantine_reasons(),
+        None
+    );
+}
+
+async fn spawn_node_on(node_id: u64, peers: Vec<YrpPeer>, port: u16) -> Node {
+    let node = spawn_node_inner(node_id, peers, port).await;
+    // Readiness: health answers.
+    let client = reqwest::Client::new();
+    for _ in 0..100 {
+        if client
+            .get(format!("{}/v1/health", node.base))
+            .send()
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    node
+}
+
+/// One full server: control DB (same db name on every node → same
+/// tenant id, which rides inside replicated ops), real engine pool,
+/// the yrp-mode assembly mirroring main.rs's Yrp arm, and the
+/// PRODUCTION router served on the pre-advertised port.
+async fn spawn_node_inner(node_id: u64, peers: Vec<YrpPeer>, port: u16) -> Node {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let data_dir = tmp.path().to_path_buf();
+
+    let mut cfg = crate::config::ServerConfig::default();
+    cfg.server.data_dir = data_dir.clone();
+
+    let control = ControlDb::open(&data_dir.join("control.db")).expect("control db");
+    let raw_token = crate::auth::generate_token();
+    let token_hash = crate::auth::hash_token(&raw_token);
+    let db_id = control.create_database(TENANT, TENANT).expect("create db");
+    control
+        .create_token(&token_hash, db_id, "yrp-test")
+        .expect("create token");
+    let control = Arc::new(Mutex::new(control));
+
+    let pool = Arc::new(crate::tenant_pool::TenantPool::new(&cfg, None, None));
+    let workers = crate::background::WorkerRegistry::new(
+        &cfg.background,
+        &cfg.maintenance,
+        crate::background::WriteAcceptanceGate::standalone(),
+    );
+    let admission = crate::admission::AdmissionState::new(Default::default());
+    let jobs: Arc<dyn crate::jobs::JobQueue> =
+        Arc::new(crate::jobs::LocalSqliteJobQueue::open_in_memory().expect("jobs"));
+    let auth_provider: Arc<dyn crate::auth::AuthProvider> = Arc::new(
+        ControlDbAuthProvider::new(Arc::clone(&control), Some(SECRET.to_string())),
+    );
+
+    let local: Arc<dyn crate::commit::MutationCommitter> = Arc::new(
+        crate::commit::LocalSqliteCommitter::open(data_dir.join("commit_log.sqlite"))
+            .expect("commit log"),
+    );
+    let resolver = Arc::new(crate::tenant_pool::TenantPoolEngineResolver::new(
+        pool.clone(),
+        control.clone(),
+    )) as Arc<dyn crate::commit::EngineResolver>;
+    let applier: Arc<dyn crate::commit::Applier> =
+        Arc::new(crate::commit::EngineApplier::new(resolver));
+    let handle = spawn_yrp(
+        YrpRuntimeConfig {
+            node_id,
+            cluster_id: CLUSTER_ID,
+            peers,
+            data_dir: data_dir.clone(),
+            cluster_secret: Some(SECRET.to_string()),
+            tick_ms: 20,
+            election_ticks: (5, 10),
+            heartbeat_ticks: 2,
+        },
+        local.clone(),
+        applier,
+    )
+    .expect("yrp spawn");
+    let commit_log: Arc<dyn crate::commit::MutationCommitter> =
+        Arc::new(YrpCommitter::new(handle.clone(), local));
+
+    let state = Arc::new(AppState {
+        control,
+        pool,
+        workers,
+        cluster: None,
+        inflight: std::sync::atomic::AtomicU32::new(0),
+        admission,
+        control_runtime: None,
+        commit_log,
+        raft: None,
+        yrp: Some(handle.clone()),
+        fault_registry: crate::debug::FaultRegistry::new(),
+        jobs,
+        data_dir,
+        auth_provider,
+    });
+
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+        .await
+        .expect("bind advertised port");
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let app = crate::http_gateway::router(state.clone());
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    Node {
+        state,
+        handle,
+        base,
+        token: raw_token,
+        _tmp: tmp,
+    }
+}
+
+/// Poll the follower's LIVE /v1/recall (client query vector — no
+/// embedder in the fixture) until `rid` appears.
+async fn wait_for_recall(node: &Node, query_embedding: &Value, rid: &str) {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        let (st, resp) = post_json(
+            &node.base,
+            &node.token,
+            "/v1/recall",
+            &json!({
+                "query": "yrp replicated memory",
+                "query_embedding": query_embedding,
+                "top_k": 10,
+            }),
+        )
+        .await;
+        if st == reqwest::StatusCode::OK {
+            let found = resp["results"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .any(|r| r.get("rid").and_then(|v| v.as_str()) == Some(rid))
+                })
+                .unwrap_or(false);
+            if found {
+                return;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "follower live recall never surfaced {rid}; last response: {resp}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}

--- a/crates/yantrikdb-server/src/yrp/driver.rs
+++ b/crates/yantrikdb-server/src/yrp/driver.rs
@@ -52,7 +52,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 
 use super::bootstrap::RejoinMessage;
-use super::replica::{Effect, KeyedProposal, LogEntry, Message, ReplicaCore, Role};
+use super::replica::{Effect, KeyedProposal, LogEntry, Message, Payload, ReplicaCore, Role};
 use super::types::{HardState, LogPosition, NodeId};
 
 /// Everything the core needs durably persisted, as one atomic unit — the
@@ -118,7 +118,7 @@ pub enum DriverEvent {
     },
     Propose {
         key: u64,
-        payload: u64,
+        payload: Payload,
         reply: oneshot::Sender<ProposeOutcome>,
     },
     /// Apply worker reports the highest contiguous durably-applied index.
@@ -352,7 +352,7 @@ impl YrpDriver {
     fn on_propose(
         &mut self,
         key: u64,
-        payload: u64,
+        payload: Payload,
         reply: oneshot::Sender<ProposeOutcome>,
     ) -> Option<DriverExit> {
         match self.core.propose_keyed(key, payload) {
@@ -457,7 +457,7 @@ impl YrpDriver {
                     let from = self.dispatched + 1;
                     for i in from..=to {
                         if let Some(e) = self.core.entry(i) {
-                            let _ = self.apply_tx.send((i, *e));
+                            let _ = self.apply_tx.send((i, e.clone()));
                         }
                     }
                     self.dispatched = self.dispatched.max(to);
@@ -561,7 +561,7 @@ mod tests {
     impl ApplySink for TestSink {
         fn apply(&mut self, index: u64, entry: &LogEntry) -> Result<(), String> {
             let mut s = self.0.lock().unwrap();
-            s.applied.push((index, *entry));
+            s.applied.push((index, entry.clone()));
             s.durable_applied = index;
             Ok(())
         }
@@ -633,7 +633,7 @@ mod tests {
                 let (otx, orx) = oneshot::channel();
                 let _ = n.tx.send(DriverEvent::Propose {
                     key,
-                    payload,
+                    payload: Payload::Test(payload),
                     reply: otx,
                 });
                 if let Ok(Ok(out)) = tokio::time::timeout(Duration::from_millis(500), orx).await {
@@ -674,7 +674,7 @@ mod tests {
         let (otx, orx) = oneshot::channel();
         let _ = nodes[&leader].tx.send(DriverEvent::Propose {
             key: 42,
-            payload: 4242,
+            payload: Payload::Test(4242),
             reply: otx,
         });
         match tokio::time::timeout(Duration::from_secs(2), orx)

--- a/crates/yantrikdb-server/src/yrp/driver.rs
+++ b/crates/yantrikdb-server/src/yrp/driver.rs
@@ -53,12 +53,14 @@ use tokio::sync::{mpsc, oneshot};
 
 use super::bootstrap::RejoinMessage;
 use super::replica::{Effect, KeyedProposal, LogEntry, Message, Payload, ReplicaCore, Role};
-use super::types::{HardState, LogPosition, NodeId};
+use super::types::{ClusterId, HardState, LogPosition, NodeId};
 
 /// Everything the core needs durably persisted, as one atomic unit — the
-/// on-disk mirror of [`Effect::Persist`].
+/// on-disk mirror of [`Effect::Persist`] (plus the node's cluster
+/// identity, so boot inspection can detect alien state).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DurableState {
+    pub cluster_id: ClusterId,
     pub hard: HardState,
     pub base: LogPosition,
     pub log: Vec<LogEntry>,
@@ -89,13 +91,47 @@ pub trait Transport: Send + 'static {
 ///    again for indices at or below the last durable applied index and
 ///    MUST be idempotent there.
 /// 2. The implementation MUST make the entry's effects AND its applied
-///    index (AND, for keyed entries, the key→outcome record) durable in
-///    ONE atomic unit before returning Ok.
+///    index (AND, for keyed entries, the key→outcome record) durable
+///    before returning Ok, such that a crash-replay of the same index is
+///    a no-op (the production sink achieves this with the op_id-idempotent
+///    commit-log transaction + idempotent engine primitives + the
+///    marker-last ordering — see `yrp::engine_sink`).
 /// 3. Returning Err is fail-stop: the driver exits (quarantine posture).
+///
+/// `apply` is async because the production sink composes the repo's async
+/// `MutationCommitter`/`Applier` traits; the worker still consumes strictly
+/// in order (one apply at a time).
+#[async_trait::async_trait]
 pub trait ApplySink: Send + 'static {
-    fn apply(&mut self, index: u64, entry: &LogEntry) -> Result<(), String>;
+    async fn apply(&mut self, index: u64, entry: &LogEntry) -> Result<(), String>;
     /// The last index this sink has durably applied (recovered at boot).
     fn durable_applied(&self) -> u64;
+}
+
+/// Live snapshot of the driver's replication state, published on a watch
+/// channel for health surfaces and write gates. Never authoritative for
+/// safety — purely observational.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct YrpStatus {
+    pub role: Role,
+    pub term: u64,
+    pub commit: u64,
+    pub applied: u64,
+    /// Last leader this node heard from (itself when leading). A HINT for
+    /// redirects — may be stale.
+    pub leader: Option<NodeId>,
+}
+
+impl Default for YrpStatus {
+    fn default() -> Self {
+        Self {
+            role: Role::Follower,
+            term: 0,
+            commit: 0,
+            applied: 0,
+            leader: None,
+        }
+    }
 }
 
 /// Client-facing outcome of a keyed proposal, delivered via oneshot.
@@ -186,6 +222,7 @@ impl FileStore {
 /// Driver configuration.
 pub struct DriverConfig {
     pub id: NodeId,
+    pub cluster_id: ClusterId,
     pub voters: std::collections::BTreeSet<NodeId>,
     pub witnesses: std::collections::BTreeSet<NodeId>,
     pub supported: u32,
@@ -218,6 +255,10 @@ pub struct YrpDriver {
     election_ticks_left: Option<u32>,
     heartbeat_ticks_left: u32,
     rng: u64,
+    /// Last leader observed via append/install traffic (self when leading).
+    leader_hint: Option<NodeId>,
+    /// Optional live-status publisher (health surface / write gate).
+    status_tx: Option<tokio::sync::watch::Sender<YrpStatus>>,
 }
 
 impl YrpDriver {
@@ -233,7 +274,13 @@ impl YrpDriver {
         durable_applied: u64,
     ) -> Self {
         let (hard, base, log, claims, active) = match restored {
-            Some(d) => (d.hard, d.base, d.log, d.claims, d.active),
+            Some(d) => {
+                debug_assert_eq!(
+                    d.cluster_id, cfg.cluster_id,
+                    "alien state must be quarantined by boot inspection, never reach the driver"
+                );
+                (d.hard, d.base, d.log, d.claims, d.active)
+            }
             None => (
                 HardState::default(),
                 LogPosition::ZERO,
@@ -267,9 +314,41 @@ impl YrpDriver {
             election_ticks_left: None,
             heartbeat_ticks_left: 0,
             rng: seed,
+            leader_hint: None,
+            status_tx: None,
         };
         d.arm_election_deadline();
         d
+    }
+
+    /// Attach a live-status publisher. The driver sends a fresh snapshot
+    /// after every processed event; receivers use it for health/redirects.
+    pub fn set_status_tx(&mut self, tx: tokio::sync::watch::Sender<YrpStatus>) {
+        tx.send_replace(self.status_snapshot());
+        self.status_tx = Some(tx);
+    }
+
+    fn status_snapshot(&self) -> YrpStatus {
+        YrpStatus {
+            role: self.core.role(),
+            term: self.core.current_term().0,
+            commit: self.core.commit_index(),
+            applied: self.applied,
+            leader: if self.core.role() == Role::Leader {
+                Some(self.cfg.id)
+            } else {
+                self.leader_hint
+            },
+        }
+    }
+
+    fn publish_status(&self) {
+        if let Some(tx) = &self.status_tx {
+            let snap = self.status_snapshot();
+            if *tx.borrow() != snap {
+                tx.send_replace(snap);
+            }
+        }
     }
 
     fn rand(&mut self) -> u64 {
@@ -308,6 +387,7 @@ impl YrpDriver {
             if let Some(e) = exit {
                 return e;
             }
+            self.publish_status();
         }
         DriverExit::Shutdown
     }
@@ -323,6 +403,7 @@ impl YrpDriver {
                     Message::AppendEntries { .. } | Message::InstallSnapshot { .. }
                 ) {
                     self.arm_election_deadline();
+                    self.leader_hint = Some(from);
                 }
                 let effects = self.core.on_message(from, m, false);
                 self.execute(effects)
@@ -332,7 +413,7 @@ impl YrpDriver {
                     self.transport.send(
                         node,
                         WireMsg::Rejoin(RejoinMessage::Grant {
-                            cluster_id: super::types::ClusterId(0), // config-bound in HTTP slice
+                            cluster_id: self.cfg.cluster_id,
                             term,
                             base,
                             log,
@@ -416,6 +497,7 @@ impl YrpDriver {
                     active,
                 } => {
                     let state = DurableState {
+                        cluster_id: self.cfg.cluster_id,
                         hard,
                         base,
                         log,
@@ -505,7 +587,7 @@ pub async fn run_apply_worker(
         if index <= sink.durable_applied() {
             continue; // crash-replay of an already-durable index: idempotent skip
         }
-        match sink.apply(index, &entry) {
+        match sink.apply(index, &entry).await {
             Ok(()) => {
                 let _ = owner.send(DriverEvent::Applied { upto: index });
             }
@@ -558,8 +640,9 @@ mod tests {
         durable_applied: u64,
     }
     struct TestSink(Arc<Mutex<SinkState>>);
+    #[async_trait::async_trait]
     impl ApplySink for TestSink {
-        fn apply(&mut self, index: u64, entry: &LogEntry) -> Result<(), String> {
+        async fn apply(&mut self, index: u64, entry: &LogEntry) -> Result<(), String> {
             let mut s = self.0.lock().unwrap();
             s.applied.push((index, entry.clone()));
             s.durable_applied = index;
@@ -593,6 +676,7 @@ mod tests {
         let driver = YrpDriver::new(
             DriverConfig {
                 id: NodeId(id),
+                cluster_id: super::super::types::ClusterId(0),
                 voters,
                 witnesses: BTreeSet::new(),
                 supported: u32::MAX,
@@ -746,6 +830,7 @@ mod tests {
         let driver = YrpDriver::new(
             DriverConfig {
                 id: NodeId(1),
+                cluster_id: super::super::types::ClusterId(0),
                 voters,
                 witnesses: BTreeSet::new(),
                 supported: u32::MAX,

--- a/crates/yantrikdb-server/src/yrp/engine_sink.rs
+++ b/crates/yantrikdb-server/src/yrp/engine_sink.rs
@@ -43,7 +43,9 @@ use rusqlite::Connection;
 use super::driver::ApplySink;
 use super::op::YrpOp;
 use super::replica::{LogEntry, Payload};
-use crate::commit::{Applier, ApplyError, CommitError, CommitOptions, MemoryMutation, MutationCommitter, TenantId};
+use crate::commit::{
+    Applier, ApplyError, CommitError, CommitOptions, MemoryMutation, MutationCommitter, TenantId,
+};
 
 /// One applied entry's durable outcome — everything the gateway needs to
 /// answer a deduped retry (the original rid), verify the full idempotency
@@ -107,9 +109,11 @@ impl OutcomeStore {
         )
         .map_err(|e| format!("init yrp_apply schema: {e}"))?;
         let applied: i64 = conn
-            .query_row("SELECT applied_index FROM yrp_applied WHERE id = 1", [], |r| {
-                r.get(0)
-            })
+            .query_row(
+                "SELECT applied_index FROM yrp_applied WHERE id = 1",
+                [],
+                |r| r.get(0),
+            )
             .map_err(|e| format!("read applied marker: {e}"))?;
         Ok(Self {
             conn: Mutex::new(conn),
@@ -125,9 +129,7 @@ impl OutcomeStore {
     /// Record an applied op's outcome AND advance the marker, atomically.
     pub fn record(&self, out: &AppliedOutcome) -> Result<(), String> {
         let mut conn = self.conn.lock();
-        let tx = conn
-            .transaction()
-            .map_err(|e| format!("outcome tx: {e}"))?;
+        let tx = conn.transaction().map_err(|e| format!("outcome tx: {e}"))?;
         tx.execute(
             "INSERT OR REPLACE INTO yrp_outcome
                  (yrp_index, term, tenant_id, op_id, key_hash, key_str, rid,
@@ -249,7 +251,9 @@ impl ApplySink for EngineApplySink {
             // A Test payload on the production sink is a wiring bug —
             // fail-stop rather than silently skip (contract clause 3).
             Payload::Test(n) => {
-                return Err(format!("Test payload {n} reached production sink at {index}"))
+                return Err(format!(
+                    "Test payload {n} reached production sink at {index}"
+                ))
             }
             Payload::Op(b) => b,
         };
@@ -283,7 +287,11 @@ impl ApplySink for EngineApplySink {
             // posture as the openraft state machine (the commit-log row is
             // the durable truth; the engine wiring lands with its RFC).
             Err(ApplyError::NotYetWired { variant, .. }) => {
-                tracing::warn!(variant, index, "YRP apply: mutation not yet wired to engine");
+                tracing::warn!(
+                    variant,
+                    index,
+                    "YRP apply: mutation not yet wired to engine"
+                );
             }
             Err(e) => return Err(format!("engine apply at {index}: {e}")),
         }
@@ -364,7 +372,10 @@ mod tests {
         let mut sink = EngineApplySink::new(committer.clone(), applier, outcomes.clone());
 
         let op = sample_op(Some("k1"));
-        let key = Some(crate::yrp::op::claim_key_for_idempotency(op.tenant_id, "k1"));
+        let key = Some(crate::yrp::op::claim_key_for_idempotency(
+            op.tenant_id,
+            "k1",
+        ));
         let entry = op_entry(3, key, &op);
 
         sink.apply(5, &entry).await.expect("first apply");

--- a/crates/yantrikdb-server/src/yrp/engine_sink.rs
+++ b/crates/yantrikdb-server/src/yrp/engine_sink.rs
@@ -1,0 +1,406 @@
+//! The production [`super::driver::ApplySink`] — where replicated YRP
+//! entries land in real engine state.
+//!
+//! ## The atomicity story (the ApplySink contract, honestly)
+//!
+//! The sink's durable footprint spans three stores that cannot share one
+//! SQLite transaction (per-tenant engine DBs, the shared commit log, and
+//! the sink's own marker DB). The contract's guarantee — a crash never
+//! separates an entry's effects from its applied-index/outcome record in
+//! an observable way — is met by ORDER + IDEMPOTENCE instead:
+//!
+//! 1. **Commit-log first** ([`crate::commit::LocalSqliteCommitter`]):
+//!    the `(tenant, op_id)` unique index makes this exactly-once — a
+//!    crash-replay returns the ORIGINAL receipt (same shape openraft's
+//!    state machine relied on).
+//! 2. **Engine apply second** ([`crate::commit::Applier`]): the
+//!    deterministic `*_with_rid` primitives are idempotent per rid/seq;
+//!    `AlreadyApplied` is success.
+//! 3. **Marker + outcome LAST**, in one transaction of the sink DB. The
+//!    marker is what `durable_applied()` reports, so a crash anywhere
+//!    before step 3 simply replays the entry through steps 1–2 (both
+//!    no-ops) and completes step 3. The marker can never run AHEAD of
+//!    the effects — which is the direction that would violate the
+//!    contract (acking an apply that didn't happen).
+//!
+//! Client acks release only on the marker (the driver's `Applied` event),
+//! so "success reported, effect missing" is structurally impossible.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use rusqlite::Connection;
+
+use super::driver::ApplySink;
+use super::op::YrpOp;
+use super::replica::{LogEntry, Payload};
+use crate::commit::{Applier, ApplyError, CommitError, CommitOptions, MemoryMutation, MutationCommitter, TenantId};
+
+/// One applied entry's durable outcome — everything the gateway needs to
+/// answer a deduped retry (the original rid), verify the full idempotency
+/// key against hash collisions, and rebuild a commit receipt.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AppliedOutcome {
+    pub yrp_index: u64,
+    pub term: u64,
+    pub tenant_id: i64,
+    pub op_id: String,
+    /// The protocol claim digest (`LogEntry.key`).
+    pub key_hash: Option<u64>,
+    /// The FULL client idempotency key (collision verification).
+    pub key_str: Option<String>,
+    /// Client-visible outcome id, when the mutation has one.
+    pub rid: Option<String>,
+    /// Per-tenant commit-log index assigned in step 1.
+    pub tenant_log_index: u64,
+    pub applied_at_unix_micros: i64,
+}
+
+/// Durable applied-index marker + outcome table (`yrp_apply.sqlite`).
+pub struct OutcomeStore {
+    conn: Mutex<Connection>,
+    applied: AtomicU64,
+}
+
+impl OutcomeStore {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, String> {
+        let conn = Connection::open(path).map_err(|e| format!("open yrp_apply: {e}"))?;
+        Self::init(conn)
+    }
+
+    pub fn open_in_memory() -> Result<Self, String> {
+        let conn = Connection::open_in_memory().map_err(|e| format!("open yrp_apply: {e}"))?;
+        Self::init(conn)
+    }
+
+    fn init(conn: Connection) -> Result<Self, String> {
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA synchronous=FULL;
+             CREATE TABLE IF NOT EXISTS yrp_applied (
+                 id INTEGER PRIMARY KEY CHECK (id = 1),
+                 applied_index INTEGER NOT NULL
+             );
+             INSERT OR IGNORE INTO yrp_applied (id, applied_index) VALUES (1, 0);
+             CREATE TABLE IF NOT EXISTS yrp_outcome (
+                 yrp_index INTEGER PRIMARY KEY,
+                 term INTEGER NOT NULL,
+                 tenant_id INTEGER NOT NULL,
+                 op_id TEXT NOT NULL,
+                 key_hash INTEGER,
+                 key_str TEXT,
+                 rid TEXT,
+                 tenant_log_index INTEGER NOT NULL,
+                 applied_at_unix_micros INTEGER NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS idx_yrp_outcome_key
+                 ON yrp_outcome (key_hash);",
+        )
+        .map_err(|e| format!("init yrp_apply schema: {e}"))?;
+        let applied: i64 = conn
+            .query_row("SELECT applied_index FROM yrp_applied WHERE id = 1", [], |r| {
+                r.get(0)
+            })
+            .map_err(|e| format!("read applied marker: {e}"))?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+            applied: AtomicU64::new(applied as u64),
+        })
+    }
+
+    /// Highest durably-applied YRP index.
+    pub fn applied(&self) -> u64 {
+        self.applied.load(Ordering::Acquire)
+    }
+
+    /// Record an applied op's outcome AND advance the marker, atomically.
+    pub fn record(&self, out: &AppliedOutcome) -> Result<(), String> {
+        let mut conn = self.conn.lock();
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("outcome tx: {e}"))?;
+        tx.execute(
+            "INSERT OR REPLACE INTO yrp_outcome
+                 (yrp_index, term, tenant_id, op_id, key_hash, key_str, rid,
+                  tenant_log_index, applied_at_unix_micros)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            rusqlite::params![
+                out.yrp_index as i64,
+                out.term as i64,
+                out.tenant_id,
+                out.op_id,
+                out.key_hash.map(|k| k as i64),
+                out.key_str,
+                out.rid,
+                out.tenant_log_index as i64,
+                out.applied_at_unix_micros,
+            ],
+        )
+        .map_err(|e| format!("insert outcome: {e}"))?;
+        tx.execute(
+            "UPDATE yrp_applied SET applied_index = MAX(applied_index, ?1) WHERE id = 1",
+            [out.yrp_index as i64],
+        )
+        .map_err(|e| format!("advance marker: {e}"))?;
+        tx.commit().map_err(|e| format!("commit outcome tx: {e}"))?;
+        self.applied.fetch_max(out.yrp_index, Ordering::AcqRel);
+        Ok(())
+    }
+
+    /// Advance the marker without an outcome row (protocol no-ops).
+    pub fn advance(&self, index: u64) -> Result<(), String> {
+        let conn = self.conn.lock();
+        conn.execute(
+            "UPDATE yrp_applied SET applied_index = MAX(applied_index, ?1) WHERE id = 1",
+            [index as i64],
+        )
+        .map_err(|e| format!("advance marker: {e}"))?;
+        self.applied.fetch_max(index, Ordering::AcqRel);
+        Ok(())
+    }
+
+    pub fn lookup_by_index(&self, yrp_index: u64) -> Result<Option<AppliedOutcome>, String> {
+        let conn = self.conn.lock();
+        Self::query_one(
+            &conn,
+            "SELECT yrp_index, term, tenant_id, op_id, key_hash, key_str, rid,
+                    tenant_log_index, applied_at_unix_micros
+             FROM yrp_outcome WHERE yrp_index = ?1",
+            [yrp_index as i64],
+        )
+    }
+
+    fn query_one(
+        conn: &Connection,
+        sql: &str,
+        params: impl rusqlite::Params,
+    ) -> Result<Option<AppliedOutcome>, String> {
+        let mut stmt = conn.prepare(sql).map_err(|e| format!("prepare: {e}"))?;
+        let mut rows = stmt
+            .query(params)
+            .map_err(|e| format!("query outcome: {e}"))?;
+        match rows.next().map_err(|e| format!("row: {e}"))? {
+            None => Ok(None),
+            Some(r) => Ok(Some(AppliedOutcome {
+                yrp_index: r.get::<_, i64>(0).map_err(|e| e.to_string())? as u64,
+                term: r.get::<_, i64>(1).map_err(|e| e.to_string())? as u64,
+                tenant_id: r.get(2).map_err(|e| e.to_string())?,
+                op_id: r.get(3).map_err(|e| e.to_string())?,
+                key_hash: r
+                    .get::<_, Option<i64>>(4)
+                    .map_err(|e| e.to_string())?
+                    .map(|k| k as u64),
+                key_str: r.get(5).map_err(|e| e.to_string())?,
+                rid: r.get(6).map_err(|e| e.to_string())?,
+                tenant_log_index: r.get::<_, i64>(7).map_err(|e| e.to_string())? as u64,
+                applied_at_unix_micros: r.get(8).map_err(|e| e.to_string())?,
+            })),
+        }
+    }
+}
+
+/// The rid a mutation makes client-visible, when it has one.
+fn outcome_rid(m: &MemoryMutation) -> Option<String> {
+    match m {
+        MemoryMutation::UpsertMemory { rid, .. } => Some(rid.clone()),
+        MemoryMutation::TombstoneMemory { rid, .. } => Some(rid.clone()),
+        _ => None,
+    }
+}
+
+/// Production sink: commit-log + engine + outcome marker, in the order
+/// documented at module level.
+pub struct EngineApplySink {
+    committer: Arc<dyn MutationCommitter>,
+    applier: Arc<dyn Applier>,
+    outcomes: Arc<OutcomeStore>,
+}
+
+impl EngineApplySink {
+    pub fn new(
+        committer: Arc<dyn MutationCommitter>,
+        applier: Arc<dyn Applier>,
+        outcomes: Arc<OutcomeStore>,
+    ) -> Self {
+        Self {
+            committer,
+            applier,
+            outcomes,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ApplySink for EngineApplySink {
+    async fn apply(&mut self, index: u64, entry: &LogEntry) -> Result<(), String> {
+        let bytes = match &entry.payload {
+            // Election no-ops and capability-activation carriers: nothing
+            // to apply, just advance the durable marker.
+            Payload::Noop => return self.outcomes.advance(index),
+            // A Test payload on the production sink is a wiring bug —
+            // fail-stop rather than silently skip (contract clause 3).
+            Payload::Test(n) => {
+                return Err(format!("Test payload {n} reached production sink at {index}"))
+            }
+            Payload::Op(b) => b,
+        };
+        let op = YrpOp::decode(bytes)?;
+
+        // Step 1 — durable commit-log append, exactly-once on (tenant, op_id).
+        let receipt = match self
+            .committer
+            .commit(
+                op.tenant_id,
+                op.mutation.clone(),
+                CommitOptions::new().with_op_id(op.op_id),
+            )
+            .await
+        {
+            Ok(r) => r,
+            // A collision here means a crash-replay carried a DIFFERENT
+            // mutation for the same op_id — divergence evidence, fail-stop.
+            Err(CommitError::OpIdCollision { op_id, .. }) => {
+                return Err(format!("op_id collision during YRP apply: {op_id}"))
+            }
+            Err(e) => return Err(format!("commit-log append during YRP apply: {e}")),
+        };
+
+        // Step 2 — engine apply (live index updates inside). Seq = the
+        // GLOBAL yrp index, mirroring openraft's use of the raft index.
+        match self.applier.apply(op.tenant_id, index, &op.mutation).await {
+            Ok(()) => {}
+            Err(e) if e.is_idempotent_ok() => {}
+            // Grammar variants without an apply path yet: non-fatal, same
+            // posture as the openraft state machine (the commit-log row is
+            // the durable truth; the engine wiring lands with its RFC).
+            Err(ApplyError::NotYetWired { variant, .. }) => {
+                tracing::warn!(variant, index, "YRP apply: mutation not yet wired to engine");
+            }
+            Err(e) => return Err(format!("engine apply at {index}: {e}")),
+        }
+
+        // Step 3 — outcome + marker, atomically, LAST.
+        let applied_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_micros() as i64)
+            .unwrap_or(0);
+        self.outcomes.record(&AppliedOutcome {
+            yrp_index: index,
+            term: entry.term.0,
+            tenant_id: op.tenant_id.0,
+            op_id: op.op_id.to_string(),
+            key_hash: entry.key,
+            key_str: op.idempotency_key.clone(),
+            rid: outcome_rid(&op.mutation),
+            tenant_log_index: receipt.log_index,
+            applied_at_unix_micros: applied_at,
+        })
+    }
+
+    fn durable_applied(&self) -> u64 {
+        self.outcomes.applied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commit::{LocalSqliteCommitter, OpId};
+    use crate::yrp::types::Term;
+
+    fn op_entry(term: u64, key: Option<u64>, op: &YrpOp) -> LogEntry {
+        LogEntry {
+            term: Term(term),
+            payload: Payload::Op(op.encode().unwrap()),
+            key,
+            activate: None,
+        }
+    }
+
+    fn sample_op(key: Option<&str>) -> YrpOp {
+        YrpOp {
+            tenant_id: TenantId::new(1),
+            op_id: OpId::new_random(),
+            mutation: MemoryMutation::UpsertMemory {
+                rid: "rid-sink-test".into(),
+                text: "sink test".into(),
+                memory_type: "semantic".into(),
+                importance: 0.5,
+                valence: 0.0,
+                half_life: 168.0,
+                metadata: serde_json::json!({}),
+                namespace: "ns".into(),
+                certainty: 1.0,
+                domain: "work".into(),
+                source: "user".into(),
+                emotional_state: None,
+                embedding: Some(vec![0.1, 0.2]),
+                extracted_entities: vec![],
+                created_at_unix_micros: Some(1),
+                embedding_model: Some("default".into()),
+            },
+            idempotency_key: key.map(String::from),
+        }
+    }
+
+    /// The crash-replay property end-to-end: applying the same index
+    /// twice (as after a crash between engine apply and marker) yields
+    /// ONE commit-log row, ONE outcome, and the same receipt fields.
+    #[tokio::test]
+    async fn replay_of_same_index_is_idempotent() {
+        let committer: Arc<dyn MutationCommitter> =
+            Arc::new(LocalSqliteCommitter::open_in_memory().unwrap());
+        let applier: Arc<dyn Applier> = Arc::new(crate::commit::LocalApplier::new());
+        let outcomes = Arc::new(OutcomeStore::open_in_memory().unwrap());
+        let mut sink = EngineApplySink::new(committer.clone(), applier, outcomes.clone());
+
+        let op = sample_op(Some("k1"));
+        let key = Some(crate::yrp::op::claim_key_for_idempotency(op.tenant_id, "k1"));
+        let entry = op_entry(3, key, &op);
+
+        sink.apply(5, &entry).await.expect("first apply");
+        assert_eq!(sink.durable_applied(), 5);
+        let first = outcomes.lookup_by_index(5).unwrap().expect("outcome");
+        assert_eq!(first.rid.as_deref(), Some("rid-sink-test"));
+        assert_eq!(first.key_str.as_deref(), Some("k1"));
+        assert_eq!(first.tenant_log_index, 1);
+
+        // Crash-replay: same index, same entry.
+        sink.apply(5, &entry).await.expect("replay apply");
+        let again = outcomes.lookup_by_index(5).unwrap().expect("outcome");
+        assert_eq!(first.tenant_log_index, again.tenant_log_index);
+        assert_eq!(
+            committer.high_watermark(op.tenant_id).await.unwrap(),
+            1,
+            "replay must not append a second commit-log row"
+        );
+    }
+
+    /// Noop entries advance the marker without an outcome row; the marker
+    /// survives reopen (recovered `durable_applied`).
+    #[tokio::test]
+    async fn noop_advances_marker_and_marker_is_durable() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("yrp_apply.sqlite");
+        {
+            let committer: Arc<dyn MutationCommitter> =
+                Arc::new(LocalSqliteCommitter::open_in_memory().unwrap());
+            let applier: Arc<dyn Applier> = Arc::new(crate::commit::LocalApplier::new());
+            let outcomes = Arc::new(OutcomeStore::open(&path).unwrap());
+            let mut sink = EngineApplySink::new(committer, applier, outcomes.clone());
+            let noop = LogEntry {
+                term: Term(1),
+                payload: Payload::Noop,
+                key: None,
+                activate: None,
+            };
+            sink.apply(1, &noop).await.unwrap();
+            assert_eq!(sink.durable_applied(), 1);
+            assert!(outcomes.lookup_by_index(1).unwrap().is_none());
+        }
+        let reopened = OutcomeStore::open(&path).unwrap();
+        assert_eq!(reopened.applied(), 1, "marker must survive restart");
+    }
+}

--- a/crates/yantrikdb-server/src/yrp/engine_sink.rs
+++ b/crates/yantrikdb-server/src/yrp/engine_sink.rs
@@ -25,6 +25,13 @@
 //!
 //! Client acks release only on the marker (the driver's `Applied` event),
 //! so "success reported, effect missing" is structurally impossible.
+//!
+//! Known residual (codex F1, shared with the openraft baseline): the
+//! marker certifies effects that were durable in the ENGINE's own store
+//! at step-2 commit time. Destruction of an engine DB with a surviving
+//! marker is data-corruption territory — the Phase C engine-checkpoint
+//! manifest (content hash + frontier binding) is the planned detection,
+//! feeding the same quarantine posture as replication-state damage.
 
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/yantrikdb-server/src/yrp/mod.rs
+++ b/crates/yantrikdb-server/src/yrp/mod.rs
@@ -29,7 +29,11 @@
 
 pub mod bootstrap;
 pub mod driver;
+pub mod engine_sink;
+pub mod op;
 pub mod replica;
+pub mod runtime;
+pub mod transport;
 pub mod types;
 
 #[cfg(test)]

--- a/crates/yantrikdb-server/src/yrp/mod.rs
+++ b/crates/yantrikdb-server/src/yrp/mod.rs
@@ -37,4 +37,6 @@ pub mod transport;
 pub mod types;
 
 #[cfg(test)]
+mod cluster_test;
+#[cfg(test)]
 mod sim;

--- a/crates/yantrikdb-server/src/yrp/op.rs
+++ b/crates/yantrikdb-server/src/yrp/op.rs
@@ -1,0 +1,161 @@
+//! The replicated-op envelope: what actually rides inside
+//! [`super::replica::Payload::Op`] bytes (runtime-integration slice).
+//!
+//! ## Encoding choice — serde_json, deliberately
+//!
+//! [`crate::commit::MemoryMutation`] is an internally-tagged serde enum
+//! (`#[serde(tag = "kind")]`). Internally-tagged enums require a
+//! self-describing format on deserialize (`deserialize_any`), which
+//! bincode is not — bincode round-trips of this envelope FAIL at decode
+//! time. serde_json is the same encoding the commit-log `payload` column
+//! and the openraft log already use for mutations, so the YRP log stays
+//! byte-compatible with the rest of the substrate's durable formats.
+//! (The outer wire envelope [`super::driver::WireMsg`] IS bincode — it
+//! contains only externally-tagged protocol types plus these opaque
+//! bytes, which bincode treats as a plain byte vector.)
+//!
+//! ## Why the rid lives in here (codex F3)
+//!
+//! The gateway allocates the client-visible rid BEFORE proposing and
+//! bakes it into the mutation. Every replica therefore applies the same
+//! rid deterministically, and a keyed retry answered from the claims
+//! table can recover its outcome from the entry (or the sink's outcome
+//! table) — no volatile per-connection state required.
+
+use serde::{Deserialize, Serialize};
+
+use crate::commit::{MemoryMutation, OpId, TenantId};
+
+/// One replicated engine operation. Everything a follower needs to apply
+/// deterministically: the tenant, the commit-log idempotency op_id, the
+/// full materialized mutation (rid + embedding + entities + timestamps
+/// inside), and — for keyed writes — the client's idempotency key string
+/// (the entry's `key` field carries only its 64-bit digest; the full
+/// string rides here so the apply sink can store it for collision
+/// verification).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct YrpOp {
+    pub tenant_id: TenantId,
+    pub op_id: OpId,
+    pub mutation: MemoryMutation,
+    /// The client idempotency key for keyed writes; `None` for unkeyed.
+    pub idempotency_key: Option<String>,
+}
+
+impl YrpOp {
+    /// Serialize for `Payload::Op`. Infallible in practice (the mutation
+    /// grammar contains no non-string-keyed maps), but surfaced as a
+    /// Result so a grammar change that breaks encoding fails loudly at
+    /// the propose site, not silently on a follower.
+    pub fn encode(&self) -> Result<Vec<u8>, String> {
+        serde_json::to_vec(self).map_err(|e| format!("encode YrpOp: {e}"))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, String> {
+        serde_json::from_slice(bytes).map_err(|e| format!("decode YrpOp: {e}"))
+    }
+}
+
+/// FNV-1a 64-bit — the stable digest used to derive the protocol-level
+/// claim key (`LogEntry.key: u64`) from string identities. Chosen because
+/// it is trivially portable and has NO platform/process variation (std's
+/// `DefaultHasher` is explicitly unstable across releases — unacceptable
+/// for a value that is replicated and persisted).
+///
+/// Collisions: two distinct identities hashing to the same u64 would make
+/// the second write dedupe against the first. The apply sink stores the
+/// FULL key string with each outcome, and the gateway verifies it on
+/// every dedupe answer — a collision is detected and refused (409), never
+/// silently mis-deduped. At ~2^-64 per pair it is a documented
+/// astronomically-unlikely refusal, not a correctness hole.
+pub fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in bytes {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+/// Claim key for a client-supplied idempotency key, scoped per tenant so
+/// identical key strings from different tenants never collide by design.
+pub fn claim_key_for_idempotency(tenant: TenantId, key: &str) -> u64 {
+    let mut buf = Vec::with_capacity(key.len() + 12);
+    buf.extend_from_slice(b"idem:");
+    buf.extend_from_slice(&tenant.0.to_le_bytes());
+    buf.extend_from_slice(key.as_bytes());
+    fnv1a64(&buf)
+}
+
+/// Claim key for an unkeyed write: derived from the op_id, giving every
+/// replicated mutation retry-idempotency at the protocol layer with the
+/// same semantics the commit log's `(tenant, op_id)` unique index
+/// provides at the storage layer.
+pub fn claim_key_for_op(tenant: TenantId, op_id: &OpId) -> u64 {
+    let mut buf = Vec::with_capacity(64);
+    buf.extend_from_slice(b"op:");
+    buf.extend_from_slice(&tenant.0.to_le_bytes());
+    buf.extend_from_slice(op_id.to_string().as_bytes());
+    fnv1a64(&buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_op(key: Option<&str>) -> YrpOp {
+        YrpOp {
+            tenant_id: TenantId::new(7),
+            op_id: OpId::new_random(),
+            mutation: MemoryMutation::UpsertMemory {
+                rid: "0198-test-rid".into(),
+                text: "hello".into(),
+                memory_type: "semantic".into(),
+                importance: 0.5,
+                valence: 0.0,
+                half_life: 168.0,
+                metadata: serde_json::json!({}),
+                namespace: "ns".into(),
+                certainty: 1.0,
+                domain: "work".into(),
+                source: "user".into(),
+                emotional_state: None,
+                embedding: Some(vec![0.25, -0.5]),
+                extracted_entities: vec!["hello".into()],
+                created_at_unix_micros: Some(1_784_000_000_000_000),
+                embedding_model: Some("default".into()),
+            },
+            idempotency_key: key.map(String::from),
+        }
+    }
+
+    /// The load-bearing property: the envelope round-trips through the
+    /// bytes that ride in `Payload::Op` — including the internally-tagged
+    /// mutation enum that bincode cannot carry.
+    #[test]
+    fn yrp_op_round_trips_through_payload_bytes() {
+        for key in [None, Some("client-key-1")] {
+            let op = sample_op(key);
+            let bytes = op.encode().expect("encode");
+            let back = YrpOp::decode(&bytes).expect("decode");
+            assert_eq!(op, back);
+        }
+    }
+
+    /// The whole point of the digest: stable across processes/platforms.
+    /// These constants are the contract — if this test ever fails, the
+    /// hash changed and every persisted claim key is invalidated.
+    #[test]
+    fn claim_key_digest_is_pinned() {
+        assert_eq!(fnv1a64(b""), 0xcbf29ce484222325);
+        assert_eq!(fnv1a64(b"a"), 0xaf63dc4c8601ec8c);
+        let k1 = claim_key_for_idempotency(TenantId::new(1), "same-key");
+        let k2 = claim_key_for_idempotency(TenantId::new(2), "same-key");
+        assert_ne!(k1, k2, "tenant scoping must separate identical keys");
+        assert_eq!(
+            k1,
+            claim_key_for_idempotency(TenantId::new(1), "same-key"),
+            "digest must be deterministic"
+        );
+    }
+}

--- a/crates/yantrikdb-server/src/yrp/replica.rs
+++ b/crates/yantrikdb-server/src/yrp/replica.rs
@@ -43,11 +43,10 @@
 //!
 //! ## What is deliberately NOT here (yet)
 //!
-//! Quarantine + incarnation fencing (Phase A2); membership changes, witness
-//! ack-exclusion (witnesses vote but never count toward data durability),
-//! snapshots/GC, and the real oplog payload binding (Phase B — `payload` is
-//! an opaque `u64` until then). The voter set is fixed at construction.
-//! Timers are the driver's job.
+//! Quarantine + incarnation fencing (Phase A2); membership changes. The
+//! voter set is fixed at construction. Timers are the driver's job.
+//! (`payload` carries real engine-mutation bytes as of the
+//! runtime-integration slice — see [`Payload`].)
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -55,12 +54,40 @@ use serde::{Deserialize, Serialize};
 
 use super::types::{quorum, HardState, LogPosition, NodeId, Term};
 
-/// Payload reserved for the no-op entry a new leader appends on election —
-/// the §5.4.2 mechanism that lets prior-term entries commit by implication.
-pub const NOOP_PAYLOAD: u64 = 0;
+/// The replicated command a log entry carries (runtime-integration slice —
+/// this is where the opaque Phase A/B `u64` became real bytes).
+///
+/// Equality is load-bearing: the append-path duplicate check and the sim's
+/// committed-entry ledgers compare entries structurally, so two ops are the
+/// same entry iff their bytes are the same.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Payload {
+    /// The no-op a new leader appends on election (§5.4.2 — lets prior-term
+    /// entries commit by implication) and the carrier for pure
+    /// capability-activation entries.
+    Noop,
+    /// Opaque numbered payload for the simulator and unit tests. Never
+    /// produced on a production path.
+    Test(u64),
+    /// A serialized engine mutation (`crate::commit::MemoryMutation` via
+    /// bincode) with the client-visible rid INSIDE the bytes (codex F3):
+    /// a retry answered from the claims table recovers its outcome from
+    /// the entry itself.
+    Op(Vec<u8>),
+}
 
-/// One canonical-log entry. `payload` is an opaque identifier until the
-/// memory-native oplog op (embedding bytes, provenance, HLC) binds here.
+/// Test-only ergonomic comparison against the sim's numeric payloads:
+/// `entry.payload == 42` ⇔ the payload is `Payload::Test(42)`.
+#[cfg(test)]
+impl PartialEq<u64> for Payload {
+    fn eq(&self, other: &u64) -> bool {
+        matches!(self, Payload::Test(n) if n == other)
+    }
+}
+
+/// One canonical-log entry. `payload` is the replicated command — engine
+/// mutation bytes on the production path (embedding bytes, provenance, HLC
+/// all inside), [`Payload::Noop`] for protocol-internal entries.
 ///
 /// `key` (Phase B, RFC 028 §7): the idempotency claim, carried IN the entry
 /// so claim and op are one atomic replicated unit — committed together,
@@ -71,10 +98,10 @@ pub const NOOP_PAYLOAD: u64 = 0;
 /// dedupes the retry (claim never lost after commit); a tentative keyed
 /// entry truncates WITH its claim, so the retry re-executes cleanly (no
 /// settled-claim-without-effect ghost).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LogEntry {
     pub term: Term,
-    pub payload: u64,
+    pub payload: Payload,
     pub key: Option<u64>,
     /// Phase B (RFC 028 §3): capability-activation entry. Bits activate on
     /// COMMIT (never on append), monotonically — there is no deactivation.
@@ -83,7 +110,7 @@ pub struct LogEntry {
 
 impl LogEntry {
     /// Unkeyed entry (the common case; also every pre-Phase-B test entry).
-    pub fn unkeyed(term: Term, payload: u64) -> Self {
+    pub fn unkeyed(term: Term, payload: Payload) -> Self {
         Self {
             term,
             payload,
@@ -407,7 +434,7 @@ impl ReplicaCore {
         let term = self.current_term();
         self.log.push(LogEntry {
             term,
-            payload: NOOP_PAYLOAD,
+            payload: Payload::Noop,
             key: None,
             activate: Some(bits),
         });
@@ -473,8 +500,9 @@ impl ReplicaCore {
         // The state below base is adopted wholesale (checkpoint semantics).
         core.commit = base.index;
         for e in restored_log {
+            let key = e.key;
             core.log.push(e);
-            if let Some(k) = e.key {
+            if let Some(k) = key {
                 core.claims.insert(k, core.last_index());
             }
         }
@@ -654,7 +682,7 @@ impl ReplicaCore {
 
     /// Propose a new entry. Leader-only; returns `None` otherwise (the
     /// caller redirects to the leader — the API layer's job in Phase B).
-    pub fn propose(&mut self, payload: u64) -> Option<Vec<Effect>> {
+    pub fn propose(&mut self, payload: Payload) -> Option<Vec<Effect>> {
         if self.role != Role::Leader {
             return None;
         }
@@ -678,7 +706,7 @@ impl ReplicaCore {
     /// (never-success-without-durable-effect), and never append the same
     /// key twice while it is claimed (never-double-write). Both halves are
     /// proven in the simulator across failover/quarantine interleavings.
-    pub fn propose_keyed(&mut self, key: u64, payload: u64) -> Option<KeyedProposal> {
+    pub fn propose_keyed(&mut self, key: u64, payload: Payload) -> Option<KeyedProposal> {
         if self.role != Role::Leader {
             return None;
         }
@@ -765,7 +793,7 @@ impl ReplicaCore {
             .log
             .iter()
             .skip((prev.index - self.base.index) as usize)
-            .copied()
+            .cloned()
             .collect();
         let msg = Message::AppendEntries {
             term,
@@ -1183,14 +1211,14 @@ impl ReplicaCore {
                         }
                     }
                     self.log.truncate((idx - self.base.index) as usize - 1);
-                    self.log.push(*e);
+                    self.log.push(e.clone());
                     if let Some(k) = e.key {
                         self.claims.insert(k, idx);
                     }
                     changed = true;
                 }
                 None => {
-                    self.log.push(*e);
+                    self.log.push(e.clone());
                     if let Some(k) = e.key {
                         self.claims.insert(k, idx);
                     }
@@ -1450,7 +1478,7 @@ impl ReplicaCore {
         out.push(Effect::BecameLeader { term });
         // §5.4.2 no-op: gives the new term an entry so the prior-term
         // suffix can commit by implication.
-        self.log.push(LogEntry::unkeyed(term, NOOP_PAYLOAD));
+        self.log.push(LogEntry::unkeyed(term, Payload::Noop));
         out.push(self.stage_log());
         self.append_effects_for_followers(out);
     }
@@ -1461,7 +1489,7 @@ impl ReplicaCore {
         debug_assert!(self.pending.is_some());
         self.init_leader_state(term);
         self.hold(Effect::BecameLeader { term });
-        self.log.push(LogEntry::unkeyed(term, NOOP_PAYLOAD));
+        self.log.push(LogEntry::unkeyed(term, Payload::Noop));
         let _ = self.stage_log(); // coalesces into the pending persist
     }
 
@@ -1532,7 +1560,7 @@ impl ReplicaCore {
             .log
             .iter()
             .take(self.durable_len as usize)
-            .copied()
+            .cloned()
             .collect();
         let commit = self.commit.min(self.base.index + self.durable_len);
         Some((

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -1,0 +1,587 @@
+//! YRP runtime assembly — config → boot inspection → driver (or
+//! quarantine) → the server-facing handle and committer.
+//!
+//! This is the `raft_mode = "yrp"` startup path (RFC 028 §5 posture):
+//! - [`spawn`] loads durable state, runs [`super::bootstrap::inspect`],
+//!   and starts EITHER the live driver (Healthy) or the fail-closed
+//!   quarantine/rejoin loop (anything less). **The process always
+//!   starts** — quarantine serves diagnostics and refuses writes; it
+//!   never wedges boot.
+//! - [`YrpHandle`] is what the HTTP layer holds: the owner funnel, the
+//!   outcome store (dedupe answers), a live status watch, and the
+//!   quarantine surface.
+//! - [`YrpCommitter`] implements [`MutationCommitter`] over the driver,
+//!   so the existing unkeyed write path replicates without handler
+//!   changes (reads delegate to the local commit log, which every node
+//!   materializes at apply time).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use async_trait::async_trait;
+use tokio::sync::{mpsc, oneshot, watch};
+
+use super::bootstrap::{
+    inspect, BootDecision, BootstrapEffect, Integrity, QuarantinedNode, RecoveredState,
+    RejoinMessage,
+};
+use super::driver::{
+    run_apply_worker, spawn_ticker, DriverConfig, DriverEvent, DriverExit, DurableState, FileStore,
+    ProposeOutcome, Transport, WireMsg, YrpDriver, YrpStatus,
+};
+use super::engine_sink::{AppliedOutcome, EngineApplySink, OutcomeStore};
+use super::op::{claim_key_for_op, YrpOp};
+use super::replica::{Payload, Role};
+use super::transport::HttpTransport;
+use super::types::{ClusterId, NodeId};
+use crate::commit::{
+    Applier, CommitError, CommitOptions, CommitReceipt, CommittedEntry, MemoryMutation,
+    MutationCommitter, OpId, TenantId,
+};
+
+/// One cluster member from the `[yrp]` config section.
+#[derive(Debug, Clone)]
+pub struct YrpPeer {
+    pub node_id: u64,
+    /// HTTP base url other nodes reach it at (scheme://host:http_port).
+    pub addr: String,
+    pub witness: bool,
+}
+
+/// Everything [`spawn`] needs, resolved from `ServerConfig`.
+#[derive(Debug, Clone)]
+pub struct YrpRuntimeConfig {
+    pub node_id: u64,
+    pub cluster_id: u64,
+    /// ALL cluster members, INCLUDING this node (self is identified by
+    /// `node_id`; its addr entry is ignored for outbound sends).
+    pub peers: Vec<YrpPeer>,
+    pub data_dir: PathBuf,
+    pub cluster_secret: Option<String>,
+    pub tick_ms: u64,
+    pub election_ticks: (u32, u32),
+    pub heartbeat_ticks: u32,
+}
+
+/// How long a proposer waits for the driver's reply / the apply marker.
+const PROPOSE_TIMEOUT: Duration = Duration::from_secs(15);
+const OUTCOME_POLL: Duration = Duration::from_millis(10);
+/// Quarantine rejoin retry cadence.
+const REJOIN_RETRY: Duration = Duration::from_secs(2);
+
+/// Propose-path failures, mapped to [`CommitError`]/HTTP by callers.
+#[derive(Debug)]
+pub enum YrpProposeError {
+    NotLeader {
+        leader_id: Option<u64>,
+        leader_addr: Option<String>,
+    },
+    Timeout,
+    Unavailable(String),
+}
+
+/// What the HTTP layer holds for a YRP node.
+pub struct YrpHandle {
+    pub node_id: NodeId,
+    owner_tx: mpsc::UnboundedSender<DriverEvent>,
+    pub outcomes: Arc<OutcomeStore>,
+    pub status: watch::Receiver<YrpStatus>,
+    /// node id → HTTP base url, for leader redirects.
+    peer_http: BTreeMap<u64, String>,
+    pub cluster_secret: Option<String>,
+    /// `Some(reasons)` while quarantined (or after a fatal driver exit);
+    /// `None` when replicating normally. The health surface reports it;
+    /// the write path refuses on it.
+    quarantine: std::sync::RwLock<Option<Vec<String>>>,
+}
+
+impl YrpHandle {
+    pub fn quarantine_reasons(&self) -> Option<Vec<String>> {
+        self.quarantine.read().expect("quarantine lock").clone()
+    }
+
+    fn set_quarantine(&self, reasons: Option<Vec<String>>) {
+        *self.quarantine.write().expect("quarantine lock") = reasons;
+    }
+
+    /// Forward a decoded inbound wire message to whichever loop currently
+    /// owns the funnel (driver or quarantine).
+    pub fn deliver_inbound(&self, body: &[u8]) -> Result<(), String> {
+        super::transport::deliver_inbound(&self.owner_tx, body)
+    }
+
+    /// Current leader hint as (id, http addr).
+    pub fn leader_hint(&self) -> (Option<u64>, Option<String>) {
+        let leader = self.status.borrow().leader.map(|n| n.0);
+        let addr = leader.and_then(|id| self.peer_http.get(&id).cloned());
+        (leader, addr)
+    }
+
+    pub fn is_leader(&self) -> bool {
+        self.quarantine_reasons().is_none() && self.status.borrow().role == Role::Leader
+    }
+
+    /// Propose a keyed op and wait for its durable outcome. This is the
+    /// single funnel both the keyed gateway path and [`YrpCommitter`]
+    /// ride: claim checked at origin (RFC 028 §7), ack released only at
+    /// the durable-apply marker, dedupe answered from the outcome store.
+    pub async fn propose_and_wait(
+        &self,
+        key: u64,
+        op: &YrpOp,
+    ) -> Result<AppliedOutcome, YrpProposeError> {
+        if let Some(reasons) = self.quarantine_reasons() {
+            return Err(YrpProposeError::Unavailable(format!(
+                "node quarantined: {reasons:?}"
+            )));
+        }
+        let bytes = op.encode().map_err(YrpProposeError::Unavailable)?;
+        let (tx, rx) = oneshot::channel();
+        self.owner_tx
+            .send(DriverEvent::Propose {
+                key,
+                payload: Payload::Op(bytes),
+                reply: tx,
+            })
+            .map_err(|_| YrpProposeError::Unavailable("YRP driver not running".into()))?;
+        let outcome = tokio::time::timeout(PROPOSE_TIMEOUT, rx)
+            .await
+            .map_err(|_| YrpProposeError::Timeout)?
+            .map_err(|_| YrpProposeError::Unavailable("YRP driver dropped reply".into()))?;
+        let index = match outcome {
+            ProposeOutcome::Applied { index } | ProposeOutcome::Duplicate { index } => index,
+            ProposeOutcome::Retry => {
+                let (leader_id, leader_addr) = self.leader_hint();
+                return Err(YrpProposeError::NotLeader {
+                    leader_id,
+                    leader_addr,
+                });
+            }
+        };
+        self.wait_outcome(index).await
+    }
+
+    /// Wait for the durable-apply marker to cover `index`, then read its
+    /// outcome. (An `Applied` reply already implies coverage; `Duplicate`
+    /// may race a lagging apply worker — poll briefly.)
+    async fn wait_outcome(&self, index: u64) -> Result<AppliedOutcome, YrpProposeError> {
+        let deadline = tokio::time::Instant::now() + PROPOSE_TIMEOUT;
+        while self.outcomes.applied() < index {
+            if tokio::time::Instant::now() >= deadline {
+                return Err(YrpProposeError::Timeout);
+            }
+            tokio::time::sleep(OUTCOME_POLL).await;
+        }
+        self.outcomes
+            .lookup_by_index(index)
+            .map_err(YrpProposeError::Unavailable)?
+            .ok_or_else(|| {
+                YrpProposeError::Unavailable(format!("applied index {index} has no outcome record"))
+            })
+    }
+}
+
+/// Boot the YRP node. Never fails on damaged replication state (that is
+/// quarantine's job) — only on genuinely unusable local resources
+/// (unopenable outcome DB, malformed config).
+pub fn spawn(
+    cfg: YrpRuntimeConfig,
+    local: Arc<dyn MutationCommitter>,
+    applier: Arc<dyn Applier>,
+) -> Result<Arc<YrpHandle>, String> {
+    if cfg.cluster_id == 0 {
+        return Err("[yrp] cluster_id must be non-zero".into());
+    }
+    if cfg.node_id == 0 {
+        return Err("[cluster] node_id must be non-zero in yrp mode".into());
+    }
+    if !cfg.peers.iter().any(|p| p.node_id == cfg.node_id) {
+        return Err("[yrp] peers must include this node's node_id".into());
+    }
+
+    let me = NodeId(cfg.node_id);
+    let cluster = ClusterId(cfg.cluster_id);
+    let state_path = cfg.data_dir.join("yrp.state");
+    let outcomes = Arc::new(OutcomeStore::open(cfg.data_dir.join("yrp_apply.sqlite"))?);
+
+    let voters: BTreeSet<NodeId> = cfg.peers.iter().map(|p| NodeId(p.node_id)).collect();
+    let witnesses: BTreeSet<NodeId> = cfg
+        .peers
+        .iter()
+        .filter(|p| p.witness)
+        .map(|p| NodeId(p.node_id))
+        .collect();
+    let peer_http: BTreeMap<u64, String> = cfg
+        .peers
+        .iter()
+        .map(|p| (p.node_id, p.addr.clone()))
+        .collect();
+    let peer_urls: BTreeMap<NodeId, String> = cfg
+        .peers
+        .iter()
+        .filter(|p| p.node_id != cfg.node_id)
+        .map(|p| (NodeId(p.node_id), p.addr.clone()))
+        .collect();
+    let data_peers: Vec<NodeId> = cfg
+        .peers
+        .iter()
+        .filter(|p| p.node_id != cfg.node_id && !p.witness)
+        .map(|p| NodeId(p.node_id))
+        .collect();
+
+    let transport = Arc::new(HttpTransport::new(
+        me,
+        peer_urls,
+        cfg.cluster_secret.clone(),
+    ));
+
+    let store = FileStore::new(state_path.clone());
+    // Boot inspection input. bincode round-trip success stands in for the
+    // record checksum (a torn/truncated file fails deserialization); a
+    // dedicated hash-chain lands with the Phase C manifest work.
+    let (restored, recovered) = match store.load() {
+        Ok(Some(d)) => {
+            let rec = RecoveredState {
+                cluster_id: Some(d.cluster_id),
+                hard: Some(d.hard),
+                log: Some(d.log.clone()),
+                active: d.active,
+                // Marker is absolute; inspect compares against the log
+                // suffix — normalize by the compaction base.
+                commit_marker: outcomes.applied().saturating_sub(d.base.index),
+                integrity: Integrity {
+                    hard_state_verified: true,
+                    log_verified: true,
+                },
+            };
+            (Some(d), rec)
+        }
+        Ok(None) => {
+            let rec = RecoveredState {
+                cluster_id: None,
+                hard: None,
+                log: None,
+                active: 0,
+                // Applied engine state with NO replication state is the
+                // frontier-beyond-data inconsistency — quarantine.
+                commit_marker: outcomes.applied(),
+                integrity: Integrity {
+                    hard_state_verified: true,
+                    log_verified: true,
+                },
+            };
+            (None, rec)
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "yrp.state unreadable — boot inspection will quarantine");
+            let rec = RecoveredState {
+                cluster_id: None,
+                hard: None,
+                log: None,
+                active: 0,
+                commit_marker: outcomes.applied(),
+                integrity: Integrity {
+                    hard_state_verified: false,
+                    log_verified: false,
+                },
+            };
+            (None, rec)
+        }
+    };
+
+    let (owner_tx, owner_rx) = mpsc::unbounded_channel();
+    let (apply_tx, apply_rx) = mpsc::unbounded_channel();
+    let (status_tx, status_rx) = watch::channel(YrpStatus::default());
+
+    let handle = Arc::new(YrpHandle {
+        node_id: me,
+        owner_tx: owner_tx.clone(),
+        outcomes: outcomes.clone(),
+        status: status_rx,
+        peer_http,
+        cluster_secret: cfg.cluster_secret.clone(),
+        quarantine: std::sync::RwLock::new(None),
+    });
+
+    let sink = EngineApplySink::new(local, applier, outcomes.clone());
+    tokio::spawn(run_apply_worker(Box::new(sink), apply_rx, owner_tx.clone()));
+    spawn_ticker(owner_tx.clone(), Duration::from_millis(cfg.tick_ms.max(1)));
+
+    let driver_cfg = move || DriverConfig {
+        id: me,
+        cluster_id: cluster,
+        voters: voters.clone(),
+        witnesses: witnesses.clone(),
+        supported: u32::MAX,
+        election_ticks: cfg.election_ticks,
+        heartbeat_ticks: cfg.heartbeat_ticks,
+    };
+
+    match inspect(cluster, u32::MAX, &recovered) {
+        BootDecision::Healthy { .. } => {
+            tracing::info!(node = cfg.node_id, cluster = cfg.cluster_id, "YRP boot: healthy");
+            let mut driver = YrpDriver::new(
+                driver_cfg(),
+                restored,
+                store,
+                Box::new(SharedTransport(transport)),
+                apply_tx,
+                outcomes.applied(),
+            );
+            driver.set_status_tx(status_tx);
+            spawn_driver(driver, owner_rx, handle.clone());
+        }
+        BootDecision::Quarantine { reasons, term_hint } => {
+            tracing::error!(?reasons, "YRP boot: QUARANTINED (fail closed, serving diagnostics)");
+            handle.set_quarantine(Some(reasons.iter().map(|r| format!("{r:?}")).collect()));
+            let node = QuarantinedNode::new(me, cluster, reasons, term_hint);
+            let ctx = QuarantineCtx {
+                node,
+                store,
+                state_path,
+                transport,
+                apply_tx,
+                status_tx,
+                data_peers,
+                outcomes,
+                driver_cfg: driver_cfg(),
+                handle: handle.clone(),
+            };
+            tokio::spawn(run_quarantined(ctx, owner_rx));
+        }
+    }
+    Ok(handle)
+}
+
+/// `Transport` over a shared [`HttpTransport`] so the quarantine loop and
+/// the driver can each hold one.
+struct SharedTransport(Arc<HttpTransport>);
+impl Transport for SharedTransport {
+    fn send(&self, to: NodeId, msg: WireMsg) {
+        self.0.send(to, msg)
+    }
+}
+
+fn spawn_driver(
+    driver: YrpDriver,
+    owner_rx: mpsc::UnboundedReceiver<DriverEvent>,
+    handle: Arc<YrpHandle>,
+) {
+    tokio::spawn(async move {
+        let exit = driver.run(owner_rx).await;
+        match exit {
+            DriverExit::Shutdown => {
+                tracing::info!("YRP driver shut down");
+            }
+            other => {
+                // Fail-stop posture: surface it on health and refuse
+                // writes; the operator restarts through boot inspection.
+                tracing::error!(?other, "YRP driver FAILED — node degraded to quarantine posture");
+                handle.set_quarantine(Some(vec![format!("driver exit: {other:?}")]));
+            }
+        }
+    });
+}
+
+struct QuarantineCtx {
+    node: QuarantinedNode,
+    store: FileStore,
+    state_path: PathBuf,
+    transport: Arc<HttpTransport>,
+    apply_tx: mpsc::UnboundedSender<(u64, super::replica::LogEntry)>,
+    status_tx: watch::Sender<YrpStatus>,
+    data_peers: Vec<NodeId>,
+    outcomes: Arc<OutcomeStore>,
+    driver_cfg: DriverConfig,
+    handle: Arc<YrpHandle>,
+}
+
+/// The fail-closed loop: retry rejoin against data peers round-robin;
+/// ignore everything except grants (no vote handler, no append handler —
+/// fail-closed by absence); on an authorized grant, persist the adopted
+/// snapshot and hand the SAME owner funnel to a fresh driver.
+async fn run_quarantined(mut ctx: QuarantineCtx, mut rx: mpsc::UnboundedReceiver<DriverEvent>) {
+    let mut retry = tokio::time::interval(REJOIN_RETRY);
+    retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut peer_rr = 0usize;
+    loop {
+        tokio::select! {
+            _ = retry.tick() => {
+                if ctx.data_peers.is_empty() {
+                    continue;
+                }
+                let target = ctx.data_peers[peer_rr % ctx.data_peers.len()];
+                peer_rr += 1;
+                for eff in ctx.node.tick_rejoin(target) {
+                    run_bootstrap_effect(&mut ctx, eff);
+                }
+            }
+            ev = rx.recv() => {
+                let Some(ev) = ev else { return };
+                match ev {
+                    DriverEvent::Shutdown => return,
+                    DriverEvent::Inbound { from, msg: WireMsg::Rejoin(grant @ RejoinMessage::Grant { .. }) } => {
+                        for eff in ctx.node.on_grant(from, grant.clone()) {
+                            if let BootstrapEffect::AdoptSnapshot { cluster_id, hard, base, log, claims, active } = eff {
+                                let adopted = DurableState { cluster_id, hard, base, log, claims, active };
+                                if let Err(e) = ctx.store.persist(&adopted) {
+                                    tracing::error!(error = %e, "adopt-snapshot persist failed; staying quarantined");
+                                    continue;
+                                }
+                                tracing::info!(?from, "YRP rejoin: snapshot adopted — resuming as follower");
+                                ctx.handle.set_quarantine(None);
+                                let mut driver = YrpDriver::new(
+                                    ctx.driver_cfg,
+                                    Some(adopted),
+                                    ctx.store,
+                                    Box::new(SharedTransport(ctx.transport)),
+                                    ctx.apply_tx,
+                                    ctx.outcomes.applied(),
+                                );
+                                driver.set_status_tx(ctx.status_tx);
+                                spawn_driver(driver, rx, ctx.handle);
+                                return;
+                            }
+                        }
+                    }
+                    // Votes/appends while quarantined: fail-closed by
+                    // absence — no handler exists to answer them.
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn run_bootstrap_effect(ctx: &mut QuarantineCtx, eff: BootstrapEffect) {
+    match eff {
+        BootstrapEffect::PreserveOldState => {
+            let ts = SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let dst = ctx.state_path.with_extension(format!("preserved-{ts}"));
+            match std::fs::copy(&ctx.state_path, &dst) {
+                Ok(_) => tracing::warn!(dst = %dst.display(), "quarantine: old state preserved"),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => tracing::error!(error = %e, "quarantine: preserve-old-state failed"),
+            }
+        }
+        BootstrapEffect::Alarm { reasons } => {
+            tracing::error!(?reasons, "YRP QUARANTINE ALARM: corruption evidence — operator attention required");
+        }
+        BootstrapEffect::Send { to, msg } => {
+            ctx.transport.send(to, WireMsg::Rejoin(msg));
+        }
+        BootstrapEffect::AdoptSnapshot { .. } => {
+            unreachable!("adopt is handled inline by run_quarantined")
+        }
+    }
+}
+
+/// [`MutationCommitter`] over the YRP driver — the yrp-mode replacement
+/// for `LocalSqliteSubmitter`/`RaftCommitter`. Every mutation becomes a
+/// keyed proposal (key derived from the op_id), giving the protocol layer
+/// the same `(tenant, op_id)` retry-idempotency the commit log enforces
+/// at the storage layer. Reads delegate to the local commit log, which
+/// the apply sink materializes identically on every node.
+pub struct YrpCommitter {
+    handle: Arc<YrpHandle>,
+    local: Arc<dyn MutationCommitter>,
+}
+
+impl YrpCommitter {
+    pub fn new(handle: Arc<YrpHandle>, local: Arc<dyn MutationCommitter>) -> Self {
+        Self { handle, local }
+    }
+}
+
+fn propose_err_to_commit(e: YrpProposeError, op_id: OpId) -> CommitError {
+    match e {
+        YrpProposeError::NotLeader {
+            leader_id,
+            leader_addr,
+        } => CommitError::NotLeader {
+            leader_id,
+            leader_addr,
+        },
+        YrpProposeError::Timeout => CommitError::CommitTimeout { op_id },
+        YrpProposeError::Unavailable(m) => CommitError::StorageFailure { message: m },
+    }
+}
+
+#[async_trait]
+impl MutationCommitter for YrpCommitter {
+    async fn commit(
+        &self,
+        tenant_id: TenantId,
+        mutation: MemoryMutation,
+        opts: CommitOptions,
+    ) -> Result<CommitReceipt, CommitError> {
+        if let Some(expected) = opts.expected_log_index {
+            return Err(CommitError::StorageFailure {
+                message: format!(
+                    "expected_log_index ({expected}) is not supported in yrp mode"
+                ),
+            });
+        }
+        let op_id = opts.op_id.unwrap_or_else(OpId::new_random);
+        let op = YrpOp {
+            tenant_id,
+            op_id,
+            mutation,
+            idempotency_key: None,
+        };
+        let key = claim_key_for_op(tenant_id, &op_id);
+        let outcome = self
+            .handle
+            .propose_and_wait(key, &op)
+            .await
+            .map_err(|e| propose_err_to_commit(e, op_id))?;
+        let applied_at = SystemTime::UNIX_EPOCH
+            + Duration::from_micros(outcome.applied_at_unix_micros.max(0) as u64);
+        Ok(CommitReceipt {
+            op_id,
+            tenant_id,
+            term: outcome.term,
+            log_index: outcome.tenant_log_index,
+            committed_at: applied_at,
+            applied_at: Some(applied_at),
+        })
+    }
+
+    async fn read_range(
+        &self,
+        tenant_id: TenantId,
+        from_index: u64,
+        limit: usize,
+    ) -> Result<Vec<CommittedEntry>, CommitError> {
+        self.local.read_range(tenant_id, from_index, limit).await
+    }
+
+    async fn high_watermark(&self, tenant_id: TenantId) -> Result<u64, CommitError> {
+        self.local.high_watermark(tenant_id).await
+    }
+
+    async fn list_active_tenants(&self) -> Result<Vec<TenantId>, CommitError> {
+        self.local.list_active_tenants().await
+    }
+
+    /// v1 approximation: leadership check only (no quorum read lease —
+    /// a deposed-but-unaware leader window exists, same as the legacy
+    /// raft-lite mode; the honest fix is a read-index barrier, tracked
+    /// for the chaos-gate slice).
+    async fn ensure_linearizable(&self) -> Result<(), CommitError> {
+        if self.handle.is_leader() {
+            Ok(())
+        } else {
+            let (leader_id, leader_addr) = self.handle.leader_hint();
+            Err(CommitError::NotLeader {
+                leader_id,
+                leader_addr,
+            })
+        }
+    }
+}

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -321,7 +321,11 @@ pub fn spawn(
 
     match inspect(cluster, u32::MAX, &recovered) {
         BootDecision::Healthy { .. } => {
-            tracing::info!(node = cfg.node_id, cluster = cfg.cluster_id, "YRP boot: healthy");
+            tracing::info!(
+                node = cfg.node_id,
+                cluster = cfg.cluster_id,
+                "YRP boot: healthy"
+            );
             let mut driver = YrpDriver::new(
                 driver_cfg(),
                 restored,
@@ -334,7 +338,10 @@ pub fn spawn(
             spawn_driver(driver, owner_rx, handle.clone());
         }
         BootDecision::Quarantine { reasons, term_hint } => {
-            tracing::error!(?reasons, "YRP boot: QUARANTINED (fail closed, serving diagnostics)");
+            tracing::error!(
+                ?reasons,
+                "YRP boot: QUARANTINED (fail closed, serving diagnostics)"
+            );
             handle.set_quarantine(Some(reasons.iter().map(|r| format!("{r:?}")).collect()));
             let node = QuarantinedNode::new(me, cluster, reasons, term_hint);
             let ctx = QuarantineCtx {
@@ -378,7 +385,10 @@ fn spawn_driver(
             other => {
                 // Fail-stop posture: surface it on health and refuse
                 // writes; the operator restarts through boot inspection.
-                tracing::error!(?other, "YRP driver FAILED — node degraded to quarantine posture");
+                tracing::error!(
+                    ?other,
+                    "YRP driver FAILED — node degraded to quarantine posture"
+                );
                 handle.set_quarantine(Some(vec![format!("driver exit: {other:?}")]));
             }
         }
@@ -470,7 +480,10 @@ fn run_bootstrap_effect(ctx: &mut QuarantineCtx, eff: BootstrapEffect) {
             }
         }
         BootstrapEffect::Alarm { reasons } => {
-            tracing::error!(?reasons, "YRP QUARANTINE ALARM: corruption evidence — operator attention required");
+            tracing::error!(
+                ?reasons,
+                "YRP QUARANTINE ALARM: corruption evidence — operator attention required"
+            );
         }
         BootstrapEffect::Send { to, msg } => {
             ctx.transport.send(to, WireMsg::Rejoin(msg));
@@ -522,9 +535,7 @@ impl MutationCommitter for YrpCommitter {
     ) -> Result<CommitReceipt, CommitError> {
         if let Some(expected) = opts.expected_log_index {
             return Err(CommitError::StorageFailure {
-                message: format!(
-                    "expected_log_index ({expected}) is not supported in yrp mode"
-                ),
+                message: format!("expected_log_index ({expected}) is not supported in yrp mode"),
             });
         }
         // Codex F2: refuse unimplemented grammar variants BEFORE they

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -498,7 +498,7 @@ impl YrpCommitter {
     }
 }
 
-fn propose_err_to_commit(e: YrpProposeError, op_id: OpId) -> CommitError {
+pub fn propose_err_to_commit(e: YrpProposeError, op_id: OpId) -> CommitError {
     match e {
         YrpProposeError::NotLeader {
             leader_id,

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -527,28 +527,64 @@ impl MutationCommitter for YrpCommitter {
                 ),
             });
         }
-        let op_id = opts.op_id.unwrap_or_else(OpId::new_random);
-        let op = YrpOp {
-            tenant_id,
-            op_id,
-            mutation,
-            idempotency_key: None,
-        };
-        let key = claim_key_for_op(tenant_id, &op_id);
-        let outcome = self
-            .handle
-            .propose_and_wait(key, &op)
-            .await
-            .map_err(|e| propose_err_to_commit(e, op_id))?;
-        let applied_at = SystemTime::UNIX_EPOCH
-            + Duration::from_micros(outcome.applied_at_unix_micros.max(0) as u64);
-        Ok(CommitReceipt {
-            op_id,
-            tenant_id,
-            term: outcome.term,
-            log_index: outcome.tenant_log_index,
-            committed_at: applied_at,
-            applied_at: Some(applied_at),
+        // Codex F2: refuse unimplemented grammar variants BEFORE they
+        // enter the replicated log. Without this, an entry with no apply
+        // path would still advance the marker and ack the client with no
+        // engine effect (same pre-check RaftCommitter performs).
+        if !mutation.is_implemented() {
+            return Err(CommitError::NotYetImplemented {
+                variant: mutation.variant_name(),
+                planned_rfc: mutation.planned_rfc(),
+            });
+        }
+        // Codex F3: the u64 claim digest can collide across DISTINCT
+        // op_ids (birthday bound over server-generated ids). A collision
+        // would dedupe a fresh write against an unrelated entry — detect
+        // it by verifying the outcome's op_id, and resolve by retrying
+        // under a fresh op_id (fresh id → fresh digest). Bounded: two
+        // independent collisions in a row are beyond astronomical.
+        let mut op_id = opts.op_id.unwrap_or_else(OpId::new_random);
+        for attempt in 0..3 {
+            let op = YrpOp {
+                tenant_id,
+                op_id,
+                mutation: mutation.clone(),
+                idempotency_key: None,
+            };
+            let key = claim_key_for_op(tenant_id, &op_id);
+            let outcome = self
+                .handle
+                .propose_and_wait(key, &op)
+                .await
+                .map_err(|e| propose_err_to_commit(e, op_id))?;
+            if outcome.op_id != op_id.to_string() {
+                tracing::warn!(
+                    attempt,
+                    "yrp unkeyed claim digest collision detected; retrying with fresh op_id"
+                );
+                // A caller-supplied op_id cannot be silently swapped —
+                // its retry contract is the whole point of supplying it.
+                if opts.op_id.is_some() {
+                    return Err(CommitError::StorageFailure {
+                        message: "claim digest collision on caller-supplied op_id".into(),
+                    });
+                }
+                op_id = OpId::new_random();
+                continue;
+            }
+            let applied_at = SystemTime::UNIX_EPOCH
+                + Duration::from_micros(outcome.applied_at_unix_micros.max(0) as u64);
+            return Ok(CommitReceipt {
+                op_id,
+                tenant_id,
+                term: outcome.term,
+                log_index: outcome.tenant_log_index,
+                committed_at: applied_at,
+                applied_at: Some(applied_at),
+            });
+        }
+        Err(CommitError::StorageFailure {
+            message: "repeated claim digest collisions (unkeyed)".into(),
         })
     }
 

--- a/crates/yantrikdb-server/src/yrp/sim.rs
+++ b/crates/yantrikdb-server/src/yrp/sim.rs
@@ -28,7 +28,7 @@ use super::bootstrap::{
     RecoveredState, RejoinMessage,
 };
 use super::replica::{
-    Effect, KeyedProposal, LogEntry, Message, ReplicaCore, Role, Snapshot, NOOP_PAYLOAD,
+    Effect, KeyedProposal, LogEntry, Message, Payload, ReplicaCore, Role, Snapshot,
 };
 use super::types::{ClusterId, HardState, LogPosition, NodeId, Term};
 
@@ -111,7 +111,7 @@ struct Sim {
     alarms: Vec<(NodeId, Vec<QuarantineReason>)>,
     /// Phase B claim ledger: key → (index, payload) of the ONE committed
     /// entry ever allowed to hold it (never-double-write, globally).
-    keyed_committed: BTreeMap<u64, (u64, u64)>,
+    keyed_committed: BTreeMap<u64, (u64, Payload)>,
     /// Witness subset (applied to every constructed core, incl. restarts).
     witnesses: BTreeSet<NodeId>,
     /// Capability-incompatibility alarms: (leader, stalled peer).
@@ -268,12 +268,26 @@ impl Sim {
     fn ledger_commit(&mut self, id: NodeId, to: u64) {
         let from = self.nodes[&id].applied + 1;
         for i in from..=to {
-            let e = *self.nodes[&id]
+            let e = self.nodes[&id]
                 .core
                 .as_ref()
                 .expect("commit on live node")
                 .entry(i)
-                .expect("committed index must be in log");
+                .expect("committed index must be in log")
+                .clone();
+            // Phase B never-double-write: one committed entry per key, ever.
+            if let Some(k) = e.key {
+                match self.keyed_committed.get(&k) {
+                    None => {
+                        self.keyed_committed.insert(k, (i, e.payload.clone()));
+                    }
+                    Some((pi, pp)) => assert_eq!(
+                        (*pi, pp),
+                        (i, &e.payload),
+                        "CLAIM DOUBLE-WRITE: key {k} committed at two places"
+                    ),
+                }
+            }
             match self.committed_at.get(&i) {
                 None => {
                     self.committed_at.insert(i, e);
@@ -283,19 +297,6 @@ impl Sim {
                     "AUTHORITY SAFETY VIOLATED: index {i} applied with two \
                      different entries ({prev:?} vs {e:?}, second by {id:?})"
                 ),
-            }
-            // Phase B never-double-write: one committed entry per key, ever.
-            if let Some(k) = e.key {
-                match self.keyed_committed.get(&k) {
-                    None => {
-                        self.keyed_committed.insert(k, (i, e.payload));
-                    }
-                    Some((pi, pp)) => assert_eq!(
-                        (*pi, *pp),
-                        (i, e.payload),
-                        "CLAIM DOUBLE-WRITE: key {k} committed at two places"
-                    ),
-                }
             }
         }
         let node = self.nodes.get_mut(&id).unwrap();
@@ -492,7 +493,7 @@ impl Sim {
         let Some(core) = self.nodes.get_mut(&id).unwrap().core.as_mut() else {
             return false;
         };
-        match core.propose(payload) {
+        match core.propose(Payload::Test(payload)) {
             Some(effects) => {
                 self.run_effects(id, effects, None);
                 true
@@ -648,7 +649,7 @@ fn entries(terms: &[u64]) -> Vec<LogEntry> {
     terms
         .iter()
         .enumerate()
-        .map(|(i, t)| LogEntry::unkeyed(Term(*t), 1000 + i as u64))
+        .map(|(i, t)| LogEntry::unkeyed(Term(*t), Payload::Test(1000 + i as u64)))
         .collect()
 }
 
@@ -674,8 +675,8 @@ fn three_nodes_elect_exactly_one_leader() {
     );
     // The winner's no-op reached commit.
     assert_eq!(
-        sim.committed_at.get(&1).map(|e| e.payload),
-        Some(NOOP_PAYLOAD)
+        sim.committed_at.get(&1).map(|e| e.payload.clone()),
+        Some(Payload::Noop)
     );
 }
 
@@ -839,9 +840,9 @@ fn replication_commits_across_cluster() {
     sim.drain();
     sim.check_all();
     // Index 1 = no-op, 2..=4 = payloads, committed everywhere.
-    assert_eq!(sim.committed_at.get(&2).map(|e| e.payload), Some(101));
-    assert_eq!(sim.committed_at.get(&3).map(|e| e.payload), Some(102));
-    assert_eq!(sim.committed_at.get(&4).map(|e| e.payload), Some(103));
+    assert!(sim.committed_at.get(&2).is_some_and(|e| e.payload == 101));
+    assert!(sim.committed_at.get(&3).is_some_and(|e| e.payload == 102));
+    assert!(sim.committed_at.get(&4).is_some_and(|e| e.payload == 103));
     for (id, node) in &sim.nodes {
         assert!(node.applied >= 4, "{id:?} applied only to {}", node.applied);
     }
@@ -903,7 +904,7 @@ fn r1_stale_leader_cannot_commit_and_gets_fenced() {
         .map(|(i, _)| *i)
         .expect("301 committed");
     let n1 = sim.nodes[&NodeId(1)].core.as_ref().unwrap();
-    assert_eq!(n1.entry(committed_301).map(|e| e.payload), Some(301));
+    assert!(n1.entry(committed_301).is_some_and(|e| e.payload == 301));
     assert_eq!(sim.current_leader(), Some(NodeId(2)));
 }
 
@@ -1348,7 +1349,7 @@ impl Sim {
     /// outcome. Mirrors what the production API layer will do.
     fn propose_keyed(&mut self, id: NodeId, key: u64, payload: u64) -> Option<KeyedProposal> {
         let core = self.nodes.get_mut(&id).unwrap().core.as_mut()?;
-        let outcome = core.propose_keyed(key, payload)?;
+        let outcome = core.propose_keyed(key, Payload::Test(payload))?;
         if let KeyedProposal::Appended { effects, index } = outcome {
             self.run_effects(id, effects, None);
             return Some(KeyedProposal::Appended {
@@ -1395,8 +1396,8 @@ fn keyed_commit_survives_failover_and_dedupes_retry() {
     }
     sim.check_all();
     assert_eq!(
-        sim.keyed_committed.get(&77).map(|(i, p)| (*i, *p)),
-        Some((orig_index, 707)),
+        sim.keyed_committed.get(&77).map(|(i, p)| (*i, p.clone())),
+        Some((orig_index, Payload::Test(707))),
         "exactly one committed effect for the key"
     );
 }
@@ -1438,8 +1439,8 @@ fn keyed_tentative_loss_reexecutes_cleanly() {
     sim.drain();
     sim.check_all();
     assert_eq!(
-        sim.keyed_committed.get(&88).map(|(i, p)| (*i, *p)),
-        Some((new_index, 808)),
+        sim.keyed_committed.get(&88).map(|(i, p)| (*i, p.clone())),
+        Some((new_index, Payload::Test(808))),
         "exactly one committed effect, at the canonical index"
     );
     // The healed ex-leader holds the canonical keyed entry.
@@ -1466,13 +1467,13 @@ fn keyed_retry_pending_parks_then_dedupes() {
         .core
         .as_mut()
         .unwrap();
-    let out1 = core.propose_keyed(99, 909).unwrap();
+    let out1 = core.propose_keyed(99, Payload::Test(909)).unwrap();
     let index = match &out1 {
         KeyedProposal::Appended { index, .. } => *index,
         other => panic!("fresh append expected, got {other:?}"),
     };
     // Immediate retry while pending: parked, same index, NO new entry.
-    let out2 = core.propose_keyed(99, 909).unwrap();
+    let out2 = core.propose_keyed(99, Payload::Test(909)).unwrap();
     assert_eq!(out2, KeyedProposal::DuplicatePending { index });
     let log_len_before = core.log_len();
     // Run the pending effects (persist + fan-out) to completion.
@@ -1492,7 +1493,7 @@ fn keyed_retry_pending_parks_then_dedupes() {
         log_len_before,
         "no second append for the key"
     );
-    let out3 = core.propose_keyed(99, 909).unwrap();
+    let out3 = core.propose_keyed(99, Payload::Test(909)).unwrap();
     assert_eq!(out3, KeyedProposal::DuplicateCommitted { index });
     sim.check_all();
 }
@@ -1667,8 +1668,15 @@ fn witness_tiebreak_preserves_all_committed_entries() {
         assert!(sim.propose(NodeId(1), p));
     }
     sim.drain();
-    let committed_before: Vec<u64> = sim.committed_at.values().map(|e| e.payload).collect();
-    assert!(committed_before.contains(&913), "writes committed");
+    let committed_before: Vec<Payload> = sim
+        .committed_at
+        .values()
+        .map(|e| e.payload.clone())
+        .collect();
+    assert!(
+        committed_before.iter().any(|p| *p == 913),
+        "writes committed"
+    );
     // Data leader dies. Survivors: one data node + the witness.
     sim.crash(NodeId(1));
     sim.timeout(NodeId(2), None);

--- a/crates/yantrikdb-server/src/yrp/transport.rs
+++ b/crates/yantrikdb-server/src/yrp/transport.rs
@@ -183,9 +183,9 @@ pub fn deliver_inbound(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::replica::Payload;
     use super::super::types::{LogPosition, Term};
+    use super::*;
 
     /// The wire envelope must round-trip through bincode — including an
     /// AppendEntries carrying real Op bytes (the exact production shape).

--- a/crates/yantrikdb-server/src/yrp/transport.rs
+++ b/crates/yantrikdb-server/src/yrp/transport.rs
@@ -20,6 +20,12 @@
 //! (votes, rejoin) is small and non-cumulative: a bounded queue; overflow
 //! drops the NEWEST (the protocol re-times-out and re-sends).
 //!
+//! Snapshot starvation (codex F4) cannot occur here: the slot is
+//! PER-PEER and the leader re-decides each peer's message TYPE from
+//! `next_index` on every heartbeat — a straggler below the compaction
+//! base gets `InstallSnapshot` again each tick, so its slot re-fills
+//! with the snapshot, never with a heartbeat that would displace it.
+//!
 //! Codex F4 also suggested term-generation tags to cancel stale sends on
 //! step-down. With a latest-only slot the stale window is exactly ONE
 //! in-flight message, which the receiver term-fences — the tag machinery

--- a/crates/yantrikdb-server/src/yrp/transport.rs
+++ b/crates/yantrikdb-server/src/yrp/transport.rs
@@ -1,0 +1,246 @@
+//! HTTP transport adapter — YRP wire messages over the cluster's HTTP
+//! plane (runtime-integration slice; codex F4 queue discipline).
+//!
+//! ## Shape
+//!
+//! - **Outbound**: [`HttpTransport`] implements [`Transport`]. One client
+//!   task per peer; the owner's `send` classifies and enqueues, never
+//!   blocks, never observes delivery failures (the protocol's timers and
+//!   retransmits are the recovery mechanism — silence is the contract).
+//! - **Inbound**: the axum route `POST /v1/yrp/msg` (mounted by the
+//!   gateway) decodes the bincode envelope and funnels
+//!   `DriverEvent::Inbound` to the owner.
+//!
+//! ## Queue discipline (codex F4)
+//!
+//! Replication traffic (AppendEntries / InstallSnapshot) is CUMULATIVE:
+//! a newer message strictly supersedes an older one to the same peer. So
+//! each peer gets a single latest-message slot — under backpressure we
+//! coalesce to the newest instead of queueing a backlog. Control traffic
+//! (votes, rejoin) is small and non-cumulative: a bounded queue; overflow
+//! drops the NEWEST (the protocol re-times-out and re-sends).
+//!
+//! Codex F4 also suggested term-generation tags to cancel stale sends on
+//! step-down. With a latest-only slot the stale window is exactly ONE
+//! in-flight message, which the receiver term-fences — the tag machinery
+//! buys nothing here, so it is deliberately omitted (documented deviation
+//! for the codex review pass).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use tokio::sync::{mpsc, Notify};
+
+use super::driver::{DriverEvent, Transport, WireMsg};
+use super::replica::Message;
+use super::types::NodeId;
+
+/// Wire envelope for `POST /v1/yrp/msg`: (sender node id, message),
+/// bincode-encoded. Everything inside is externally-tagged serde —
+/// bincode-safe (the engine-mutation bytes inside `Payload::Op` are an
+/// opaque byte vector at this layer; see `yrp::op` for THEIR encoding).
+pub type WireEnvelope = (u64, WireMsg);
+
+/// Bounded control-queue depth per peer (votes, rejoin traffic).
+const CONTROL_QUEUE_DEPTH: usize = 64;
+
+/// Per-request send timeout. Losing a message is always safe; wedging a
+/// peer task behind a black-holed connection is not.
+const SEND_TIMEOUT: Duration = Duration::from_secs(2);
+
+struct PeerQueues {
+    /// Latest replication message only — newer supersedes older.
+    latest: Mutex<Option<WireMsg>>,
+    wake: Notify,
+    control: mpsc::Sender<WireMsg>,
+}
+
+/// Outbound HTTP transport: one sender task per peer.
+pub struct HttpTransport {
+    me: NodeId,
+    peers: BTreeMap<NodeId, Arc<PeerQueues>>,
+}
+
+impl HttpTransport {
+    /// `peer_urls`: peer node id → HTTP base url (e.g. `http://10.0.0.2:7438`).
+    /// `secret`: shared cluster secret sent as a bearer token (peers refuse
+    /// envelopes without it when configured).
+    pub fn new(me: NodeId, peer_urls: BTreeMap<NodeId, String>, secret: Option<String>) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(SEND_TIMEOUT)
+            .build()
+            .expect("reqwest client");
+        let mut peers = BTreeMap::new();
+        for (peer, base) in peer_urls {
+            let (control_tx, control_rx) = mpsc::channel(CONTROL_QUEUE_DEPTH);
+            let q = Arc::new(PeerQueues {
+                latest: Mutex::new(None),
+                wake: Notify::new(),
+                control: control_tx,
+            });
+            tokio::spawn(run_peer_sender(
+                me,
+                peer,
+                base,
+                client.clone(),
+                secret.clone(),
+                q.clone(),
+                control_rx,
+            ));
+            peers.insert(peer, q);
+        }
+        Self { me, peers }
+    }
+}
+
+impl Transport for HttpTransport {
+    fn send(&self, to: NodeId, msg: WireMsg) {
+        let Some(q) = self.peers.get(&to) else {
+            tracing::warn!(?to, "YRP send to unknown peer dropped");
+            return;
+        };
+        let cumulative = matches!(
+            msg,
+            WireMsg::Replica(Message::AppendEntries { .. })
+                | WireMsg::Replica(Message::InstallSnapshot { .. })
+        );
+        if cumulative {
+            *q.latest.lock() = Some(msg);
+            q.wake.notify_one();
+        } else if q.control.try_send(msg).is_err() {
+            // Full queue: drop the newest — the sender's timers re-drive.
+            tracing::debug!(?to, "YRP control queue full; message dropped");
+        }
+    }
+}
+
+async fn run_peer_sender(
+    me: NodeId,
+    peer: NodeId,
+    base: String,
+    client: reqwest::Client,
+    secret: Option<String>,
+    q: Arc<PeerQueues>,
+    mut control_rx: mpsc::Receiver<WireMsg>,
+) {
+    let url = format!("{}/v1/yrp/msg", base.trim_end_matches('/'));
+    loop {
+        // Control first (election traffic must not starve behind bulky
+        // appends), then the latest replication message.
+        let msg = tokio::select! {
+            biased;
+            ctrl = control_rx.recv() => match ctrl {
+                Some(m) => m,
+                None => return, // transport dropped
+            },
+            _ = q.wake.notified() => match q.latest.lock().take() {
+                Some(m) => m,
+                None => continue, // already taken by a prior wake
+            },
+        };
+        let envelope: WireEnvelope = (me.0, msg);
+        let body = match bincode::serialize(&envelope) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!(error = %e, "YRP envelope serialize failed; dropped");
+                continue;
+            }
+        };
+        let mut req = client.post(&url).body(body);
+        if let Some(s) = &secret {
+            req = req.bearer_auth(s);
+        }
+        if let Err(e) = req.send().await {
+            // Silence IS the failure signal — the protocol retransmits.
+            tracing::debug!(?peer, error = %e, "YRP send failed (will retransmit)");
+        }
+    }
+}
+
+/// Decode an inbound `POST /v1/yrp/msg` body and forward it to the owner
+/// funnel. Returns Err on malformed bytes (HTTP 400 at the route).
+pub fn deliver_inbound(
+    owner: &mpsc::UnboundedSender<DriverEvent>,
+    body: &[u8],
+) -> Result<(), String> {
+    let (from, msg): WireEnvelope =
+        bincode::deserialize(body).map_err(|e| format!("malformed YRP envelope: {e}"))?;
+    owner
+        .send(DriverEvent::Inbound {
+            from: NodeId(from),
+            msg,
+        })
+        .map_err(|_| "YRP driver not running".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::replica::Payload;
+    use super::super::types::{LogPosition, Term};
+
+    /// The wire envelope must round-trip through bincode — including an
+    /// AppendEntries carrying real Op bytes (the exact production shape).
+    #[test]
+    fn wire_envelope_bincode_round_trip() {
+        let entry = super::super::replica::LogEntry {
+            term: Term(3),
+            payload: Payload::Op(vec![1, 2, 3, 255]),
+            key: Some(42),
+            activate: None,
+        };
+        let msg = WireMsg::Replica(Message::AppendEntries {
+            term: Term(3),
+            leader: NodeId(1),
+            prev: LogPosition { term: 2, index: 9 },
+            entries: vec![entry],
+            commit: 9,
+        });
+        let env: WireEnvelope = (1, msg);
+        let bytes = bincode::serialize(&env).unwrap();
+        let (from, back): WireEnvelope = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(from, 1);
+        match back {
+            WireMsg::Replica(Message::AppendEntries { entries, .. }) => {
+                assert_eq!(entries[0].payload, Payload::Op(vec![1, 2, 3, 255]));
+                assert_eq!(entries[0].key, Some(42));
+            }
+            other => panic!("wrong decode: {other:?}"),
+        }
+    }
+
+    /// Coalescing: two replication sends before the peer task drains
+    /// leave only the LATEST in the slot.
+    #[tokio::test]
+    async fn replication_messages_coalesce_to_latest() {
+        // Build the queues directly (no network) to observe the slot.
+        let (control_tx, _control_rx) = mpsc::channel(CONTROL_QUEUE_DEPTH);
+        let q = Arc::new(PeerQueues {
+            latest: Mutex::new(None),
+            wake: Notify::new(),
+            control: control_tx,
+        });
+        let transport = HttpTransport {
+            me: NodeId(1),
+            peers: [(NodeId(2), q.clone())].into_iter().collect(),
+        };
+        let hb = |commit| {
+            WireMsg::Replica(Message::AppendEntries {
+                term: Term(1),
+                leader: NodeId(1),
+                prev: LogPosition::ZERO,
+                entries: vec![],
+                commit,
+            })
+        };
+        transport.send(NodeId(2), hb(1));
+        transport.send(NodeId(2), hb(2));
+        let latest = q.latest.lock().take().expect("slot filled");
+        match latest {
+            WireMsg::Replica(Message::AppendEntries { commit, .. }) => assert_eq!(commit, 2),
+            other => panic!("wrong slot content: {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## What this is

The runtime-integration slice from the handoff: YRP native replication now runs on the real server — `raft_mode = "yrp"` boots a live cluster whose wire messages ride the HTTP plane, and the keyed `/v1/remember` path that returned **501 in cluster mode** now resolves through the replicated claim-in-log (RFC 028 §7).

## The eight steps, as landed

1. **`Payload` enum** — `LogEntry.payload` graduates from opaque `u64` to `{Noop, Test(u64), Op(Vec<u8>)}`; sim ledgers key off `Payload` equality.
2. **Op envelope** (`yrp/op.rs`) — `YrpOp{tenant, op_id, mutation, idempotency_key}` as serde_json inside `Payload::Op` (the mutation enum is internally tagged — bincode cannot round-trip it); rid allocated at the gateway pre-propose (codex F3), pinned FNV-1a-64 claim digests scoped per tenant.
3. **`EngineApplySink`** (`yrp/engine_sink.rs`) — commit-log-first (op_id exactly-once) → idempotent engine apply (yrp index as seq) → outcome + applied-marker transaction LAST. The marker can never run ahead of effects; crash-replay is proven by test. Acks release only at the marker.
4. **HTTP transport** (`yrp/transport.rs`) — per-peer sender tasks, latest-only coalescing slot for append/install, bounded control queue drained first, fire-and-forget sends (codex F4 discipline; generation tags documented as deliberately unnecessary).
5. **Config + boot** — `[yrp]` section, `RaftClusterMode::Yrp`, and a startup path through `bootstrap::inspect`: Healthy → driver; anything less → the fail-closed quarantine loop (preserve-once, alarm-once, round-robin rejoin, adopt → same-funnel driver handoff). The process always starts; health says the truth.
6. **Gateway binding** — `POST /v1/yrp/msg` (cluster-secret gated), `YrpCommitter` drives ALL handler writes through the replicated log, keyed `/v1/remember` replaces the 501 with claim-in-log while preserving the issue-#58 response contract byte-for-byte (silent-HIT / 200 conflict shape / 400 invalid key), plus a fail-closed digest-collision guard.
7. **Live-recall axis** — the 2-node test asserts the FOLLOWER's live `/v1/recall` surfaces replicated writes (in-memory index coherence, the durable-green/live-red class).
8. **2-node cluster over real localhost HTTP** — election, keyed dedupe across the wire, unkeyed replication, follower write refusal, honest health on both nodes.

## Codex review (standing collaboration mode)

gpt-5.6-sol redteam returned 6 findings. Fixed now: pre-propose `is_implemented()` gate (F2) and unkeyed op_id-collision detection with fresh-id retry (F3). Documented as residuals with rationale: engine-DB-loss-vs-marker (Phase C manifest, shared with openraft baseline), snapshot starvation (impossible — per-peer type re-decided per heartbeat), grant freshness (the documented Gate C incarnation work).

## Validation

- Full suite green: 2169 tests across all targets, including the new 2-node HTTP cluster test (`yrp::cluster_test`, ~1.3s).
- Sink fail-stop observed working during development: a bad embedding dimension fail-stopped the apply worker and the client got a timeout, never a false ack.

## Next (per handoff sequence)

Live chaos gate (task 237) → Phase C 3-node homelab deploy (238) → Phase D delete openraft (239). yantrikdb-mcp to be pinged so their contract gate can exercise keyed-retry-during-any-replication-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)