### PR TITLE
feat(studio): admin cluster console at /admin + /v1/cluster/topology

### DIFF
--- a/crates/yantrikdb-server/src/admin/studio.html
+++ b/crates/yantrikdb-server/src/admin/studio.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>YantrikDB Studio — Cluster</title>
+<style>
+  :root {
+    --bg: #f6f7f9; --panel: #ffffff; --ink: #1a1d21; --muted: #6b7280;
+    --line: #e5e7eb; --accent: #4f46e5; --ok: #16a34a; --warn: #d97706;
+    --bad: #dc2626; --leader: #4f46e5; --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117; --panel: #161b22; --ink: #e6edf3; --muted: #8b949e;
+      --line: #21262d; --accent: #7c8cff; --ok: #3fb950; --warn: #d29922;
+      --bad: #f85149; --leader: #7c8cff;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    background: var(--bg); color: var(--ink); -webkit-font-smoothing: antialiased;
+  }
+  header {
+    display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap;
+    padding: 1.1rem 1.5rem; border-bottom: 1px solid var(--line); background: var(--panel);
+  }
+  header h1 { font-size: 1.05rem; margin: 0; font-weight: 650; letter-spacing: -0.01em; }
+  header .sub { color: var(--muted); font-size: .82rem; }
+  header .meta { margin-left: auto; font-family: var(--mono); font-size: .78rem; color: var(--muted); }
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1rem; }
+  .card {
+    background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
+    padding: 1rem 1.1rem; position: relative; overflow: hidden;
+  }
+  .card.leader { border-color: var(--leader); box-shadow: 0 0 0 1px var(--leader) inset; }
+  .card.unreachable { opacity: .55; }
+  .card .top { display: flex; align-items: center; gap: .5rem; margin-bottom: .6rem; }
+  .node-id { font-family: var(--mono); font-weight: 650; font-size: .95rem; }
+  .badge {
+    font-size: .68rem; font-weight: 600; padding: .12rem .5rem; border-radius: 999px;
+    text-transform: uppercase; letter-spacing: .03em;
+  }
+  .badge.leader { background: color-mix(in srgb, var(--leader) 18%, transparent); color: var(--leader); }
+  .badge.follower { background: color-mix(in srgb, var(--muted) 20%, transparent); color: var(--muted); }
+  .badge.witness { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
+  .badge.candidate, .badge.quarantined { background: color-mix(in srgb, var(--bad) 18%, transparent); color: var(--bad); }
+  .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-left: auto; }
+  .dot.ok { background: var(--ok); } .dot.bad { background: var(--bad); } .dot.warn { background: var(--warn); }
+  .rows { display: grid; grid-template-columns: auto 1fr; gap: .25rem .75rem; font-size: .8rem; margin-top: .5rem; }
+  .rows dt { color: var(--muted); } .rows dd { margin: 0; font-family: var(--mono); text-align: right; }
+  .lagbar { height: 4px; border-radius: 3px; background: color-mix(in srgb, var(--muted) 25%, transparent); margin-top: .1rem; overflow: hidden; }
+  .lagbar > i { display: block; height: 100%; background: var(--ok); width: 100%; }
+  .lagbar.lag > i { background: var(--warn); }
+  .empty, .err { color: var(--muted); padding: 2rem; text-align: center; }
+  .err { color: var(--bad); }
+  footer { color: var(--muted); font-size: .74rem; text-align: center; padding: 1.5rem; }
+  .pulse { animation: p 1.2s ease-in-out infinite; }
+  @keyframes p { 50% { opacity: .4; } }
+</style>
+</head>
+<body>
+<header>
+  <h1>YantrikDB <span style="color:var(--accent)">Studio</span></h1>
+  <span class="sub">cluster console</span>
+  <span class="meta" id="meta">connecting…</span>
+</header>
+<div class="wrap">
+  <div id="view" class="grid"></div>
+  <div id="msg" class="empty">Loading cluster topology…</div>
+</div>
+<footer>Read-only cluster view · polls <code>/v1/cluster/topology</code> every 3s · identity &amp; config management coming with control-plane replication (RFC 029)</footer>
+<script>
+(function () {
+  const view = document.getElementById('view');
+  const msg = document.getElementById('msg');
+  const meta = document.getElementById('meta');
+  const roleClass = r => ({leader:'leader',follower:'follower',witness:'witness',candidate:'candidate',quarantined:'quarantined'}[r] || 'follower');
+  const num = v => (v === null || v === undefined) ? '—' : v;
+
+  function render(data) {
+    const nodes = (data && data.nodes) || [];
+    if (!data || data.raft_mode !== 'yrp') {
+      view.innerHTML = ''; msg.style.display = 'block';
+      msg.className = 'empty';
+      msg.textContent = 'This node is not running in cluster (yrp) mode — nothing to show.';
+      meta.textContent = 'mode: ' + ((data && data.raft_mode) || 'unknown');
+      return;
+    }
+    msg.style.display = nodes.length ? 'none' : 'block';
+    meta.textContent = `cluster ${num(data.cluster_id)} · ${nodes.length} member${nodes.length===1?'':'s'} · viewed from node ${num(data.viewed_from)}`;
+    view.innerHTML = nodes.map(n => {
+      const role = (n.role || (n.reachable ? 'unknown' : 'unreachable')) + '';
+      const rc = roleClass(role);
+      const reach = n.reachable !== false;
+      const healthy = n.healthy === true;
+      const dot = !reach ? 'bad' : (healthy ? 'ok' : 'warn');
+      const lag = (n.replication_lag == null) ? null : Number(n.replication_lag);
+      const lagPct = lag == null ? 0 : Math.max(0, Math.min(100, 100 - Math.min(lag, 100)));
+      return `<div class="card ${rc==='leader'?'leader':''} ${reach?'':'unreachable'}">
+        <div class="top">
+          <span class="node-id">node ${num(n.node_id)}</span>
+          <span class="badge ${rc}">${reach ? role : 'unreachable'}</span>
+          <span class="dot ${dot}" title="${reach ? (healthy?'healthy':'unhealthy') : 'unreachable'}"></span>
+        </div>
+        <div style="font-family:var(--mono);font-size:.72rem;color:var(--muted);word-break:break-all">${n.addr||''}${n.self?' · this node':''}</div>
+        <dl class="rows">
+          <dt>term</dt><dd>${num(n.term)}</dd>
+          <dt>leader</dt><dd>${num(n.leader)}</dd>
+          <dt>applied</dt><dd>${num(n.last_applied_index)}</dd>
+          <dt>lag</dt><dd>${lag==null?'—':lag}</dd>
+        </dl>
+        <div class="lagbar ${lag?'lag':''}"><i style="width:${lagPct}%"></i></div>
+      </div>`;
+    }).join('');
+  }
+
+  async function poll() {
+    try {
+      const r = await fetch('/v1/cluster/topology', { cache: 'no-store' });
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      render(await r.json());
+      meta.classList.remove('pulse');
+    } catch (e) {
+      meta.classList.add('pulse');
+      meta.textContent = 'reconnecting… (' + e.message + ')';
+      if (!view.children.length) { msg.className = 'err'; msg.style.display='block'; msg.textContent = 'Cannot reach the server.'; }
+    }
+  }
+  poll();
+  setInterval(poll, 3000);
+})();
+</script>
+</body>
+</html>

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -1162,6 +1162,92 @@ async fn yrp_backfill(
     })
 }
 
