### PR TITLE
feat(yrp): Phase C engine backfill — beyond-GC stragglers heal their engine

### DIFF
--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -490,6 +490,14 @@ async fn health(State(state): State<Arc<AppState>>) -> Json<Value> {
         if let Some(reasons) = yrp.quarantine_reasons() {
             payload["status"] = json!("quarantined");
             payload["yrp_quarantine_reasons"] = json!(reasons);
+        } else if yrp.engine_incomplete() {
+            // RFC 028 Phase C: protocol-current but engine still
+            // backfilling a compacted range — not read/lead eligible.
+            let s = *yrp.status.borrow();
+            payload["status"] = json!("engine_backfilling");
+            payload["yrp_engine_incomplete"] = json!(true);
+            payload["yrp_backfill_applied"] = json!(s.applied);
+            payload["yrp_backfill_target"] = json!(s.backfill_target);
         }
     }
     Json(payload)
@@ -1153,6 +1161,46 @@ async fn yrp_msg(
     yrp.deliver(from, msg)
         .map_err(|e| app_error(StatusCode::BAD_REQUEST, e))?;
     Ok(Json(json!({ "ok": true })))
+}
+
+/// RFC 028 Phase C: serve an engine-backfill range to a beyond-GC
+/// straggler. Cluster-secret gated; body is JSON `BackfillRequest`;
+/// response is a bincode `Vec<(u64, LogEntry)>` the requester feeds to
+/// its apply worker. A node that cannot fully cover the range refuses
+/// (503) rather than serving a hole.
+async fn yrp_backfill(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<crate::yrp::runtime::BackfillRequest>,
+) -> Result<Vec<u8>, AppError> {
+    let Some(yrp) = &state.yrp else {
+        return Err(app_error(StatusCode::NOT_FOUND, "yrp mode not enabled"));
+    };
+    if let Some(secret) = &yrp.cluster_secret {
+        let presented = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "));
+        if presented != Some(secret.as_str()) {
+            return Err(app_error(
+                StatusCode::UNAUTHORIZED,
+                "invalid cluster secret",
+            ));
+        }
+    }
+    if req.cluster_id != yrp.cluster_id {
+        return Err(app_error(StatusCode::BAD_REQUEST, "cluster_id mismatch"));
+    }
+    let rows = yrp
+        .serve_backfill(req.from_index, req.to_index)
+        .await
+        .map_err(|e| app_error(StatusCode::SERVICE_UNAVAILABLE, e))?;
+    bincode::serialize(&rows).map_err(|e| {
+        app_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("encode backfill: {e}"),
+        )
+    })
 }
 
 /// Issue #58: keyed `/v1/remember/batch` — the engine's atomic batch path.
@@ -5128,6 +5176,8 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/v1/cluster/promote", post(cluster_promote))
         // RFC 028: YRP peer wire (bincode envelope; cluster-secret gated)
         .route("/v1/yrp/msg", post(yrp_msg))
+        // RFC 028 Phase C: engine backfill for beyond-GC stragglers
+        .route("/v1/yrp/backfill", post(yrp_backfill))
         // v0.8.3 #24: openraft membership management
         .route("/v1/cluster/initialize", post(cluster_initialize))
         .route("/v1/cluster/add-learner", post(cluster_add_learner))

--- a/crates/yantrikdb-server/src/yrp/chaos_test.rs
+++ b/crates/yantrikdb-server/src/yrp/chaos_test.rs
@@ -280,8 +280,12 @@ async fn torn_state_boots_quarantined_then_rejoins_via_grant() {
 }
 
 /// A straggler that falls below the leader's compaction base catches up
-/// via InstallSnapshot — and claims RIDE the snapshot: a keyed retry of
-/// a COMPACTED entry still dedupes (P1-9, live on real HTTP).
+/// via InstallSnapshot — claims RIDE the snapshot (a keyed retry of a
+/// COMPACTED entry still dedupes, P1-9), AND its ENGINE state is
+/// backfilled: a memory written into the compacted range while the
+/// straggler was dead is RECALLABLE after rejoin (RFC 028 Phase C —
+/// the beyond-GC engine backfill, the correctness hole that gated
+/// compaction off).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn straggler_beyond_gc_catches_up_and_compacted_claims_survive() {
     let _serial = serial_guard().await;
@@ -293,11 +297,19 @@ async fn straggler_beyond_gc_catches_up_and_compacted_claims_survive() {
         },
     )
     .await;
