### PR TITLE
feat(yrp): chaos gate — mechanical cluster-mode proof, wired as the release gate (saga 237)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,30 @@ jobs:
       - name: CLI smoke test
         run: cargo run -p yantrikdb-server -- --help
 
+  # RFC 028 / saga 237: the cluster-mode release gate, as its own named
+  # job so a red gate is visible at a glance (the v0.8.18 lesson —
+  # single-node green is NOT cluster validation). Runs the full YRP
+  # suite: sim invariants, driver runtime, the 2-node HTTP cluster test,
+  # and the chaos scenarios (kill-leader, partition+heal, torn-state
+  # quarantine/rejoin, beyond-GC snapshot install).
+  chaos-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: YRP cluster-mode gate (sim + runtime + chaos)
+        run: "cargo test -p yantrikdb-server --bin yantrikdb yrp::"
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,18 @@ permissions:
   contents: write
 
 jobs:
+  # RFC 028 / saga 237: a release tag CANNOT produce binaries without the
+  # cluster-mode chaos gate passing first (v0.8.18 lesson made permanent).
+  chaos-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: YRP cluster-mode gate (sim + runtime + chaos)
+        run: "cargo test -p yantrikdb-server --bin yantrikdb yrp::"
+
   build:
+    needs: chaos-gate
     strategy:
       fail-fast: false
       matrix:

--- a/crates/yantrikdb-server/src/config/mod.rs
+++ b/crates/yantrikdb-server/src/config/mod.rs
@@ -335,6 +335,13 @@ pub struct YrpSection {
     pub election_ticks_max: u32,
     /// Leader heartbeat cadence, in ticks.
     pub heartbeat_ticks: u32,
+    /// Log compaction: compact once the durably-applied span exceeds
+    /// this many entries. 0 = disabled — the production default until
+    /// Phase C ships engine-checkpoint transfer for beyond-GC stragglers.
+    pub compact_after_entries: u64,
+    /// Entries a LEADER retains above its compaction base so transient
+    /// follower lag is served from the log, not a snapshot.
+    pub leader_retain_entries: u64,
     /// All cluster members (including this node).
     pub peers: Vec<YrpPeerConfig>,
 }
@@ -359,6 +366,8 @@ impl Default for YrpSection {
             election_ticks_min: 10,
             election_ticks_max: 20,
             heartbeat_ticks: 2,
+            compact_after_entries: 0,
+            leader_retain_entries: 512,
             peers: Vec::new(),
         }
     }

--- a/crates/yantrikdb-server/src/debug/fault.rs
+++ b/crates/yantrikdb-server/src/debug/fault.rs
@@ -191,6 +191,86 @@ impl FaultRegistry {
     pub fn active_count(&self) -> usize {
         self.list().len()
     }
+
+    /// Decide the fate of one peer message `from → to`. Consulted by the
+    /// YRP receive route (`POST /v1/yrp/msg`) BEFORE any protocol
+    /// handling, per the chaos-gate design (codex D1: receive-side
+    /// injection is externally controllable across process restarts and
+    /// exercises the real HTTP path).
+    ///
+    /// Precedence: any matching Drop-class fault wins over delays; among
+    /// delays the LONGEST matching delay applies. `CorruptBytes` is not
+    /// evaluated here — the receive route's bincode decode rejecting
+    /// corrupt bytes is covered separately.
+    pub fn verdict(&self, from: u32, to: u32) -> FaultVerdict {
+        let now = Instant::now();
+        let faults = self.inner.faults.read();
+        let mut delay_ms: Option<u64> = None;
+        for r in faults.values() {
+            if r.is_expired(now) {
+                continue;
+            }
+            match &r.kind {
+                FaultKind::Partition { side_a, side_b } => {
+                    let crosses = (side_a.contains(&from) && side_b.contains(&to))
+                        || (side_b.contains(&from) && side_a.contains(&to));
+                    if crosses {
+                        return FaultVerdict::Drop;
+                    }
+                }
+                FaultKind::PauseLeader { node_id } => {
+                    if *node_id == from {
+                        return FaultVerdict::Drop;
+                    }
+                }
+                FaultKind::DropMessages {
+                    from_peer,
+                    to_peer,
+                    probability,
+                } => {
+                    let matches = from_peer.map_or(true, |f| f == from)
+                        && to_peer.map_or(true, |t| t == to);
+                    if matches && rand::Rng::gen::<f64>(&mut rand::thread_rng()) < *probability {
+                        return FaultVerdict::Drop;
+                    }
+                }
+                FaultKind::InjectLatency {
+                    from_peer,
+                    to_peer,
+                    min_ms,
+                    max_ms,
+                } => {
+                    let matches = from_peer.map_or(true, |f| f == from)
+                        && to_peer.map_or(true, |t| t == to);
+                    if matches {
+                        let hi = (*max_ms).max(*min_ms);
+                        let picked = if hi == *min_ms {
+                            *min_ms
+                        } else {
+                            rand::Rng::gen_range(&mut rand::thread_rng(), *min_ms..=hi)
+                        };
+                        delay_ms = Some(delay_ms.map_or(picked, |d| d.max(picked)));
+                    }
+                }
+                FaultKind::CorruptBytes { .. } => {}
+            }
+        }
+        match delay_ms {
+            Some(ms) => FaultVerdict::Delay(Duration::from_millis(ms)),
+            None => FaultVerdict::Deliver,
+        }
+    }
+}
+
+/// Outcome of [`FaultRegistry::verdict`] for one message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaultVerdict {
+    Deliver,
+    Drop,
+    /// Deliver after this delay (the DELIVERY is delayed, not the HTTP
+    /// response — otherwise latency faults just manufacture client
+    /// timeouts, codex D1 pitfall).
+    Delay(Duration),
 }
 
 impl Default for FaultRegistry {

--- a/crates/yantrikdb-server/src/debug/fault.rs
+++ b/crates/yantrikdb-server/src/debug/fault.rs
@@ -228,8 +228,8 @@ impl FaultRegistry {
                     to_peer,
                     probability,
                 } => {
-                    let matches = from_peer.map_or(true, |f| f == from)
-                        && to_peer.map_or(true, |t| t == to);
+                    let matches =
+                        from_peer.map_or(true, |f| f == from) && to_peer.map_or(true, |t| t == to);
                     if matches && rand::Rng::gen::<f64>(&mut rand::thread_rng()) < *probability {
                         return FaultVerdict::Drop;
                     }
@@ -240,8 +240,8 @@ impl FaultRegistry {
                     min_ms,
                     max_ms,
                 } => {
-                    let matches = from_peer.map_or(true, |f| f == from)
-                        && to_peer.map_or(true, |t| t == to);
+                    let matches =
+                        from_peer.map_or(true, |f| f == from) && to_peer.map_or(true, |t| t == to);
                     if matches {
                         let hi = (*max_ms).max(*min_ms);
                         let picked = if hi == *min_ms {

--- a/crates/yantrikdb-server/src/debug/mod.rs
+++ b/crates/yantrikdb-server/src/debug/mod.rs
@@ -48,6 +48,6 @@ pub mod fault;
 pub mod history;
 
 pub use fault::{
-    FaultId, FaultKind, FaultRecord, FaultRegistry, FaultyNetwork, NoopFaultyNetwork,
-    RegistryFaultyNetwork,
+    FaultId, FaultKind, FaultRecord, FaultRegistry, FaultVerdict, FaultyNetwork,
+    NoopFaultyNetwork, RegistryFaultyNetwork,
 };

--- a/crates/yantrikdb-server/src/debug/mod.rs
+++ b/crates/yantrikdb-server/src/debug/mod.rs
@@ -48,6 +48,6 @@ pub mod fault;
 pub mod history;
 
 pub use fault::{
-    FaultId, FaultKind, FaultRecord, FaultRegistry, FaultVerdict, FaultyNetwork,
-    NoopFaultyNetwork, RegistryFaultyNetwork,
+    FaultId, FaultKind, FaultRecord, FaultRegistry, FaultVerdict, FaultyNetwork, NoopFaultyNetwork,
+    RegistryFaultyNetwork,
 };

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -1126,7 +1126,31 @@ async fn yrp_msg(
             ));
         }
     }
-    yrp.deliver_inbound(&body)
+    let (from, msg) = crate::yrp::transport::decode_envelope(&body)
+        .map_err(|e| app_error(StatusCode::BAD_REQUEST, e))?;
+    // Chaos gate (RFC 010 PR-5 registry, codex D1): faults are evaluated
+    // at the receive seam, BEFORE protocol handling. Drop answers 200 —
+    // to the protocol, a dropped delivery is indistinguishable from
+    // network loss, and its timers re-drive. Delays defer the DELIVERY,
+    // not the HTTP response.
+    match state
+        .fault_registry
+        .verdict(from as u32, yrp.node_id.0 as u32)
+    {
+        crate::debug::FaultVerdict::Drop => {
+            return Ok(Json(json!({ "ok": true, "faulted": "dropped" })));
+        }
+        crate::debug::FaultVerdict::Delay(d) => {
+            let yrp = yrp.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(d).await;
+                let _ = yrp.deliver(from, msg);
+            });
+            return Ok(Json(json!({ "ok": true, "faulted": "delayed" })));
+        }
+        crate::debug::FaultVerdict::Deliver => {}
+    }
+    yrp.deliver(from, msg)
         .map_err(|e| app_error(StatusCode::BAD_REQUEST, e))?;
     Ok(Json(json!({ "ok": true })))
 }

