### PR TITLE
feat(yrp): linearizable-read barrier — ensure_linearizable becomes real

### DIFF
--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -191,6 +191,25 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
         "follower must refuse writes: {resp}"
     );
 
+    // ensure_linearizable: the leader's committer passes a REAL barrier
+    // (noop through the replicated commit path); the follower's answers
+    // NotLeader with the leader's address for redirect.
+    leader
+        .state
+        .commit_log
+        .ensure_linearizable()
+        .await
+        .expect("leader read barrier must succeed");
+    match follower.state.commit_log.ensure_linearizable().await {
+        Err(crate::commit::CommitError::NotLeader { leader_addr, .. }) => {
+            assert!(
+                leader_addr.is_some(),
+                "follower barrier refusal must carry the leader address"
+            );
+        }
+        other => panic!("follower barrier must answer NotLeader, got {other:?}"),
+    }
+
     // Health surfaces yrp mode honestly on both nodes.
     let client = reqwest::Client::new();
     for n in [&leader, &follower] {

--- a/crates/yantrikdb-server/src/yrp/driver.rs
+++ b/crates/yantrikdb-server/src/yrp/driver.rs
@@ -146,6 +146,21 @@ pub enum ProposeOutcome {
     Retry,
 }
 
+/// Outcome of a linearizable-read barrier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BarrierOutcome {
+    /// Every write committed before the barrier was requested is durably
+    /// applied LOCALLY. Reads served from local state after this reflect
+    /// them. This is a linearization POINT, not a leadership lease —
+    /// writes committed by a newer leader after the barrier may be
+    /// absent, which is permitted for reads concurrent with them
+    /// (codex barrier-consult pitfall 2, made explicit).
+    Ok,
+    /// Not the leader (or leadership was lost while the barrier was
+    /// pending) — retry against the current leader.
+    Retry,
+}
+
 /// Events into the owner funnel.
 pub enum DriverEvent {
     Inbound {
@@ -156,6 +171,14 @@ pub enum DriverEvent {
         key: u64,
         payload: Payload,
         reply: oneshot::Sender<ProposeOutcome>,
+    },
+    /// Linearizable-read barrier (codex-consulted design: a protocol
+    /// no-op through the NORMAL commit path — soundness rides entirely
+    /// on the proven current-term commit rule; committing the no-op IS
+    /// the fresh quorum contact that proves this node was still leader
+    /// at the barrier's linearization point).
+    ReadBarrier {
+        reply: oneshot::Sender<BarrierOutcome>,
     },
     /// Apply worker reports the highest contiguous durably-applied index.
     Applied {
@@ -252,6 +275,9 @@ pub struct YrpDriver {
     /// (index → reply) awaiting contiguous durable apply (volatile —
     /// connection state only, per codex F3).
     pending_acks: BTreeMap<u64, oneshot::Sender<ProposeOutcome>>,
+    /// (barrier no-op index → waiters). Resolved Ok when the durable
+    /// applied marker covers the index; failed Retry on step-down.
+    pending_barriers: BTreeMap<u64, Vec<oneshot::Sender<BarrierOutcome>>>,
     /// Highest contiguous durably-applied index (from the apply worker).
     applied: u64,
     /// Committed-but-not-yet-dispatched-to-apply frontier.
@@ -317,6 +343,7 @@ impl YrpDriver {
             apply_tx,
             cfg,
             pending_acks: BTreeMap::new(),
+            pending_barriers: BTreeMap::new(),
             applied: durable_applied,
             dispatched: durable_applied,
             election_ticks_left: None,
@@ -384,6 +411,7 @@ impl YrpDriver {
                     payload,
                     reply,
                 } => self.on_propose(key, payload, reply),
+                DriverEvent::ReadBarrier { reply } => self.on_read_barrier(reply),
                 DriverEvent::Applied { upto } => {
                     self.applied = self.applied.max(upto);
                     self.release_acks();
@@ -501,6 +529,41 @@ impl YrpDriver {
         }
     }
 
+    /// Linearizable-read barrier (codex barrier-consult, verdict A).
+    /// A protocol no-op is proposed through the NORMAL replicated commit
+    /// path; the barrier resolves when the durable applied marker covers
+    /// the no-op's index. Coalescing honors codex pitfall 1: a waiter may
+    /// only attach to an in-flight barrier no-op whose index is at least
+    /// the commit index THIS caller observed — otherwise writes committed
+    /// after that no-op was appended could be missed.
+    fn on_read_barrier(&mut self, reply: oneshot::Sender<BarrierOutcome>) -> Option<DriverExit> {
+        if self.core.role() != Role::Leader {
+            let _ = reply.send(BarrierOutcome::Retry);
+            return None;
+        }
+        let observed_commit = self.core.commit_index();
+        if let Some((&inflight, _)) = self.pending_barriers.iter().next_back() {
+            if inflight >= observed_commit && inflight > self.applied {
+                self.pending_barriers
+                    .entry(inflight)
+                    .or_default()
+                    .push(reply);
+                return None;
+            }
+        }
+        match self.core.propose(Payload::Noop) {
+            Some(effects) => {
+                let index = self.core.last_index();
+                self.pending_barriers.entry(index).or_default().push(reply);
+                self.execute(effects)
+            }
+            None => {
+                let _ = reply.send(BarrierOutcome::Retry);
+                None
+            }
+        }
+    }
+
     fn on_tick(&mut self) -> Option<DriverExit> {
         if self.core.role() == Role::Leader {
             self.heartbeat_ticks_left = self.heartbeat_ticks_left.saturating_sub(1);
@@ -571,6 +634,14 @@ impl YrpDriver {
                     for (_, tx) in std::mem::take(&mut self.pending_acks) {
                         let _ = tx.send(ProposeOutcome::Retry);
                     }
+                    // Pending barriers likewise: our reign can no longer
+                    // prove a linearization point — the caller retries
+                    // against the current leader.
+                    for (_, waiters) in std::mem::take(&mut self.pending_barriers) {
+                        for tx in waiters {
+                            let _ = tx.send(BarrierOutcome::Retry);
+                        }
+                    }
                 }
                 Effect::CommitAdvanced { to } => {
                     // Dispatch newly committed entries to the sequential
@@ -610,6 +681,19 @@ impl YrpDriver {
         for i in ready {
             if let Some(tx) = self.pending_acks.remove(&i) {
                 let _ = tx.send(ProposeOutcome::Applied { index: i });
+            }
+        }
+        let ready_barriers: Vec<u64> = self
+            .pending_barriers
+            .keys()
+            .copied()
+            .take_while(|i| *i <= self.applied)
+            .collect();
+        for i in ready_barriers {
+            if let Some(waiters) = self.pending_barriers.remove(&i) {
+                for tx in waiters {
+                    let _ = tx.send(BarrierOutcome::Ok);
+                }
             }
         }
     }
@@ -858,6 +942,64 @@ mod tests {
             ProposeOutcome::Applied { .. } => panic!("keyed retry double-applied after restart"),
             other => panic!("unexpected {other:?}"),
         }
+
+        for n in nodes.values() {
+            let _ = n.tx.send(DriverEvent::Shutdown);
+        }
+    }
+
+    /// Read barrier: Ok on the leader (noop committed + applied), Retry
+    /// on followers. Ordering: a write acked before the barrier is in
+    /// the sink before the barrier resolves.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn read_barrier_ok_on_leader_retry_on_follower() {
+        let _serial = crate::yrp::testkit::serial_guard().await;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let router = Arc::new(Mutex::new(BTreeMap::new()));
+        let mut nodes = BTreeMap::new();
+        for id in [1u64, 2, 3] {
+            let sink = Arc::new(Mutex::new(SinkState::default()));
+            nodes.insert(id, spawn_node(id, tmp.path(), &router, sink));
+        }
+        let (leader, out) = propose_until_settled(&nodes, 7, 777).await;
+        let index = match out {
+            ProposeOutcome::Applied { index } | ProposeOutcome::Duplicate { index } => index,
+            ProposeOutcome::Retry => unreachable!(),
+        };
+
+        // Barrier on the leader resolves Ok, and the pre-barrier write is
+        // in the leader's sink by then.
+        let (btx, brx) = oneshot::channel();
+        let _ = nodes[&leader]
+            .tx
+            .send(DriverEvent::ReadBarrier { reply: btx });
+        let out = tokio::time::timeout(Duration::from_secs(5), brx)
+            .await
+            .expect("barrier reply in time")
+            .expect("driver alive");
+        assert_eq!(out, BarrierOutcome::Ok);
+        assert!(
+            nodes[&leader]
+                .sink
+                .lock()
+                .unwrap()
+                .applied
+                .iter()
+                .any(|(i, _)| *i == index),
+            "barrier resolved before the pre-barrier write was applied"
+        );
+
+        // Barrier on a follower answers Retry immediately.
+        let follower = *nodes.keys().find(|id| **id != leader).unwrap();
+        let (btx, brx) = oneshot::channel();
+        let _ = nodes[&follower]
+            .tx
+            .send(DriverEvent::ReadBarrier { reply: btx });
+        let out = tokio::time::timeout(Duration::from_secs(5), brx)
+            .await
+            .expect("barrier reply in time")
+            .expect("driver alive");
+        assert_eq!(out, BarrierOutcome::Retry);
 
         for n in nodes.values() {
             let _ = n.tx.send(DriverEvent::Shutdown);

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -28,8 +28,8 @@ use super::bootstrap::{
     RejoinMessage,
 };
 use super::driver::{
-    run_apply_worker, spawn_ticker, DriverConfig, DriverEvent, DriverExit, DurableState, FileStore,
-    ProposeOutcome, Transport, WireMsg, YrpDriver, YrpStatus,
+    run_apply_worker, spawn_ticker, BarrierOutcome, DriverConfig, DriverEvent, DriverExit,
+    DurableState, FileStore, ProposeOutcome, Transport, WireMsg, YrpDriver, YrpStatus,
 };
 use super::engine_sink::{AppliedOutcome, EngineApplySink, OutcomeStore};
 use super::op::{claim_key_for_op, YrpOp};
@@ -116,6 +116,36 @@ impl YrpHandle {
     /// owns the funnel (driver or quarantine).
     pub fn deliver(&self, from: u64, msg: WireMsg) -> Result<(), String> {
         super::transport::deliver(&self.owner_tx, from, msg)
+    }
+
+    /// Linearizable-read barrier: resolves Ok once every write committed
+    /// before this call is durably applied locally, with the no-op commit
+    /// itself proving leadership at the linearization point. `Err` maps
+    /// exactly like propose failures (NotLeader with hint / Timeout).
+    pub async fn read_barrier(&self) -> Result<(), YrpProposeError> {
+        if let Some(reasons) = self.quarantine_reasons() {
+            return Err(YrpProposeError::Unavailable(format!(
+                "node quarantined: {reasons:?}"
+            )));
+        }
+        let (tx, rx) = oneshot::channel();
+        self.owner_tx
+            .send(DriverEvent::ReadBarrier { reply: tx })
+            .map_err(|_| YrpProposeError::Unavailable("YRP driver not running".into()))?;
+        let out = tokio::time::timeout(PROPOSE_TIMEOUT, rx)
+            .await
+            .map_err(|_| YrpProposeError::Timeout)?
+            .map_err(|_| YrpProposeError::Unavailable("YRP driver dropped reply".into()))?;
+        match out {
+            BarrierOutcome::Ok => Ok(()),
+            BarrierOutcome::Retry => {
+                let (leader_id, leader_addr) = self.leader_hint();
+                Err(YrpProposeError::NotLeader {
+                    leader_id,
+                    leader_addr,
+                })
+            }
+        }
     }
 
     /// Graceful stop of whichever loop owns the funnel (tests/shutdown).
@@ -652,19 +682,15 @@ impl MutationCommitter for YrpCommitter {
         self.local.list_active_tenants().await
     }
 
-    /// v1 approximation: leadership check only (no quorum read lease —
-    /// a deposed-but-unaware leader window exists, same as the legacy
-    /// raft-lite mode; the honest fix is a read-index barrier, tracked
-    /// for the chaos-gate slice).
+    /// Real linearizable-read barrier (replaces the v1 leadership-only
+    /// approximation): a protocol no-op committed through the normal
+    /// replicated path + a wait on the durable applied marker. A deposed
+    /// leader's no-op cannot commit in its term (Gate A #2), so the
+    /// stale-read window the approximation left open is closed.
     async fn ensure_linearizable(&self) -> Result<(), CommitError> {
-        if self.handle.is_leader() {
-            Ok(())
-        } else {
-            let (leader_id, leader_addr) = self.handle.leader_hint();
-            Err(CommitError::NotLeader {
-                leader_id,
-                leader_addr,
-            })
-        }
+        self.handle
+            .read_barrier()
+            .await
+            .map_err(|e| propose_err_to_commit(e, OpId::new_random()))
     }
 }


### PR DESCRIPTION
Closes the deposed-leader stale-read window: `ensure_linearizable` now commits a protocol no-op through the normal replicated path and waits for the durable applied marker (codex-consulted, verdict A over ReadIndex — soundness rides entirely on the proven current-term commit rule; a deposed leader's no-op cannot commit in its term). Coalescing honors the observed-commit bound; step-down fails pending barriers to NotLeader-with-hint. Driver + cluster tests added; yrp gate 61 green, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)