-    let emb = embedding(3.3);
+    // DISTINCT embeddings per write (each seed unique) so recall can
+    // target a SPECIFIC memory — identical vectors would make recall
+    // unable to rank any one write within top_k.
+    let emb_first = embedding(100.0);
     let all: Vec<&TestNode> = nodes.iter().collect();
 
-    let (rid_first, _) =
-        keyed_write_until_accepted(&all, "chaos-gc-first", "the earliest keyed write", &emb).await;
+    let (rid_first, _) = keyed_write_until_accepted(
+        &all,
+        "chaos-gc-first",
+        "the earliest keyed write",
+        &emb_first,
+    )
+    .await;
 
     // Kill a follower, then push the cluster far past the compaction
     // threshold so the victim's next_index falls below the leader's base.
@@ -310,21 +322,50 @@ async fn straggler_beyond_gc_catches_up_and_compacted_claims_survive() {
 
     let survivors: Vec<&TestNode> = live.iter().collect();
     let mut last_rid = String::new();
+    let mut mid_rid = String::new();
+    let emb_mid = embedding(12.5);
+    let emb_last = embedding(29.5);
     for i in 0..30 {
+        // Each write gets its own vector; the middle and last ones use
+        // the exact vectors we later query with.
+        let e = if i == 12 {
+            emb_mid.clone()
+        } else if i == 29 {
+            emb_last.clone()
+        } else {
+            embedding(i as f32)
+        };
         let (rid, _) = keyed_write_until_accepted(
             &survivors,
             &format!("chaos-gc-{i}"),
             &format!("bulk write {i}"),
-            &emb,
+            &e,
         )
         .await;
+        // A write from the MIDDLE of the burst — its log entry is
+        // compacted away (below base) by the time the straggler rejoins,
+        // so it can only reach the straggler's engine via backfill, never
+        // via tail AppendEntries.
+        if i == 12 {
+            mid_rid = rid.clone();
+        }
         last_rid = rid;
     }
 
-    // Restart the straggler: it must converge (snapshot install + tail
-    // replication) to the newest write, LIVE.
+    // Sanity: mid_rid is genuinely committed (recallable on a survivor)
+    // before we test the revived straggler — guards against a phantom rid.
+    wait_for_recall(survivors[0], &emb_mid, &mid_rid).await;
+
+    // Restart the straggler: it must converge (snapshot install + engine
+    // backfill + tail replication) to the newest write, LIVE.
     let revived = dead.restart().await;
-    wait_for_recall(&revived, &emb, &last_rid).await;
+    wait_for_recall(&revived, &emb_last, &last_rid).await;
+
+    // THE PHASE C PROPERTY: the compacted-range memory is in the revived
+    // straggler's LIVE engine, not just its protocol state. Without
+    // engine backfill this recall never surfaces mid_rid (the driver
+    // fast-forwarded the marker past the mutation without applying it).
+    wait_for_recall(&revived, &emb_mid, &mid_rid).await;
 
     // The claim of the FIRST write — whose log entry is long compacted on
     // the leader — still dedupes to the original rid. Claims ride the
@@ -338,7 +379,7 @@ async fn straggler_beyond_gc_catches_up_and_compacted_claims_survive() {
         &with_revived,
         "chaos-gc-first",
         "the earliest keyed write",
-        &emb,
+        &emb_first,
         &rid_first,
     )
     .await;

--- a/crates/yantrikdb-server/src/yrp/driver.rs
+++ b/crates/yantrikdb-server/src/yrp/driver.rs
@@ -120,6 +120,19 @@ pub struct YrpStatus {
     /// Last leader this node heard from (itself when leading). A HINT for
     /// redirects — may be stale.
     pub leader: Option<NodeId>,
+    /// RFC 028 Phase C: the engine-apply frontier a beyond-GC snapshot
+    /// install requires the sink to reach via backfill. `applied <
+    /// backfill_target` ⇒ engine-incomplete (no reads, no leadership).
+    /// 0 = no outstanding backfill.
+    pub backfill_target: u64,
+}
+
+impl YrpStatus {
+    /// True while this node's engine trails an adopted snapshot frontier
+    /// and must not serve reads or lead.
+    pub fn engine_incomplete(&self) -> bool {
+        self.applied < self.backfill_target
+    }
 }
 
 impl Default for YrpStatus {
@@ -130,6 +143,7 @@ impl Default for YrpStatus {
             commit: 0,
             applied: 0,
             leader: None,
+            backfill_target: 0,
         }
     }
 }