--- a/crates/yantrikdb-server/src/main.rs
+++ b/crates/yantrikdb-server/src/main.rs
@@ -2078,6 +2078,8 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
                     tick_ms: cfg.yrp.tick_ms,
                     election_ticks: (cfg.yrp.election_ticks_min, cfg.yrp.election_ticks_max),
                     heartbeat_ticks: cfg.yrp.heartbeat_ticks,
+                    compact_after_entries: cfg.yrp.compact_after_entries,
+                    leader_retain_entries: cfg.yrp.leader_retain_entries,
                 };
                 let handle = crate::yrp::runtime::spawn(runtime_cfg, local.clone(), applier)
                     .map_err(|e| anyhow::anyhow!("YRP assembly failed: {e}"))?;

--- a/crates/yantrikdb-server/src/yrp/chaos_test.rs
+++ b/crates/yantrikdb-server/src/yrp/chaos_test.rs
@@ -37,6 +37,7 @@ async fn assert_dedupes_everywhere(
 /// the restarted node catches up live.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn kill_leader_under_keyed_load_never_double_writes() {
+    let _serial = serial_guard().await;
     let (nodes, _tmps) = spawn_cluster(3, ClusterSpec::default()).await;
     let mut live: Vec<TestNode> = nodes;
     let emb = embedding(0.3);
@@ -96,6 +97,7 @@ async fn kill_leader_under_keyed_load_never_double_writes() {
 /// leaks.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn partition_and_heal_fences_stale_leader() {
+    let _serial = serial_guard().await;
     let (nodes, _tmps) = spawn_cluster(3, ClusterSpec::default()).await;
     let emb = embedding(1.1);
     let all: Vec<&TestNode> = nodes.iter().collect();
@@ -185,6 +187,7 @@ async fn partition_and_heal_fences_stale_leader() {
 /// follower — the CT 141 posture, live end to end.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn torn_state_boots_quarantined_then_rejoins_via_grant() {
+    let _serial = serial_guard().await;
     let (nodes, _tmps) = spawn_cluster(3, ClusterSpec::default()).await;
     let emb = embedding(2.2);
     let all: Vec<&TestNode> = nodes.iter().collect();
@@ -255,6 +258,7 @@ async fn torn_state_boots_quarantined_then_rejoins_via_grant() {
 /// a COMPACTED entry still dedupes (P1-9, live on real HTTP).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn straggler_beyond_gc_catches_up_and_compacted_claims_survive() {
+    let _serial = serial_guard().await;
     let (nodes, _tmps) = spawn_cluster(
         3,
         ClusterSpec {

--- a/crates/yantrikdb-server/src/yrp/chaos_test.rs
+++ b/crates/yantrikdb-server/src/yrp/chaos_test.rs
@@ -58,7 +58,7 @@ async fn kill_leader_under_keyed_load_never_double_writes() {
 
     // Kill the current leader.
     let leader_idx = wait_leader(&live.iter().collect::<Vec<_>>()).await;
-    let dead = live.remove(leader_idx).kill();
+    let dead = live.remove(leader_idx).kill().await;
 
     // Phase 2: writes against the survivors (forces re-election).
     let survivors: Vec<&TestNode> = live.iter().collect();
@@ -204,7 +204,8 @@ async fn torn_state_boots_quarantined_then_rejoins_via_grant() {
                 .position(|n| !n.handle.is_leader())
                 .expect("some follower")
         });
-    let dead = live.remove(victim_idx).kill();
+    let victim_id = live[victim_idx].node_id as u32;
+    let dead = live.remove(victim_idx).kill().await;
     std::fs::write(dead.data_dir.join("yrp.state"), b"CORRUPT GARBAGE BYTES").unwrap();
 
     // Meanwhile the cluster keeps committing.
@@ -212,24 +213,49 @@ async fn torn_state_boots_quarantined_then_rejoins_via_grant() {
     let (rid_b, _) =
         keyed_write_until_accepted(&survivors, "chaos-torn-b", "post-tear write", &emb).await;
 
-    // Restart: boot inspection must quarantine, honestly, on /v1/health.
+    // Isolate the victim BEFORE restarting it: its rejoin Requests are
+    // dropped at every survivor's receive seam, so no grant can arrive.
+    // This both removes the observation race (on a fast machine the very
+    // first rejoin retry heals within milliseconds) and proves the
+    // stronger property: quarantine HOLDS under repeated retries until a
+    // quorum-authorized grant actually lands (fail closed, not
+    // fail-until-lucky).
+    let survivor_ids: Vec<u32> = survivors.iter().map(|n| n.node_id as u32).collect();
+    for n in &survivors {
+        n.state.fault_registry.inject(
+            FaultKind::Partition {
+                side_a: vec![victim_id],
+                side_b: survivor_ids.clone(),
+            },
+            None,
+        );
+    }
+
+    // Restart: boot inspection must quarantine, honestly, on /v1/health —
+    // and STAY quarantined across several 2s rejoin-retry cycles.
     let revived = dead.restart().await;
     let client = reqwest::Client::new();
-    let health: serde_json::Value = client
-        .get(format!("{}/v1/health", revived.base))
-        .send()
-        .await
-        .unwrap()
-        .json()
-        .await
-        .unwrap();
-    assert_eq!(
-        health["status"],
-        json!("quarantined"),
-        "torn state must surface as quarantine: {health}"
-    );
+    for _ in 0..2 {
+        tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+        let health: serde_json::Value = client
+            .get(format!("{}/v1/health", revived.base))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(
+            health["status"],
+            json!("quarantined"),
+            "torn state must surface (and hold) as quarantine: {health}"
+        );
+    }
 
-    // Rejoin loop → leader grant → adoption → quarantine clears.
+    // Heal the isolation: rejoin loop → leader grant → adoption.
+    for n in &survivors {
+        n.state.fault_registry.clear();
+    }
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
     while revived.handle.quarantine_reasons().is_some() {
         assert!(
@@ -280,7 +306,7 @@ async fn straggler_beyond_gc_catches_up_and_compacted_claims_survive() {
         .iter()
         .position(|n| !n.handle.is_leader())
         .expect("some follower");
-    let dead = live.remove(victim_idx).kill();
+    let dead = live.remove(victim_idx).kill().await;
 
     let survivors: Vec<&TestNode> = live.iter().collect();
     let mut last_rid = String::new();

--- a/crates/yantrikdb-server/src/yrp/chaos_test.rs
+++ b/crates/yantrikdb-server/src/yrp/chaos_test.rs
@@ -1,0 +1,315 @@
+//! Chaos gate (saga 237): mechanical proof, not vibes — the cluster-mode
+//! release gate the v0.8.18 regression made mandatory.
+//!
+//! Every scenario runs REAL servers over real localhost HTTP with real
+//! persistence, then breaks something and asserts the two properties the
+//! whole protocol exists for:
+//! - **never-double-write**: a key acked with rid R answers R forever;
+//! - **never-lost-ack**: a 200 survives kills, partitions, and rejoins.
+//!
+//! Faults are injected at the receive seam (`FaultRegistry::verdict` in
+//! the `/v1/yrp/msg` route) — the codex-D1 design: externally
+//! controllable, restart-surviving, exercising the production HTTP path.
+
+use serde_json::json;
+
+use super::testkit::*;
+use crate::debug::FaultKind;
+
+/// Retry a keyed write (same key + same text) and assert it answers the
+/// ORIGINAL rid as a silent HIT — on whichever node currently leads.
+async fn assert_dedupes_everywhere(
+    nodes: &[&TestNode],
+    key: &str,
+    text: &str,
+    emb: &serde_json::Value,
+    expected_rid: &str,
+) {
+    let (rid, _) = keyed_write_until_accepted(nodes, key, text, emb).await;
+    assert_eq!(
+        rid, expected_rid,
+        "key {key} answered a DIFFERENT rid after chaos — double-write"
+    );
+}
+
+/// Kill the leader mid-stream under keyed write load. Acked writes must
+/// dedupe to their original rid on the new leader; nothing double-writes;
+/// the restarted node catches up live.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn kill_leader_under_keyed_load_never_double_writes() {
+    let (nodes, _tmps) = spawn_cluster(3, ClusterSpec::default()).await;
+    let mut live: Vec<TestNode> = nodes;
+    let emb = embedding(0.3);
+
+    // Phase 1: writes while healthy.
+    let all: Vec<&TestNode> = live.iter().collect();
+    let mut rids = Vec::new();
+    for i in 0..5 {
+        let (rid, _) = keyed_write_until_accepted(
+            &all,
+            &format!("chaos-k{i}"),
+            &format!("chaos replicated memory {i}"),
+            &emb,
+        )
+        .await;
+        rids.push(rid);
+    }
+
+    // Kill the current leader.
+    let leader_idx = wait_leader(&live.iter().collect::<Vec<_>>()).await;
+    let dead = live.remove(leader_idx).kill();
+
+    // Phase 2: writes against the survivors (forces re-election).
+    let survivors: Vec<&TestNode> = live.iter().collect();
+    for i in 5..10 {
+        let (rid, _) = keyed_write_until_accepted(
+            &survivors,
+            &format!("chaos-k{i}"),
+            &format!("chaos replicated memory {i}"),
+            &emb,
+        )
+        .await;
+        rids.push(rid);
+    }
+
+    // EVERY acked key — from before and after the kill — dedupes to its
+    // original rid on the surviving cluster.
+    for i in 0..10 {
+        assert_dedupes_everywhere(
+            &survivors,
+            &format!("chaos-k{i}"),
+            &format!("chaos replicated memory {i}"),
+            &emb,
+            &rids[i],
+        )
+        .await;
+    }
+
+    // The killed ex-leader restarts from disk and converges live.
+    let revived = dead.restart().await;
+    wait_for_recall(&revived, &emb, &rids[9]).await;
+}
+
+/// Partition the leader from the majority: its writes stall (never
+/// commit), the majority elects, and on heal the stale leader is fenced,
+/// truncates, and adopts canonical history — retries dedupe, nothing
+/// leaks.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn partition_and_heal_fences_stale_leader() {
+    let (nodes, _tmps) = spawn_cluster(3, ClusterSpec::default()).await;
+    let emb = embedding(1.1);
+    let all: Vec<&TestNode> = nodes.iter().collect();
+    let leader_idx = wait_leader(&all).await;
+    let leader_id = nodes[leader_idx].node_id as u32;
+    let others: Vec<u32> = nodes
+        .iter()
+        .filter(|n| n.node_id as u32 != leader_id)
+        .map(|n| n.node_id as u32)
+        .collect();
+
+    // Full cut, injected at every RECEIVER's registry.
+    for n in &nodes {
+        n.state.fault_registry.inject(
+            FaultKind::Partition {
+                side_a: vec![leader_id],
+                side_b: others.clone(),
+            },
+            None,
+        );
+    }
+
+    // A write fired at the partitioned leader must never report success —
+    // fire-and-forget with a short client timeout; the claim may sit
+    // tentative and is expected to be truncated on heal OR re-executed
+    // cleanly on retry (both are correct; double-success is not).
+    let doomed = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+        .unwrap()
+        .post(format!("{}/v1/remember", nodes[leader_idx].base))
+        .bearer_auth(&nodes[leader_idx].token)
+        .json(&json!({
+            "text": "doomed partition write",
+            "embedding": emb,
+            "idempotency_key": "chaos-doomed",
+        }))
+        .send()
+        .await;
+    assert!(
+        doomed.is_err() || !doomed.unwrap().status().is_success(),
+        "a partitioned leader must not ack a write"
+    );
+
+    // Majority side elects and commits.
+    let majority: Vec<&TestNode> = nodes
+        .iter()
+        .filter(|n| n.node_id as u32 != leader_id)
+        .collect();
+    let (rid_k, _) =
+        keyed_write_until_accepted(&majority, "chaos-part-k", "canonical partition write", &emb)
+            .await;
+
+    // Heal.
+    for n in &nodes {
+        n.state.fault_registry.clear();
+    }
+
+    // The canonical write dedupes cluster-wide; the ex-leader converges
+    // to it live (its tentative suffix truncated in favor of canon).
+    assert_dedupes_everywhere(
+        &all,
+        "chaos-part-k",
+        "canonical partition write",
+        &emb,
+        &rid_k,
+    )
+    .await;
+    wait_for_recall(&nodes[leader_idx], &emb, &rid_k).await;
+
+    // The doomed key resolves EXACTLY-ONCE post-heal: first retry gets
+    // some rid, second retry gets the same one.
+    let (rid_d1, _) =
+        keyed_write_until_accepted(&all, "chaos-doomed", "doomed partition write", &emb).await;
+    assert_dedupes_everywhere(
+        &all,
+        "chaos-doomed",
+        "doomed partition write",
+        &emb,
+        &rid_d1,
+    )
+    .await;
+}
+
+/// Torn replication state boots QUARANTINED (fail closed, health says
+/// so), then rejoins via a quorum-authorized grant and resumes as a
+/// follower — the CT 141 posture, live end to end.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn torn_state_boots_quarantined_then_rejoins_via_grant() {
+    let (nodes, _tmps) = spawn_cluster(3, ClusterSpec::default()).await;
+    let emb = embedding(2.2);
+    let all: Vec<&TestNode> = nodes.iter().collect();
+    let (_rid_a, _) =
+        keyed_write_until_accepted(&all, "chaos-torn-a", "pre-tear write", &emb).await;
+
+    // Kill node 3 and tear its replication state (NOT its engine data).
+    let mut live = nodes;
+    let victim_idx = live
+        .iter()
+        .position(|n| n.node_id == 3 && !n.handle.is_leader())
+        .unwrap_or_else(|| {
+            live.iter()
+                .position(|n| !n.handle.is_leader())
+                .expect("some follower")
+        });
+    let dead = live.remove(victim_idx).kill();
+    std::fs::write(dead.data_dir.join("yrp.state"), b"CORRUPT GARBAGE BYTES").unwrap();
+
+    // Meanwhile the cluster keeps committing.
+    let survivors: Vec<&TestNode> = live.iter().collect();
+    let (rid_b, _) =
+        keyed_write_until_accepted(&survivors, "chaos-torn-b", "post-tear write", &emb).await;
+
+    // Restart: boot inspection must quarantine, honestly, on /v1/health.
+    let revived = dead.restart().await;
+    let client = reqwest::Client::new();
+    let health: serde_json::Value = client
+        .get(format!("{}/v1/health", revived.base))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        health["status"],
+        json!("quarantined"),
+        "torn state must surface as quarantine: {health}"
+    );
+
+    // Rejoin loop → leader grant → adoption → quarantine clears.
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+    while revived.handle.quarantine_reasons().is_some() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "quarantined node never rejoined"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    // Forensics preserved before resync (the automated CT 141 backup).
+    let preserved = std::fs::read_dir(&revived.data_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .any(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .starts_with("yrp.preserved-")
+        });
+    assert!(preserved, "old state must be preserved before resync");
+
+    // Post-rejoin the node replicates live again.
+    wait_for_recall(&revived, &emb, &rid_b).await;
+}
+
+/// A straggler that falls below the leader's compaction base catches up
+/// via InstallSnapshot — and claims RIDE the snapshot: a keyed retry of
+/// a COMPACTED entry still dedupes (P1-9, live on real HTTP).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn straggler_beyond_gc_catches_up_and_compacted_claims_survive() {
+    let (nodes, _tmps) = spawn_cluster(
+        3,
+        ClusterSpec {
+            compact_after_entries: 8,
+            leader_retain_entries: 2,
+        },
+    )
+    .await;
+    let emb = embedding(3.3);
+    let all: Vec<&TestNode> = nodes.iter().collect();
+
+    let (rid_first, _) =
+        keyed_write_until_accepted(&all, "chaos-gc-first", "the earliest keyed write", &emb).await;
+
+    // Kill a follower, then push the cluster far past the compaction
+    // threshold so the victim's next_index falls below the leader's base.
+    let mut live = nodes;
+    let victim_idx = live
+        .iter()
+        .position(|n| !n.handle.is_leader())
+        .expect("some follower");
+    let dead = live.remove(victim_idx).kill();
+
+    let survivors: Vec<&TestNode> = live.iter().collect();
+    let mut last_rid = String::new();
+    for i in 0..30 {
+        let (rid, _) = keyed_write_until_accepted(
+            &survivors,
+            &format!("chaos-gc-{i}"),
+            &format!("bulk write {i}"),
+            &emb,
+        )
+        .await;
+        last_rid = rid;
+    }
+
+    // Restart the straggler: it must converge (snapshot install + tail
+    // replication) to the newest write, LIVE.
+    let revived = dead.restart().await;
+    wait_for_recall(&revived, &emb, &last_rid).await;
+
+    // The claim of the FIRST write — whose log entry is long compacted on
+    // the leader — still dedupes to the original rid. Claims ride the
+    // snapshot; compaction may never open a replay window.
+    let with_revived: Vec<&TestNode> = survivors
+        .iter()
+        .copied()
+        .chain(std::iter::once(&revived))
+        .collect();
+    assert_dedupes_everywhere(
+        &with_revived,
+        "chaos-gc-first",
+        "the earliest keyed write",
+        &emb,
+        &rid_first,
+    )
+    .await;
+}

--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -281,6 +281,8 @@ async fn spawn_node_inner(node_id: u64, peers: Vec<YrpPeer>, port: u16) -> Node 
             tick_ms: 20,
             election_ticks: (5, 10),
             heartbeat_ticks: 2,
+            compact_after_entries: 0,
+            leader_retain_entries: 0,
         },
         local.clone(),
         applier,

--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -65,6 +65,7 @@ async fn post_json(
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
+    let _serial = crate::yrp::testkit::serial_guard().await;
     let _ = tracing_subscriber::fmt()
         .with_env_filter("yantrikdb=info")
         .with_test_writer()

--- a/crates/yantrikdb-server/src/yrp/driver.rs
+++ b/crates/yantrikdb-server/src/yrp/driver.rs
@@ -231,6 +231,14 @@ pub struct DriverConfig {
     pub election_ticks: (u32, u32),
     /// Heartbeat every N ticks while leader.
     pub heartbeat_ticks: u32,
+    /// Compact the log once the retained span exceeds this many entries.
+    /// `None` = never (the production default until Phase C ships engine
+    /// checkpoint transfer — see `maybe_compact` for why).
+    pub compact_after: Option<u64>,
+    /// Leader retention margin: leaders compact only to `frontier - M` so
+    /// briefly-lagging followers catch up from the log instead of
+    /// forcing a snapshot transfer (codex chaos-consult D2).
+    pub leader_retain: u64,
 }
 
 /// The YRP runtime driver. Construct with restored state, then run the
@@ -387,9 +395,40 @@ impl YrpDriver {
             if let Some(e) = exit {
                 return e;
             }
+            if let Some(e) = self.maybe_compact() {
+                return e;
+            }
             self.publish_status();
         }
         DriverExit::Shutdown
+    }
+
+    /// Runtime compaction trigger (RFC 028 §6 bound to real I/O).
+    ///
+    /// The frontier is `min(commit, durable_applied)` — NEVER bare
+    /// commit: compacting an entry the apply sink has not durably
+    /// applied would make crash-replay impossible (the re-dispatch loop
+    /// reads entries from the log; a compacted, unapplied index would be
+    /// silently skipped, leaving a permanent hole in engine state).
+    /// Leaders additionally retain `leader_retain` entries so transient
+    /// follower lag is served from the log, not a snapshot.
+    fn maybe_compact(&mut self) -> Option<DriverExit> {
+        let threshold = self.cfg.compact_after?;
+        let base = self.core.base().index;
+        let frontier = self.core.commit_index().min(self.applied);
+        if frontier.saturating_sub(base) <= threshold {
+            return None;
+        }
+        let target = if self.core.role() == Role::Leader {
+            frontier.saturating_sub(self.cfg.leader_retain)
+        } else {
+            frontier
+        };
+        if target <= base {
+            return None;
+        }
+        let (_snapshot, effects) = self.core.compact(target)?;
+        self.execute(effects)
     }
 
     fn on_inbound(&mut self, from: NodeId, msg: WireMsg) -> Option<DriverExit> {
@@ -682,6 +721,8 @@ mod tests {
                 supported: u32::MAX,
                 election_ticks: (5, 10),
                 heartbeat_ticks: 2,
+                compact_after: None,
+                leader_retain: 0,
             },
             restored,
             store,
@@ -836,6 +877,8 @@ mod tests {
                 supported: u32::MAX,
                 election_ticks: (1, 2),
                 heartbeat_ticks: 2,
+                compact_after: None,
+                leader_retain: 0,
             },
             None,
             store,

--- a/crates/yantrikdb-server/src/yrp/driver.rs
+++ b/crates/yantrikdb-server/src/yrp/driver.rs
@@ -781,6 +781,7 @@ mod tests {
     /// a node from disk and verify durable state survived.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn three_driver_cluster_elects_applies_dedupes_and_restarts() {
+        let _serial = crate::yrp::testkit::serial_guard().await;
         let tmp = tempfile::TempDir::new().unwrap();
         let router = Arc::new(Mutex::new(BTreeMap::new()));
         let mut nodes = BTreeMap::new();
@@ -790,9 +791,14 @@ mod tests {
         }
 
         let (leader, out) = propose_until_settled(&nodes, 42, 4242).await;
+        // Applied on the first attempt, or Duplicate when the first
+        // attempt's 500ms reply window expired mid-apply and the retry
+        // deduped against it — BOTH are the keyed contract holding
+        // (exactly-once, ambiguous attempts resolved by retry). Only a
+        // fresh double-apply would be a failure, asserted below.
         let index = match out {
-            ProposeOutcome::Applied { index } => index,
-            other => panic!("expected Applied, got {other:?}"),
+            ProposeOutcome::Applied { index } | ProposeOutcome::Duplicate { index } => index,
+            ProposeOutcome::Retry => unreachable!("propose_until_settled never returns Retry"),
         };
 
         // Same key retried on the leader dedupes to the same index.

--- a/crates/yantrikdb-server/src/yrp/mod.rs
+++ b/crates/yantrikdb-server/src/yrp/mod.rs
@@ -37,6 +37,10 @@ pub mod transport;
 pub mod types;
 
 #[cfg(test)]
+mod chaos_test;
+#[cfg(test)]
 mod cluster_test;
 #[cfg(test)]
 mod sim;
+#[cfg(test)]
+mod testkit;

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -63,6 +63,12 @@ pub struct YrpRuntimeConfig {
     pub tick_ms: u64,
     pub election_ticks: (u32, u32),
     pub heartbeat_ticks: u32,
+    /// Compact once the applied span exceeds this (0 = disabled — the
+    /// production default until Phase C ships engine-checkpoint transfer
+    /// for beyond-GC stragglers; the protocol path is chaos-tested).
+    pub compact_after_entries: u64,
+    /// Leader retention margin (entries kept above the compaction base).
+    pub leader_retain_entries: u64,
 }
 
 /// How long a proposer waits for the driver's reply / the apply marker.
@@ -108,8 +114,8 @@ impl YrpHandle {
 
     /// Forward a decoded inbound wire message to whichever loop currently
     /// owns the funnel (driver or quarantine).
-    pub fn deliver_inbound(&self, body: &[u8]) -> Result<(), String> {
-        super::transport::deliver_inbound(&self.owner_tx, body)
+    pub fn deliver(&self, from: u64, msg: WireMsg) -> Result<(), String> {
+        super::transport::deliver(&self.owner_tx, from, msg)
     }
 
     /// Current leader hint as (id, http addr).
@@ -317,6 +323,8 @@ pub fn spawn(
         supported: u32::MAX,
         election_ticks: cfg.election_ticks,
         heartbeat_ticks: cfg.heartbeat_ticks,
+        compact_after: (cfg.compact_after_entries > 0).then_some(cfg.compact_after_entries),
+        leader_retain: cfg.leader_retain_entries,
     };
 
     match inspect(cluster, u32::MAX, &recovered) {

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -123,6 +123,14 @@ impl YrpHandle {
         let _ = self.owner_tx.send(DriverEvent::Shutdown);
     }
 
+    /// True once the owning loop has exited (its receiver dropped). A
+    /// killer that intends to mutate the node's on-disk state MUST wait
+    /// for this — Shutdown is queued behind in-flight events, and a
+    /// still-draining driver may persist over external modifications.
+    pub fn is_stopped(&self) -> bool {
+        self.owner_tx.is_closed()
+    }
+
     /// Current leader hint as (id, http addr).
     pub fn leader_hint(&self) -> (Option<u64>, Option<String>) {
         let leader = self.status.borrow().leader.map(|n| n.0);

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -118,6 +118,11 @@ impl YrpHandle {
         super::transport::deliver(&self.owner_tx, from, msg)
     }
 
+    /// Graceful stop of whichever loop owns the funnel (tests/shutdown).
+    pub fn shutdown(&self) {
+        let _ = self.owner_tx.send(DriverEvent::Shutdown);
+    }
+
     /// Current leader hint as (id, http addr).
     pub fn leader_hint(&self) -> (Option<u64>, Option<String>) {
         let leader = self.status.borrow().leader.map(|n| n.0);
@@ -205,6 +210,21 @@ pub fn spawn(
     }
     if !cfg.peers.iter().any(|p| p.node_id == cfg.node_id) {
         return Err("[yrp] peers must include this node's node_id".into());
+    }
+
+    if cfg.compact_after_entries > 0 {
+        // Codex chaos-review P0, made loud: until Phase C ships
+        // engine-checkpoint transfer, a straggler that falls below the
+        // compaction base receives a PROTOCOL snapshot (claims/active)
+        // but no engine backfill for the compacted range. Enabling
+        // compaction is a chaos-test/operator-experiment posture, not a
+        // production default.
+        tracing::warn!(
+            compact_after = cfg.compact_after_entries,
+            "[yrp] log compaction ENABLED: beyond-GC stragglers rejoin without \
+             engine backfill for the compacted range until Phase C \
+             (engine-checkpoint transfer). Not recommended in production."
+        );
     }
 
     let me = NodeId(cfg.node_id);

--- a/crates/yantrikdb-server/src/yrp/testkit.rs
+++ b/crates/yantrikdb-server/src/yrp/testkit.rs
@@ -70,10 +70,23 @@ pub struct DeadNode {
 }
 
 impl TestNode {
-    /// Stop the driver loop and the HTTP server. The data dir survives.
-    pub fn kill(self) -> DeadNode {
+    /// Stop the driver loop and the HTTP server; WAIT for the driver to
+    /// actually exit before returning. The wait is load-bearing:
+    /// Shutdown queues behind in-flight events, and a still-draining
+    /// driver can persist yrp.state AFTER kill() — silently undoing any
+    /// state corruption a chaos scenario applies next (the exact race
+    /// the torn-state test hit on fast runners). The data dir survives.
+    pub async fn kill(self) -> DeadNode {
         self.handle.shutdown();
         self.server.abort();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !self.handle.is_stopped() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "driver did not exit within 5s of Shutdown"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
         DeadNode {
             node_id: self.node_id,
             token: self.token,

--- a/crates/yantrikdb-server/src/yrp/testkit.rs
+++ b/crates/yantrikdb-server/src/yrp/testkit.rs
@@ -17,6 +17,17 @@ use crate::yrp::runtime::{spawn as spawn_yrp, YrpCommitter, YrpHandle, YrpPeer, 
 pub const SECRET: &str = "yrp-chaos-cluster-secret";
 pub const TENANT: &str = "yrpchaos";
 
+/// Serializes the heavy multi-node tests (chaos, 2-node cluster, the
+/// 3-driver channel test). Each spawns real servers with 10-20ms tick
+/// timers; running several such multi-threaded runtimes concurrently in
+/// one test binary starves tickers and flakes elections. Hold this for
+/// the duration of any multi-node test.
+pub async fn serial_guard() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+    LOCK.lock().await
+}
+
 /// Per-cluster tuning shared by every node.
 #[derive(Debug, Clone, Copy)]
 pub struct ClusterSpec {

--- a/crates/yantrikdb-server/src/yrp/testkit.rs
+++ b/crates/yantrikdb-server/src/yrp/testkit.rs
@@ -1,0 +1,354 @@
+//! Test harness for multi-node YRP clusters over real localhost HTTP —
+//! the chaos gate's substrate (saga 237). Nodes are KILLABLE and
+//! RESTARTABLE against the same data dir, which is what makes
+//! crash/recovery scenarios meaningful.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde_json::{json, Value};
+
+use crate::auth::ControlDbAuthProvider;
+use crate::control::ControlDb;
+use crate::server::AppState;
+use crate::yrp::runtime::{spawn as spawn_yrp, YrpCommitter, YrpHandle, YrpPeer, YrpRuntimeConfig};
+
+pub const SECRET: &str = "yrp-chaos-cluster-secret";
+pub const TENANT: &str = "yrpchaos";
+
+/// Per-cluster tuning shared by every node.
+#[derive(Debug, Clone, Copy)]
+pub struct ClusterSpec {
+    pub compact_after_entries: u64,
+    pub leader_retain_entries: u64,
+}
+
+impl Default for ClusterSpec {
+    fn default() -> Self {
+        Self {
+            compact_after_entries: 0,
+            leader_retain_entries: 0,
+        }
+    }
+}
+
+/// A live node. Kill it to get a [`DeadNode`]; restart that to get a
+/// live node again on the same data dir + port.
+pub struct TestNode {
+    pub node_id: u64,
+    pub base: String,
+    pub token: String,
+    pub state: Arc<AppState>,
+    pub handle: Arc<YrpHandle>,
+    pub data_dir: PathBuf,
+    pub port: u16,
+    peers: Vec<YrpPeer>,
+    spec: ClusterSpec,
+    server: tokio::task::JoinHandle<()>,
+}
+
+/// A killed node's identity — everything needed to restart it.
+pub struct DeadNode {
+    pub node_id: u64,
+    pub token: String,
+    pub data_dir: PathBuf,
+    pub port: u16,
+    peers: Vec<YrpPeer>,
+    spec: ClusterSpec,
+}
+
+impl TestNode {
+    /// Stop the driver loop and the HTTP server. The data dir survives.
+    pub fn kill(self) -> DeadNode {
+        self.handle.shutdown();
+        self.server.abort();
+        DeadNode {
+            node_id: self.node_id,
+            token: self.token,
+            data_dir: self.data_dir,
+            port: self.port,
+            peers: self.peers,
+            spec: self.spec,
+        }
+    }
+}
+
+impl DeadNode {
+    pub async fn restart(self) -> TestNode {
+        spawn_node(
+            self.node_id,
+            self.peers.clone(),
+            self.port,
+            self.data_dir.clone(),
+            Some(self.token.clone()),
+            self.spec,
+        )
+        .await
+    }
+}
+
+/// Spawn an n-node cluster (all data voters) on ephemeral pre-bound
+/// ports. Returns the nodes plus the tempdirs keeping their data alive.
+pub async fn spawn_cluster(n: usize, spec: ClusterSpec) -> (Vec<TestNode>, Vec<tempfile::TempDir>) {
+    let mut ports = Vec::new();
+    for _ in 0..n {
+        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        ports.push(l.local_addr().unwrap().port());
+        drop(l);
+    }
+    let peers: Vec<YrpPeer> = ports
+        .iter()
+        .enumerate()
+        .map(|(i, p)| YrpPeer {
+            node_id: i as u64 + 1,
+            addr: format!("http://127.0.0.1:{p}"),
+            witness: false,
+        })
+        .collect();
+    let mut nodes = Vec::new();
+    let mut tmps = Vec::new();
+    for (i, port) in ports.iter().enumerate() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let node = spawn_node(
+            i as u64 + 1,
+            peers.clone(),
+            *port,
+            tmp.path().to_path_buf(),
+            None,
+            spec,
+        )
+        .await;
+        nodes.push(node);
+        tmps.push(tmp);
+    }
+    (nodes, tmps)
+}
+
+/// One full server on `port` with the production router, mirroring
+/// main.rs's Yrp assembly. `existing_token = Some` on restart (the
+/// control DB already holds the tenant + token).
+pub async fn spawn_node(
+    node_id: u64,
+    peers: Vec<YrpPeer>,
+    port: u16,
+    data_dir: PathBuf,
+    existing_token: Option<String>,
+    spec: ClusterSpec,
+) -> TestNode {
+    let mut cfg = crate::config::ServerConfig::default();
+    cfg.server.data_dir = data_dir.clone();
+
+    let control = ControlDb::open(&data_dir.join("control.db")).expect("control db");
+    let token = match existing_token {
+        Some(t) => t,
+        None => {
+            let raw = crate::auth::generate_token();
+            let hash = crate::auth::hash_token(&raw);
+            let db_id = control.create_database(TENANT, TENANT).expect("create db");
+            control
+                .create_token(&hash, db_id, "yrp-chaos")
+                .expect("create token");
+            raw
+        }
+    };
+    let control = Arc::new(Mutex::new(control));
+
+    let pool = Arc::new(crate::tenant_pool::TenantPool::new(&cfg, None, None));
+    let workers = crate::background::WorkerRegistry::new(
+        &cfg.background,
+        &cfg.maintenance,
+        crate::background::WriteAcceptanceGate::standalone(),
+    );
+    let admission = crate::admission::AdmissionState::new(Default::default());
+    let jobs: Arc<dyn crate::jobs::JobQueue> =
+        Arc::new(crate::jobs::LocalSqliteJobQueue::open_in_memory().expect("jobs"));
+    let auth_provider: Arc<dyn crate::auth::AuthProvider> = Arc::new(ControlDbAuthProvider::new(
+        Arc::clone(&control),
+        Some(SECRET.to_string()),
+    ));
+
+    let local: Arc<dyn crate::commit::MutationCommitter> = Arc::new(
+        crate::commit::LocalSqliteCommitter::open(data_dir.join("commit_log.sqlite"))
+            .expect("commit log"),
+    );
+    let resolver = Arc::new(crate::tenant_pool::TenantPoolEngineResolver::new(
+        pool.clone(),
+        control.clone(),
+    )) as Arc<dyn crate::commit::EngineResolver>;
+    let applier: Arc<dyn crate::commit::Applier> =
+        Arc::new(crate::commit::EngineApplier::new(resolver));
+    let handle = spawn_yrp(
+        YrpRuntimeConfig {
+            node_id,
+            cluster_id: 7,
+            peers: peers.clone(),
+            data_dir: data_dir.clone(),
+            cluster_secret: Some(SECRET.to_string()),
+            tick_ms: 20,
+            election_ticks: (5, 10),
+            heartbeat_ticks: 2,
+            compact_after_entries: spec.compact_after_entries,
+            leader_retain_entries: spec.leader_retain_entries,
+        },
+        local.clone(),
+        applier,
+    )
+    .expect("yrp spawn");
+    let commit_log: Arc<dyn crate::commit::MutationCommitter> =
+        Arc::new(YrpCommitter::new(handle.clone(), local));
+
+    let state = Arc::new(AppState {
+        control,
+        pool,
+        workers,
+        cluster: None,
+        inflight: std::sync::atomic::AtomicU32::new(0),
+        admission,
+        control_runtime: None,
+        commit_log,
+        raft: None,
+        yrp: Some(handle.clone()),
+        fault_registry: crate::debug::FaultRegistry::new(),
+        jobs,
+        data_dir: data_dir.clone(),
+        auth_provider,
+    });
+
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+        .await
+        .expect("bind advertised port");
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let app = crate::http_gateway::router(state.clone());
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let node = TestNode {
+        node_id,
+        base,
+        token,
+        state,
+        handle,
+        data_dir,
+        port,
+        peers,
+        spec,
+        server,
+    };
+    // Readiness poll.
+    let client = reqwest::Client::new();
+    for _ in 0..100 {
+        if client
+            .get(format!("{}/v1/health", node.base))
+            .send()
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    node
+}
+
+/// Wait until exactly one live node leads; return its index.
+pub async fn wait_leader(nodes: &[&TestNode]) -> usize {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        for (i, n) in nodes.iter().enumerate() {
+            if n.handle.is_leader() {
+                return i;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "no leader elected in time"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+pub async fn post_json(node: &TestNode, path: &str, body: &Value) -> (reqwest::StatusCode, Value) {
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .unwrap();
+    let resp = client
+        .post(format!("{}{}", node.base, path))
+        .bearer_auth(&node.token)
+        .json(body)
+        .send()
+        .await
+        .expect("request");
+    let status = resp.status();
+    let text = resp.text().await.expect("body");
+    let val: Value = serde_json::from_str(&text).unwrap_or(json!({ "raw": text }));
+    (status, val)
+}
+
+/// 384-dim deterministic embedding (engine default dim).
+pub fn embedding(seed: f32) -> Value {
+    json!((0..384)
+        .map(|i| (i as f32).mul_add(0.001, seed).sin())
+        .collect::<Vec<f32>>())
+}
+
+/// Keyed remember against whichever node currently accepts it; retries
+/// across nodes until a 200 lands. Returns (rid, node_index).
+pub async fn keyed_write_until_accepted(
+    nodes: &[&TestNode],
+    key: &str,
+    text: &str,
+    emb: &Value,
+) -> (String, usize) {
+    let body = json!({ "text": text, "embedding": emb, "idempotency_key": key });
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        for (i, n) in nodes.iter().enumerate() {
+            let (st, resp) = post_json(n, "/v1/remember", &body).await;
+            if st == reqwest::StatusCode::OK {
+                let rid = resp["rid"].as_str().expect("rid").to_string();
+                return (rid, i);
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "no node accepted keyed write {key}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
+/// Poll a node's LIVE /v1/recall until `rid` appears.
+pub async fn wait_for_recall(node: &TestNode, query_embedding: &Value, rid: &str) {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        let (st, resp) = post_json(
+            node,
+            "/v1/recall",
+            &json!({
+                "query": "chaos replicated memory",
+                "query_embedding": query_embedding,
+                "top_k": 20,
+            }),
+        )
+        .await;
+        if st == reqwest::StatusCode::OK {
+            let found = resp["results"]
+                .as_array()
+                .map(|a| a.iter().any(|r| r["rid"].as_str() == Some(rid)))
+                .unwrap_or(false);
+            if found {
+                return;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "node {} live recall never surfaced {rid}; last: {resp}",
+            node.node_id
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}

--- a/crates/yantrikdb-server/src/yrp/transport.rs
+++ b/crates/yantrikdb-server/src/yrp/transport.rs
@@ -165,14 +165,19 @@ async fn run_peer_sender(
     }
 }
 
-/// Decode an inbound `POST /v1/yrp/msg` body and forward it to the owner
-/// funnel. Returns Err on malformed bytes (HTTP 400 at the route).
-pub fn deliver_inbound(
+/// Decode an inbound `POST /v1/yrp/msg` body. Returns Err on malformed
+/// bytes (HTTP 400 at the route). Split from delivery so the route can
+/// consult the fault registry BETWEEN decode and delivery (chaos gate).
+pub fn decode_envelope(body: &[u8]) -> Result<WireEnvelope, String> {
+    bincode::deserialize(body).map_err(|e| format!("malformed YRP envelope: {e}"))
+}
+
+/// Forward a decoded message to the owner funnel.
+pub fn deliver(
     owner: &mpsc::UnboundedSender<DriverEvent>,
-    body: &[u8],
+    from: u64,
+    msg: WireMsg,
 ) -> Result<(), String> {
-    let (from, msg): WireEnvelope =
-        bincode::deserialize(body).map_err(|e| format!("malformed YRP envelope: {e}"))?;
     owner
         .send(DriverEvent::Inbound {
             from: NodeId(from),


### PR DESCRIPTION
## What this is

The live chaos gate from the handoff sequence (saga task 237): the cluster-mode release gate the v0.8.18 regression made mandatory — "mechanical proof, not vibes." Four chaos scenarios run REAL servers over real localhost HTTP with real persistence, break things, and assert the two properties the protocol exists for: **never-double-write** and **never-lost-ack**.

## Substrate

- **Fault injection at the receive seam** (codex consult D1): `FaultRegistry::verdict(from, to)` — Partition / PauseLeader / probabilistic Drop / longest-matching InjectLatency — consulted in `POST /v1/yrp/msg` BEFORE protocol handling. Drops answer 200 (indistinguishable from network loss to the protocol); delays defer the *delivery*, never the HTTP response.
- **Runtime compaction trigger** (codex consult D2 + one strengthening): frontier = `min(commit, durable_applied)` — never bare commit, because compacting an unapplied entry would make crash-replay silently skip it (permanent engine hole). Leaders retain `leader_retain_entries` above base so transient lag is served from the log. Ships **disabled by default** with a loud startup warning when enabled — beyond-GC stragglers get the protocol snapshot but no engine backfill until Phase C (codex post-review P0, accepted and documented; P1 underflow already saturating).
- **Testkit**: killable/restartable full-server nodes on the same data dir + port.

## Scenarios (all on real HTTP, stable across 10 consecutive gate runs)

1. **Kill-leader under keyed load** — every acked key dedupes to its original rid on the new leader; the revived ex-leader converges live.
2. **Partition + heal** — a partitioned leader never acks; the majority commits; on heal the stale leader is fenced and truncates to canon; the doomed key resolves exactly-once.
3. **Torn-state boot** — corrupt `yrp.state` → honest quarantine on `/v1/health`, forensics preserved (`yrp.preserved-*`), quorum-authorized grant → adoption → live replication resumes. First end-to-end exercise of the rejoin loop.
4. **Straggler beyond GC** — InstallSnapshot catch-up; a keyed retry of a *compacted* entry still dedupes (claims ride the snapshot — P1-9, live).

## CI

`chaos-gate` is a named job in ci.yml AND a hard `needs:` of the release build in release.yml — a tag cannot produce binaries without the cluster-mode gate. (Releases previously built with no test gate at all.)

## Deflake (separate commit)

The heavy multi-node tests are serialized via `testkit::serial_guard()` (concurrent multi-threaded runtimes starved each other's 10-20ms tickers), and a latent pre-existing test bug is fixed: the 3-driver test insisted the first settled keyed proposal be `Applied`, but a reply-window expiry mid-apply legitimately settles the retry as `Duplicate` — which is the exactly-once contract *holding*, not failing.

## Validation

yrp gate 10/10 consecutive green (60 tests); full suite green (2173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)