+/// Admin studio: aggregated cluster topology. Fans out to every YRP
+/// member's `/v1/health` (public, like this endpoint) and returns one
+/// array the dashboard renders. Own-node state is read directly; peers
+/// are fetched concurrently with a short timeout (unreachable peers are
+/// marked `reachable: false`). Read-only cluster metadata — no auth, same
+/// posture as `/v1/health`.
+async fn yrp_topology(State(state): State<Arc<AppState>>) -> Json<Value> {
+    let Some(yrp) = &state.yrp else {
+        return Json(json!({ "raft_mode": cluster_state_view(&state)
+            .map(|v| v.raft_mode).unwrap_or("disabled"), "nodes": [] }));
+    };
+    let self_id = yrp.node_id.0;
+    let peers = yrp.peer_urls();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+        .unwrap_or_default();
+
+    let fetches = peers.into_iter().map(|(id, url)| {
+        let client = client.clone();
+        let own = id == self_id;
+        // Own node: read the local view directly (no self-HTTP).
+        let local = if own {
+            cluster_state_view(&state)
+        } else {
+            None
+        };
+        async move {
+            if own {
+                let v = local;
+                json!({
+                    "node_id": id, "addr": url, "reachable": true, "self": true,
+                    "role": v.as_ref().map(|c| c.role_label).unwrap_or(Some("unknown")),
+                    "term": v.as_ref().map(|c| c.term),
+                    "leader": v.as_ref().and_then(|c| c.leader),
+                    "healthy": v.as_ref().map(|c| c.healthy),
+                    "last_applied_index": v.as_ref().and_then(|c| c.last_applied_index),
+                    "replication_lag": v.as_ref().and_then(|c| c.replication_lag_log_entries),
+                })
+            } else {
+                match client
+                    .get(format!("{}/v1/health", url.trim_end_matches('/')))
+                    .send()
+                    .await
+                {
+                    Ok(resp) => match resp.json::<Value>().await {
+                        Ok(h) => {
+                            let c = h.get("cluster").cloned().unwrap_or(json!({}));
+                            json!({
+                                "node_id": id, "addr": url, "reachable": true, "self": false,
+                                "role": c.get("role_label").or(c.get("role")),
+                                "term": c.get("term"),
+                                "leader": c.get("leader"),
+                                "healthy": c.get("healthy"),
+                                "last_applied_index": c.get("last_applied_index"),
+                                "replication_lag": c.get("replication_lag_log_entries"),
+                                "status": h.get("status"),
+                            })
+                        }
+                        Err(_) => {
+                            json!({ "node_id": id, "addr": url, "reachable": false, "self": false })
+                        }
+                    },
+                    Err(_) => {
+                        json!({ "node_id": id, "addr": url, "reachable": false, "self": false })
+                    }
+                }
+            }
+        }
+    });
+    let nodes: Vec<Value> = futures::future::join_all(fetches).await;
+    Json(json!({
+        "raft_mode": "yrp",
+        "cluster_id": yrp.cluster_id,
+        "viewed_from": self_id,
+        "nodes": nodes,
+    }))
+}
+
+/// Admin studio: a single self-contained page served from the binary at
+/// `/admin` — no build step, no external assets (works air-gapped). Polls
+/// `/v1/cluster/topology` and renders the live cluster. Theme-aware.
+async fn admin_studio() -> axum::response::Html<&'static str> {
+    axum::response::Html(include_str!("admin/studio.html"))
+}
+
 /// Issue #58: keyed `/v1/remember/batch` — the engine's atomic batch path.
 /// Claims + rows commit in one transaction; a key conflict fails the WHOLE
 /// batch (all-or-nothing), returning the same 200-conflict shape as the