@@ -183,6 +197,13 @@ pub enum DriverEvent {
     /// Apply worker reports the highest contiguous durably-applied index.
     Applied {
         upto: u64,
+    },
+    /// RFC 028 Phase C: an engine mutation pulled by the backfill task
+    /// for the compacted range (its log entry is gone). The owner
+    /// sequences it into the apply stream in contiguous order.
+    Backfilled {
+        index: u64,
+        entry: LogEntry,
     },
     /// Periodic tick — the owner checks its own election/heartbeat
     /// deadlines (generation-tagged; a stale tick is a no-op).
@@ -255,8 +276,11 @@ pub struct DriverConfig {
     /// Heartbeat every N ticks while leader.
     pub heartbeat_ticks: u32,
     /// Compact the log once the retained span exceeds this many entries.
-    /// `None` = never (the production default until Phase C ships engine
-    /// checkpoint transfer — see `maybe_compact` for why).
+    /// `None` = never. Beyond-GC stragglers are healed by engine backfill
+    /// (RFC 028 Phase C slice A — `run_backfill_task`), so enabling this
+    /// is now correctness-safe; it stays off by DEFAULT only pending the
+    /// fuller interruption-test hardening (crash/leader-change mid-
+    /// backfill) before it becomes the shipped default.
     pub compact_after: Option<u64>,
     /// Leader retention margin: leaders compact only to `frontier - M` so
     /// briefly-lagging followers catch up from the log instead of
@@ -282,6 +306,16 @@ pub struct YrpDriver {
     applied: u64,
     /// Committed-but-not-yet-dispatched-to-apply frontier.
     dispatched: u64,
+    /// RFC 028 Phase C: the engine-apply frontier a beyond-GC snapshot
+    /// install requires the sink to reach via BACKFILL (the compacted
+    /// range's mutations are not in the log). `applied < backfill_target`
+    /// ⇒ this node is ENGINE-INCOMPLETE: it must not campaign and its
+    /// read barriers cannot resolve. 0 = no outstanding backfill.
+    backfill_target: u64,
+    /// Out-of-band backfilled entries awaiting in-order dispatch to the
+    /// apply worker (keyed by absolute yrp index). Drained by
+    /// `dispatch_ready` strictly in contiguous ascending order.
+    backfill_buffer: BTreeMap<u64, LogEntry>,
     /// Election deadline in ticks-remaining; None while leader. Reset on
     /// valid leader contact (the owner sees every inbound message, so the
     /// codex F5 race cannot occur: queued heartbeats are processed before
@@ -346,6 +380,17 @@ impl YrpDriver {
             pending_barriers: BTreeMap::new(),
             applied: durable_applied,
             dispatched: durable_applied,
+            // Boot-time resumption (codex pitfall: never trust HTTP
+            // completion): if the durable engine marker is below the
+            // adopted protocol frontier, an interrupted backfill must
+            // resume. `base.index` IS the adopted frontier for a
+            // compacted node; a healthy node has durable_applied ≥ base.
+            backfill_target: if durable_applied < base.index {
+                base.index
+            } else {
+                0
+            },
+            backfill_buffer: BTreeMap::new(),
             election_ticks_left: None,
             heartbeat_ticks_left: 0,
             rng: seed,
@@ -374,6 +419,7 @@ impl YrpDriver {
             } else {
                 self.leader_hint
             },
+            backfill_target: self.backfill_target,
         }
     }
 
@@ -415,6 +461,13 @@ impl YrpDriver {
                 DriverEvent::Applied { upto } => {
                     self.applied = self.applied.max(upto);
                     self.release_acks();
+                    None
+                }
+                DriverEvent::Backfilled { index, entry } => {
+                    if index > self.applied {
+                        self.backfill_buffer.insert(index, entry);
+                        self.dispatch_ready();
+                    }
                     None
                 }
                 DriverEvent::Tick => self.on_tick(),
@@ -574,6 +627,17 @@ impl YrpDriver {
             }
             return None;
         }
+        // Engine-incomplete nodes never campaign (RFC 028 Phase C / codex
+        // pitfall 1): they still receive AppendEntries and keep their log
+        // current, but must not win leadership before their engine is
+        // backfilled — a protocol-current, engine-behind leader would
+        // serve stale reads and could not source engine history. Keep the
+        // deadline re-armed so a genuinely stuck backfill still surfaces
+        // via health, not a spurious election.
+        if self.engine_incomplete() {
+            self.arm_election_deadline();
+            return None;
+        }
         if let Some(left) = self.election_ticks_left.as_mut() {
             *left = left.saturating_sub(1);
             if *left == 0 {
@@ -643,22 +707,33 @@ impl YrpDriver {
                         }
                     }
                 }
-                Effect::CommitAdvanced { to } => {
+                Effect::CommitAdvanced { .. } => {
                     // Dispatch newly committed entries to the sequential
                     // apply worker (codex F1: never apply in the owner).
-                    let from = self.dispatched + 1;
-                    for i in from..=to {
-                        if let Some(e) = self.core.entry(i) {
-                            let _ = self.apply_tx.send((i, e.clone()));
-                        }
-                    }
-                    self.dispatched = self.dispatched.max(to);
+                    // `dispatch_ready` sequences log entries and any
+                    // backfilled entries strictly in order, so a beyond-GC
+                    // gap cannot let a later index apply before an earlier.
+                    self.dispatch_ready();
                 }
                 Effect::InstallState { last_index } => {
-                    // v1: snapshots restricted to uncompacted rejoin — the
-                    // engine-checkpoint manifest protocol is Phase C.
-                    self.applied = self.applied.max(last_index);
-                    self.dispatched = self.dispatched.max(last_index);
+                    // RFC 028 Phase C: adopting the protocol snapshot does
+                    // NOT fast-forward the engine marker. The compacted
+                    // range's mutations are absent from the log; the sink
+                    // must apply them via backfill. Record the frontier
+                    // the engine must reach (engine-incomplete until then)
+                    // and let dispatch/backfill fill it. NEVER advance
+                    // `applied` here — that is the old hole.
+                    if last_index > self.applied {
+                        self.backfill_target = self.backfill_target.max(last_index);
+                        // Leave `dispatched` at the real engine frontier
+                        // so the gap [dispatched+1, last_index] is fed by
+                        // backfill (from `backfill_buffer`), NOT skipped.
+                    } else {
+                        // Snapshot at/below what we've already applied —
+                        // nothing to backfill.
+                        self.dispatched = self.dispatched.max(last_index);
+                    }
+                    self.dispatch_ready();
                 }
                 Effect::PeerIncompatible { peer } => {
                     tracing::error!(?peer, "YRP peer capability-incompatible; sends stalled");
@@ -667,6 +742,43 @@ impl YrpDriver {
         }
         self.release_acks();
         None
+    }
+
+    /// Dispatch committed entries to the apply worker in strictly
+    /// contiguous ascending order, pulling each index from the log or —
+    /// for a compacted beyond-GC gap — the backfill buffer. Stops at the
+    /// first index it does not yet hold (backfill will re-drive it) and
+    /// never dispatches past the commit index. This single sequencer is
+    /// what guarantees no later index applies before an earlier one, even
+    /// when a snapshot install leaves a hole below the log base.
+    fn dispatch_ready(&mut self) {
+        let commit = self.core.commit_index();
+        loop {
+            let next = self.dispatched + 1;
+            if next > commit {
+                break;
+            }
+            let entry = self
+                .core
+                .entry(next)
+                .cloned()
+                .or_else(|| self.backfill_buffer.remove(&next));
+            match entry {
+                Some(e) => {
+                    let _ = self.apply_tx.send((next, e));
+                    self.dispatched = next;
+                }
+                None => break, // gap — awaiting backfill for `next`
+            }
+        }
+    }
+
+    /// This node cannot serve reads or lead until its engine has been
+    /// backfilled up to the adopted snapshot frontier (RFC 028 Phase C /
+    /// codex pitfall 1): a protocol-current but engine-incomplete leader
+    /// would serve stale reads and be unable to source engine history.
+    fn engine_incomplete(&self) -> bool {
+        self.applied < self.backfill_target
     }
 
     /// Release client replies up to the highest contiguous durably-applied

--- a/crates/yantrikdb-server/src/yrp/engine_sink.rs
+++ b/crates/yantrikdb-server/src/yrp/engine_sink.rs
@@ -181,6 +181,48 @@ impl OutcomeStore {
         )
     }
 
+    /// Outcome rows in `(from_exclusive, to_inclusive]`, ascending — the
+    /// serve side of Phase C backfill. Contiguity is the caller's to
+    /// verify (a gap here means this node cannot fully cover the range and
+    /// must refuse rather than serve a partial answer, codex source-
+    /// completeness invariant).
+    pub fn outcomes_in_range(
+        &self,
+        from_exclusive: u64,
+        to_inclusive: u64,
+    ) -> Result<Vec<AppliedOutcome>, String> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT yrp_index, term, tenant_id, op_id, key_hash, key_str, rid,
+                        tenant_log_index, applied_at_unix_micros
+                 FROM yrp_outcome
+                 WHERE yrp_index > ?1 AND yrp_index <= ?2
+                 ORDER BY yrp_index ASC",
+            )
+            .map_err(|e| format!("prepare range: {e}"))?;
+        let rows = stmt
+            .query_map([from_exclusive as i64, to_inclusive as i64], |r| {
+                Ok(AppliedOutcome {
+                    yrp_index: r.get::<_, i64>(0)? as u64,
+                    term: r.get::<_, i64>(1)? as u64,
+                    tenant_id: r.get(2)?,
+                    op_id: r.get(3)?,
+                    key_hash: r.get::<_, Option<i64>>(4)?.map(|k| k as u64),
+                    key_str: r.get(5)?,
+                    rid: r.get(6)?,
+                    tenant_log_index: r.get::<_, i64>(7)? as u64,
+                    applied_at_unix_micros: r.get(8)?,
+                })
+            })
+            .map_err(|e| format!("query range: {e}"))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|e| format!("row: {e}"))?);
+        }
+        Ok(out)
+    }
+
     fn query_one(
         conn: &Connection,
         sql: &str,

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -33,7 +33,7 @@ use super::driver::{
 };
 use super::engine_sink::{AppliedOutcome, EngineApplySink, OutcomeStore};
 use super::op::{claim_key_for_op, YrpOp};
-use super::replica::{Payload, Role};
+use super::replica::{LogEntry, Payload, Role};
 use super::transport::HttpTransport;
 use super::types::{ClusterId, NodeId};
 use crate::commit::{
@@ -91,12 +91,16 @@ pub enum YrpProposeError {
 /// What the HTTP layer holds for a YRP node.
 pub struct YrpHandle {
     pub node_id: NodeId,
+    pub cluster_id: u64,
     owner_tx: mpsc::UnboundedSender<DriverEvent>,
     pub outcomes: Arc<OutcomeStore>,
     pub status: watch::Receiver<YrpStatus>,
     /// node id → HTTP base url, for leader redirects.
     peer_http: BTreeMap<u64, String>,
     pub cluster_secret: Option<String>,
+    /// Local commit log — the retained source of truth the backfill serve
+    /// path joins against the outcome store (RFC 028 Phase C).
+    local: Arc<dyn MutationCommitter>,
     /// `Some(reasons)` while quarantined (or after a fatal driver exit);
     /// `None` when replicating normally. The health surface reports it;
     /// the write path refuses on it.
@@ -148,6 +152,71 @@ impl YrpHandle {
         }
     }
 
+    /// Serve a Phase C backfill range: reconstruct the log entries for
+    /// `(from_index, to_index]` by joining the outcome store against the
+    /// retained commit log. Range-complete or `Err` — never a partial
+    /// answer (codex source-completeness invariant). An engine-incomplete
+    /// node refuses outright: it cannot prove it holds the range.
+    pub async fn serve_backfill(
+        &self,
+        from_index: u64,
+        to_index: u64,
+    ) -> Result<Vec<(u64, LogEntry)>, String> {
+        if self.status.borrow().engine_incomplete() {
+            return Err("node is engine-incomplete; cannot source backfill".into());
+        }
+        let outcomes = self
+            .outcomes
+            .outcomes_in_range(from_index, to_index)
+            .map_err(|e| format!("outcome range: {e}"))?;
+        // Contiguity check: the range must be dense (no missing yrp_index).
+        let expected = (to_index.saturating_sub(from_index)) as usize;
+        if outcomes.len() != expected {
+            return Err(format!(
+                "backfill range ({from_index},{to_index}] not fully retained: {} of {expected} rows",
+                outcomes.len()
+            ));
+        }
+        let mut rows = Vec::with_capacity(outcomes.len());
+        for o in outcomes {
+            let tenant = TenantId::new(o.tenant_id);
+            // Fetch the exact committed mutation (materialized — embedding
+            // inside) from the retained per-tenant commit log.
+            let entry = self
+                .local
+                .read_range(tenant, o.tenant_log_index, 1)
+                .await
+                .map_err(|e| format!("commit-log read: {e}"))?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    format!(
+                        "commit-log row missing for tenant {tenant} idx {}",
+                        o.tenant_log_index
+                    )
+                })?;
+            let op_id = OpId::from_uuid(
+                o.op_id
+                    .parse()
+                    .map_err(|e| format!("bad op_id in outcome: {e}"))?,
+            );
+            let op = YrpOp {
+                tenant_id: tenant,
+                op_id,
+                mutation: entry.mutation,
+                idempotency_key: o.key_str.clone(),
+            };
+            let log_entry = LogEntry {
+                term: super::types::Term(o.term),
+                payload: Payload::Op(op.encode()?),
+                key: o.key_hash,
+                activate: None,
+            };
+            rows.push((o.yrp_index, log_entry));
+        }
+        Ok(rows)
+    }
+
     /// Graceful stop of whichever loop owns the funnel (tests/shutdown).
     pub fn shutdown(&self) {
         let _ = self.owner_tx.send(DriverEvent::Shutdown);
@@ -169,7 +238,14 @@ impl YrpHandle {
     }
 
     pub fn is_leader(&self) -> bool {
-        self.quarantine_reasons().is_none() && self.status.borrow().role == Role::Leader
+        let s = *self.status.borrow();
+        self.quarantine_reasons().is_none() && s.role == Role::Leader && !s.engine_incomplete()
+    }
+
+    /// True while this node's engine trails an adopted snapshot frontier
+    /// (RFC 028 Phase C) — surfaced on health, gates reads/leadership.
+    pub fn engine_incomplete(&self) -> bool {
+        self.status.borrow().engine_incomplete()
     }
 
     /// Propose a keyed op and wait for its durable outcome. This is the
@@ -361,13 +437,20 @@ pub fn spawn(
 
     let handle = Arc::new(YrpHandle {
         node_id: me,
+        cluster_id: cfg.cluster_id,
         owner_tx: owner_tx.clone(),
         outcomes: outcomes.clone(),
         status: status_rx,
         peer_http,
         cluster_secret: cfg.cluster_secret.clone(),
+        local: local.clone(),
         quarantine: std::sync::RwLock::new(None),
     });
+
+    // RFC 028 Phase C: pull engine backfill for compacted ranges after a
+    // snapshot install. Runs for the lifetime of the node; idle unless
+    // `status.backfill_target > applied`.
+    tokio::spawn(run_backfill_task(handle.clone(), owner_tx.clone()));
 
     let sink = EngineApplySink::new(local, applier, outcomes.clone());
     tokio::spawn(run_apply_worker(Box::new(sink), apply_rx, owner_tx.clone()));
@@ -426,6 +509,95 @@ pub fn spawn(
         }
     }
     Ok(handle)
+}
+
+/// Backfill request body (`POST /v1/yrp/backfill`, cluster-secret bearer).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BackfillRequest {
+    pub cluster_id: u64,
+    pub from_index: u64,
+    pub to_index: u64,
+}
+
+/// Backfill batch size per request round — bounds one pull's size.
+const BACKFILL_BATCH: u64 = 256;
+
+/// Pull engine backfill for compacted ranges after a snapshot install
+/// and feed each entry to the owner (which sequences it into the apply
+/// stream). Idle unless `status.backfill_target > applied`. Durably
+/// resumable: it always re-derives the outstanding gap from the live
+/// status, so a crash or interrupted stream simply re-pulls from the
+/// persisted marker.
+async fn run_backfill_task(handle: Arc<YrpHandle>, owner: mpsc::UnboundedSender<DriverEvent>) {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("reqwest client");
+    let mut status = handle.status.clone();
+    loop {
+        // Wait for engine-incomplete (or exit when the driver drops the
+        // status sender).
+        let (from, to, leader_id) = {
+            let s = *status.borrow();
+            (s.applied, s.backfill_target, s.leader.map(|n| n.0))
+        };
+        if to <= from {
+            if status.changed().await.is_err() {
+                return;
+            }
+            continue;
+        }
+        // Source = current leader (a complete node by the eligibility
+        // gate). If we don't know one yet, wait for status to move.
+        let Some(leader_id) = leader_id.filter(|id| *id != handle.node_id.0) else {
+            if status.changed().await.is_err() {
+                return;
+            }
+            continue;
+        };
+        let Some(base_url) = handle.peer_http.get(&leader_id).cloned() else {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            continue;
+        };
+
+        let batch_to = (from + BACKFILL_BATCH).min(to);
+        let req = BackfillRequest {
+            cluster_id: handle.cluster_id,
+            from_index: from,
+            to_index: batch_to,
+        };
+        let url = format!("{}/v1/yrp/backfill", base_url.trim_end_matches('/'));
+        let mut http = client.post(&url).json(&req);
+        if let Some(s) = &handle.cluster_secret {
+            http = http.bearer_auth(s);
+        }
+        match http.send().await {
+            Ok(resp) if resp.status().is_success() => match resp.bytes().await {
+                Ok(bytes) => match bincode::deserialize::<Vec<(u64, LogEntry)>>(&bytes) {
+                    Ok(rows) => {
+                        for (index, entry) in rows {
+                            let _ = owner.send(DriverEvent::Backfilled { index, entry });
+                        }
+                        // Let the apply worker make progress before the
+                        // next batch; the status watch reflects it.
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "backfill decode failed; retrying");
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(error = %e, "backfill body read failed; retrying");
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+            },
+            other => {
+                tracing::debug!(?other, from, batch_to, "backfill pull failed; retrying");
+                tokio::time::sleep(Duration::from_millis(300)).await;
+            }
+        }
+    }
 }
 
 /// `Transport` over a shared [`HttpTransport`] so the quarantine loop and

--- a/docs/rfcs/rfc_028_phase_c_engine_backfill.md
+++ b/docs/rfcs/rfc_028_phase_c_engine_backfill.md
@@ -1,0 +1,98 @@
+# RFC 028 addendum — Phase C: engine backfill for beyond-GC stragglers
+
+Implementation design for the code-level "Phase C engine-checkpoint
+transfer" milestone (referenced in `src/yrp/driver.rs`,
+`src/yrp/engine_sink.rs`). Normative parent: RFC 028 §6.
+
+## The hole
+
+YRP log compaction (`ReplicaCore::compact`) drops **protocol-log**
+entries below a base index. When a follower falls below that base, the
+leader sends `InstallSnapshot` carrying only protocol state
+(`claims` / `active` / frontier `last`). The driver's
+`Effect::InstallState` handler fast-forwards its `applied` / `dispatched`
+counters to the snapshot frontier **without applying the engine
+mutations** for the compacted range — a permanent hole in the
+follower's engine state (memories/embeddings/entities). This is why
+compaction ships `compact_after = None` (disabled) by default.
+
+## Decision (codex-consulted 2026-07-19): log-replay backfill first
+
+YRP compaction GCs **only the protocol log**. The per-tenant
+`commit_log.sqlite` — full materialized mutations, embeddings inside —
+is written by the apply sink and is **never GC'd**; the leader retains
+every committed mutation. The `OutcomeStore` (`yrp_apply.sqlite`) maps
+`yrp_index → (tenant_id, op_id, tenant_log_index, rid, …)`.
+
+So a beyond-GC straggler can be healed by **replaying the retained
+commit-log mutations for the gap through the existing deterministic
+apply sink** — no binary checkpoint, no new crash-consistency
+machinery. This is the openraft model (snapshot = replay committed log),
+made GC-safe because the commit-log is the retained source of truth.
+
+- **Slice A (this work): log-replay backfill.** Closes the correctness
+  hole; lets protocol-log compaction run default-on. Does NOT bound
+  total storage (commit-log still grows).
+- **Slice B (tracked follow-up): binary engine checkpoint.** WAL-
+  checkpoint + copy the per-tenant sqlite at a quiesced global frontier,
+  extended `SnapshotManifest` (reuse `crate::backup::SnapshotManifest`),
+  out-of-band blob stream, crash-safe online swap, HNSW rebuild. This is
+  what bounds storage (enables commit-log GC). Separately specified.
+
+## Slice A mechanism
+
+### Serve (leader / any complete node)
+`POST /v1/yrp/backfill` — body `{cluster_id, from_index, to_index}`
+(cluster-secret bearer, like `/v1/yrp/msg`). The server, for each
+`yrp_index` in `(from, to]`, joins `OutcomeStore` → `commit_log` and
+returns `[(yrp_index, YrpOp-bytes)]`, contiguous and range-complete.
+**Source completeness invariant:** refuse (or truncate honestly) any
+range the node cannot fully cover from its own retained history —
+never serve a partial range that would leave a hole the requester
+believes filled.
+
+### Request + apply (backfilling follower)
+On `Effect::InstallState { last_index }`, the driver records an **engine
+gap** `[durable_applied+1, last_index]` instead of blindly fast-
+forwarding the durable marker. A backfill task (runtime layer) pulls the
+range from the current leader in contiguous batches and feeds each
+`(yrp_index, LogEntry{Payload::Op})` to the **existing apply worker** —
+which does commit-log append + engine apply + marker advance, already
+atomic and idempotent per `(tenant, index)`. The follower is "engine-
+caught-up" only when the durable marker reaches `last_index`. Backfill
+is durably resumable: a crash mid-backfill re-derives the gap from the
+persisted marker vs. protocol frontier (never trust HTTP completion).
+
+### Eligibility gate (codex pitfall 1 — the safety crux)
+A node whose durable engine marker `applied < commit` (protocol frontier
+it has adopted) is **engine-incomplete** and MUST be:
+- ineligible to serve reads / linearizable barriers — already true by
+  construction: the read barrier waits for `applied ≥ noop_index`, so an
+  incomplete node's barrier never resolves (fails closed, never serves
+  stale);
+- ineligible to campaign — the driver suppresses `on_election_timeout`
+  while engine-incomplete (same mechanism that makes a witness never
+  campaign), so an incomplete node cannot win leadership and then fail
+  to serve engine history to the next straggler;
+- reported honestly on `/v1/health` (`engine_incomplete: true` +
+  the gap).
+
+### Duplicate-index integrity (codex pitfall 2)
+Backfilled entries carry the original `op_id`; the sink's commit-log
+append is idempotent on `(tenant, op_id)` and fail-stops on an
+op_id-with-divergent-payload. So a duplicate `yrp_index` cannot conceal
+a divergent mutation — the existing collision guard covers it.
+
+## Invariants to test before enabling compaction by default
+Per codex: crash mid-backfill, interrupted stream, leader change during
+backfill, repeated snapshots, and truncation must all establish that
+**no durable marker advances past an unapplied mutation**. The chaos
+scenario `straggler_beyond_gc_*` is extended to write a memory that
+lands in the COMPACTED range, then assert the revived straggler can
+RECALL it (not just dedupe its claim) — the direct proof the engine
+hole is closed.
+
+## Storage caveat (codex pitfall 3)
+Slice A shifts the bound from protocol-log growth to commit-log growth;
+admission control + disk monitoring remain mandatory until Slice B's
+commit-log GC lands.


