### PR TITLE
chore(deps): bump engine to v0.10.1 (materializer idle-scan fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1635,7 +1635,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2530,7 +2530,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2567,7 +2567,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4519,8 +4519,8 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yantrikdb"
-version = "0.10.0"
-source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.10.0#9bbcd8e249d569c2f5f73f272be0b6d80a7eaaa2"
+version = "0.10.1"
+source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.10.1#db9f7655dd6f0fe8e0b8b7a5ed8d9d233a34279e"
 dependencies = [
  "aes-gcm",
  "arc-swap",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -17,29 +17,17 @@ name = "yantrikdb"
 path = "src/main.rs"
 
 [dependencies]
-# Engine v0.9.4 — latest tagged release. Pinned by tag (not branch=main) for a
-# reproducible, released dependency; main is 37 commits into the untagged v0.10
-# work (single-origin provenance gate + schema v37) which we adopt once core
-# tags v0.10.0 and we validate its REST-contract changes (correct→200, reembed
-# deferral→409). The v0.9.1→v0.9.4 line over our previous v0.9.0 pin adds:
-# v0.9.1 set_embedder_named worker-pool fix; v0.9.2 NaN-safe recall; v0.9.3
-# contract gate + isolation repair + 7.4x distance path; v0.9.4 cold-tier
-# recall decompression fix. v0.9.0 base still provides the session-lifecycle
-# surface (session_digest, draft_memories_from_summary) wired in v0.8.25 and
-# the autonomous maintenance cycle (run_maintenance_cycle) driven from the host:
-#   - run_maintenance_cycle(&MaintenanceCycleConfig) -> MaintenanceCycleReport:
-#     the unified "sleep cycle" — think (consolidation + conflict scan +
-#     trigger expiry) → entity backfill → auto-relate → conflict burn-down →
-#     trigger prune → importance recalibration → (opt-in) split/repair. The
-#     engine deliberately owns NO timer thread ("a storage engine scheduling
-#     itself is the wrong boundary"); the host drives cadence. RFC 027 / #55.
-#   - last_maintenance_cycle() -> Option<String>: persisted JSON of the last
-#     cycle for the status endpoint + boot digest.
-#   - session_digest(&SessionDigestConfig) -> SessionDigest, chain_head(ns):
-#     wired by v0.8.25 (RFC 023 / #56).
-# Carries forward the v0.7.18 compactor + v0.7.19 orphan-rollback reliability
-# arc that every deployment since v0.8.18 depends on.
-yantrikdb = { version = "0.10.0", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.10.0" }
+# Engine v0.10.1 — latest tagged release. Pinned by tag for a reproducible,
+# released dependency. v0.10.1 is the materializer idle-scan fix (#114): a
+# missing `idx_oplog_pending` on fresh installs made the drain poll scan the
+# whole oplog every tick, burning up to ~34% of a 32-core box while idle;
+# fixed by declaring the partial index in SCHEMA_SQL. Schema 37→38, ADDITIVE
+# (version stamping is forward-only; no server API/contract change, and the
+# server asserts no exact schema version). v0.10.0 carried the single-origin
+# provenance gate + schema v37 (correct→200, reembed-deferral→409). The engine
+# owns no timer thread — the host drives run_maintenance_cycle() cadence
+# (RFC 027 / #55); session_digest + chain_head wired in v0.8.25 (RFC 023 / #56).
+yantrikdb = { version = "0.10.1", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.10.1" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime


### PR DESCRIPTION
Bumps the `yantrikdb` engine pin v0.10.0 → **v0.10.1** — the materializer idle-scan fix.

**What it fixes (engine-side):** a missing `idx_oplog_pending` on *fresh* installs made the drain poll scan the whole oplog on every tick — up to ~34% of a 32-core box **while idle**, plus ingest starvation (`Backpressure`) at depth. Fixed by declaring the partial index in `SCHEMA_SQL` (so every fresh DB carries it) + a migration for existing DBs. Measured 246× reduction at 6k records; the CPU curve goes flat.

Directly relevant to us — the homelab runs multiple engines that sit idle between writes, exactly the pathological case.

**Server impact:** none beyond the bump. Schema 37→38 is **additive** (forward-only version stamping); no REST/API/contract change. The release's one compat note ("relax any exact schema-version assertion to >=") doesn't apply — the server asserts no exact schema version (grep-verified).

**Validation:** builds clean; full suite green against the new core (2000+ tests across all targets, incl. http_integration / crash_recovery / crdt_convergence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