@@ -4948,6 +5034,9 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/v1/yrp/msg", post(yrp_msg))
         // RFC 028 Phase C: engine backfill for beyond-GC stragglers
         .route("/v1/yrp/backfill", post(yrp_backfill))
+        // Admin studio: aggregated cluster topology + the embedded console
+        .route("/v1/cluster/topology", get(yrp_topology))
+        .route("/admin", get(admin_studio))
         .route("/v1/admin/control-snapshot", get(control_snapshot))
         .route("/v1/admin/snapshot", post(admin_snapshot))
         // RFC 027 / v0.8.24 — autonomous-maintenance operator surface.

--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -227,6 +227,38 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
         leader.state.yrp.as_ref().unwrap().quarantine_reasons(),
         None
     );
+
+    // Admin studio: /v1/cluster/topology aggregates BOTH members (fan-out
+    // to peers' /v1/health), and /admin serves the embedded console.
+    let topo: Value = client
+        .get(format!("{}/v1/cluster/topology", leader.base))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(topo["raft_mode"], json!("yrp"));
+    let nodes = topo["nodes"].as_array().expect("nodes array");
+    assert_eq!(nodes.len(), 2, "topology must list both members: {topo}");
+    assert!(
+        nodes.iter().any(|n| n["role"] == json!("leader")),
+        "topology must show a leader: {topo}"
+    );
+    assert!(
+        nodes.iter().all(|n| n["reachable"] == json!(true)),
+        "both members reachable: {topo}"
+    );
+    let admin = client
+        .get(format!("{}/admin", leader.base))
+        .send()
+        .await
+        .unwrap();
+    assert!(admin.status().is_success());
+    assert!(
+        admin.text().await.unwrap().contains("YantrikDB"),
+        "/admin must serve the studio page"
+    );
 }
 
 async fn spawn_node_on(node_id: u64, peers: Vec<YrpPeer>, port: u16) -> Node {

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -112,6 +112,15 @@ impl YrpHandle {
         self.quarantine.read().expect("quarantine lock").clone()
     }
 
+    /// All cluster members as `(node_id, http_base_url)`, including self —
+    /// used by the admin studio's topology aggregator.
+    pub fn peer_urls(&self) -> Vec<(u64, String)> {
+        self.peer_http
+            .iter()
+            .map(|(id, url)| (*id, url.clone()))
+            .collect()
+    }
+
     fn set_quarantine(&self, reasons: Option<Vec<String>>) {
         *self.quarantine.write().expect("quarantine lock") = reasons;
     }


### PR DESCRIPTION
First slice of the first-party **admin/dev studio** — the ops surface (distinct from wysie's community memory-*browser* dashboard, which is a data-plane console for a Hermes agent's memories).

## What ships
- **`GET /admin`** — a single self-contained page served from the binary: no build step, no external assets, works air-gapped, theme-aware (light/dark). It polls the topology endpoint and renders the live cluster.
- **`GET /v1/cluster/topology`** — server-side fan-out to every YRP member's `/v1/health` (own-node state read directly; peers concurrent with a 2s timeout; unreachable peers flagged), returning one array the dashboard renders. Read-only cluster metadata, same public posture as `/v1/health`.

The console shows, per node: role (leader highlighted), term, leader, applied index, replication lag, and health/reachability.

## Why
- **Enterprise:** an admin console is a procurement checkbox.
- **Distribution:** a live *cluster-health* console is a shareable proof-point — "self-hostable agent memory with a real cluster and a console to run it."

## Validation
Exercised in the 2-node HTTP cluster test: `/v1/cluster/topology` lists both members with correct roles + reachability, and `/admin` serves the page. Full suite green.

## Next
Identity/config management (create/revoke tokens, databases, scopes) lands on top of **control-plane replication (RFC 029)** so it's cluster-meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