### PR DESCRIPTION
Closes the last real correctness gap in YRP: a follower that falls below the leader's compaction base adopted protocol state but its **engine** state had a permanent hole for the compacted range (the driver fast-forwarded the apply marker without applying those mutations). This is why compaction shipped disabled-by-default.

## Design (codex scope-consulted — verdict A)

YRP compaction GCs only the **protocol** log; the per-tenant `commit_log.sqlite` (full materialized mutations, embeddings inside) is retained. So a straggler is healed by **replaying its gap's retained mutations through the existing deterministic apply sink** — no new crash-consistency machinery. The binary-checkpoint route (which additionally *bounds storage* by enabling commit-log GC) is the tracked follow-up, specified in `docs/rfcs/rfc_028_phase_c_engine_backfill.md`.

## Mechanism

- **Serve**: `POST /v1/yrp/backfill` reconstructs `(yrp_index, LogEntry)` for a range by joining the outcome store against the commit log — range-complete or it refuses (source-completeness invariant).
- **Driver**: `InstallState` records an engine gap instead of fast-forwarding the marker; a single owner-sequenced `dispatch_ready` interleaves log and backfilled entries **strictly ascending**, so no later index applies before an earlier one.
- **Pull**: `run_backfill_task` pulls the gap from the current leader in batches, resumable from the persisted marker (never trusts HTTP completion).
- **Eligibility gate** (the safety crux): `applied < adopted frontier` ⇒ **engine-incomplete** — the node does not campaign (a protocol-current, engine-behind leader would serve stale reads and couldn't source engine history), its read barrier can't resolve, and `/v1/health` reports `engine_backfilling`.

## Proof

The `straggler_beyond_gc` chaos test now writes a memory **into the compacted range** and asserts the revived straggler can **recall** it (not just dedupe its claim). It failed before this change, passes after. yrp gate 61 tests, 5× stable; full suite green.

Also flushed out (and fixed as a test artifact, not a code bug): the beyond-GC test used identical embeddings for every write, so recall couldn't rank a specific memory within top_k — now distinct per write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)