### PR TITLE
feat(yrp): RFC 029 — replicated control plane (tokens/databases survive failover)

### DIFF
--- a/crates/yantrikdb-server/src/control.rs
+++ b/crates/yantrikdb-server/src/control.rs
@@ -250,6 +250,75 @@ impl ControlDb {
         Ok(count as usize)
     }
 
+    // ── RFC 029: control-op apply (replicated control plane) ───────
+    //
+    // These are the deterministic apply primitives the YRP `ControlApplySink`
+    // calls when a `Payload::Control` entry commits. Ids and timestamps are
+    // **leader-assigned** and carried in the op, so every node writes the
+    // identical row; apply is **idempotent on the natural key** so replaying
+    // an already-durable index is a no-op.
+
+    /// The next database id the leader will assign (`MAX(id)+1`). RFC 029:
+    /// the leader allocates ids under a serializing lock so every node
+    /// inserts the same one (local AUTOINCREMENT would diverge across nodes).
+    pub fn next_database_id(&self) -> anyhow::Result<i64> {
+        let n: i64 =
+            self.conn
+                .query_row("SELECT COALESCE(MAX(id), 0) + 1 FROM databases", [], |r| {
+                    r.get(0)
+                })?;
+        Ok(n)
+    }
+
+    /// Apply a replicated database create: explicit leader-assigned id,
+    /// idempotent on both the id PK and the name UNIQUE index. Returns
+    /// `true` if a row was inserted, `false` if it already existed
+    /// (crash-replay). A `false` is NOT an error — the natural key already
+    /// holds the leader's value.
+    pub fn apply_create_database(
+        &self,
+        id: i64,
+        name: &str,
+        path: &str,
+        config: &str,
+        created_at: &str,
+    ) -> anyhow::Result<bool> {
+        let changed = self.conn.execute(
+            "INSERT OR IGNORE INTO databases (id, name, path, config, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![id, name, path, config, created_at],
+        )?;
+        Ok(changed > 0)
+    }
+
+    /// Apply a replicated token create: register a token hash idempotently
+    /// (the `hash` PK dedupes crash-replay). Verifier material only — the
+    /// plaintext token never reaches this layer (RFC 029 Invariant 3).
+    pub fn apply_create_token(
+        &self,
+        hash: &str,
+        database_id: i64,
+        label: &str,
+        created_at: &str,
+    ) -> anyhow::Result<bool> {
+        let changed = self.conn.execute(
+            "INSERT OR IGNORE INTO tokens (hash, database_id, label, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![hash, database_id, label, created_at],
+        )?;
+        Ok(changed > 0)
+    }
+
+    /// Apply a replicated token revoke at a leader-supplied timestamp.
+    /// Idempotent: only the first revoke sets `revoked_at`.
+    pub fn apply_revoke_token(&self, hash: &str, revoked_at: &str) -> anyhow::Result<bool> {
+        let changed = self.conn.execute(
+            "UPDATE tokens SET revoked_at = ?2 WHERE hash = ?1 AND revoked_at IS NULL",
+            params![hash, revoked_at],
+        )?;
+        Ok(changed > 0)
+    }
+
     // ── Control Plane Replication ──────────────────────────────────
 
     /// Export a full snapshot of databases + active tokens for replication.

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -2618,6 +2618,20 @@ fn control_propose_err(e: crate::yrp::runtime::YrpProposeError) -> AppError {
     }
 }
 
+/// Map a replicated control-write failure (RFC 029) to an HTTP response:
+/// duplicate → 409, redirect/timeout → via [`control_propose_err`],
+/// divergence/internal → 500 (fail closed — never report success for a
+/// write that did not take effect).
+fn control_write_err(e: crate::yrp::runtime::ControlWriteError) -> AppError {
+    use crate::yrp::runtime::ControlWriteError as E;
+    match e {
+        E::AlreadyExists => app_error(StatusCode::CONFLICT, "database name already exists"),
+        E::Propose(p) => control_propose_err(p),
+        E::Diverged(m) => app_error(StatusCode::INTERNAL_SERVER_ERROR, m),
+        E::Internal(m) => app_error(StatusCode::INTERNAL_SERVER_ERROR, m),
+    }
+}
+
 /// POST /v1/admin/databases — create a database as a replicated control op
 /// (RFC 029). Body: `{"name": "...", "path"?: "...", "config"?: {...}}`.
 /// Master-token gated. Returns `{"id", "name", "replicated"}`. In yrp mode
@@ -2649,7 +2663,7 @@ async fn admin_create_database(
         let id = yrp
             .create_database_replicated(&name, &path, &config, created_at)
             .await
-            .map_err(control_propose_err)?;
+            .map_err(control_write_err)?;
         Ok(Json(json!({ "id": id, "name": name, "replicated": true })))
     } else {
         let id = tokio::task::spawn_blocking({
@@ -2694,6 +2708,24 @@ async fn admin_create_token(
             "provide 'database_id' or 'database'",
         ));
     };
+    // Validate the target database EXISTS before proposing (review F3): a
+    // CreateToken for a nonexistent db FK-fails at apply, and apply errors
+    // fail-stop the worker on EVERY node — one bad id would wedge the whole
+    // cluster. Reject here instead.
+    let db_present = tokio::task::spawn_blocking({
+        let control = state.control.clone();
+        move || control.lock().get_database_by_id(db_id)
+    })
+    .await
+    .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+    .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+    .is_some();
+    if !db_present {
+        return Err(app_error(
+            StatusCode::NOT_FOUND,
+            format!("database_id {db_id} does not exist"),
+        ));
+    }
     let label = body
         .get("label")
         .and_then(|v| v.as_str())
@@ -2704,15 +2736,9 @@ async fn admin_create_token(
     let hash = crate::auth::hash_token(&raw);
 
     if let Some(yrp) = &state.yrp {
-        let op = crate::yrp::control_op::ControlOp::CreateToken {
-            db_id,
-            token_hash: hash,
-            label,
-            created_at: chrono::Utc::now().to_rfc3339(),
-        };
-        yrp.propose_control(&op)
+        yrp.create_token_replicated(db_id, hash, label, chrono::Utc::now().to_rfc3339())
             .await
-            .map_err(control_propose_err)?;
+            .map_err(control_write_err)?;
         Ok(Json(
             json!({ "token": raw, "database_id": db_id, "replicated": true }),
         ))
@@ -2753,13 +2779,9 @@ async fn admin_revoke_token(
     };
 
     if let Some(yrp) = &state.yrp {
-        let op = crate::yrp::control_op::ControlOp::RevokeToken {
-            token_hash: hash,
-            revoked_at: chrono::Utc::now().to_rfc3339(),
-        };
-        yrp.propose_control(&op)
+        yrp.revoke_token_replicated(hash, chrono::Utc::now().to_rfc3339())
             .await
-            .map_err(control_propose_err)?;
+            .map_err(control_write_err)?;
         Ok(Json(json!({ "revoked": true, "replicated": true })))
     } else {
         let revoked = tokio::task::spawn_blocking({

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -2593,6 +2593,186 @@ async fn list_databases(
     Ok(Json(json!({ "databases": list })))
 }
 
+/// Map a control-plane propose failure (RFC 029) to an HTTP response. A
+/// follower answers 503 with the leader's address so the caller (studio or
+/// operator CLI) redirects the admin write to the leader — the same posture
+/// as a data-plane write against a follower.
+fn control_propose_err(e: crate::yrp::runtime::YrpProposeError) -> AppError {
+    use crate::yrp::runtime::YrpProposeError as E;
+    match e {
+        E::NotLeader { leader_addr, .. } => app_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!(
+                "not the leader; retry this admin write against the leader{}",
+                leader_addr.map(|a| format!(" at {a}")).unwrap_or_default()
+            ),
+        ),
+        E::Timeout => app_error(
+            StatusCode::GATEWAY_TIMEOUT,
+            "control op timed out awaiting quorum",
+        ),
+        E::Unavailable(m) => app_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("control plane unavailable: {m}"),
+        ),
+    }
+}
+
+/// POST /v1/admin/databases — create a database as a replicated control op
+/// (RFC 029). Body: `{"name": "...", "path"?: "...", "config"?: {...}}`.
+/// Master-token gated. Returns `{"id", "name", "replicated"}`. In yrp mode
+/// the create is committed through YRP and applied on every node; in
+/// single-node mode it writes `control.db` directly.
+async fn admin_create_database(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<Value>,
+) -> AppResult {
+    require_master_token(&state, &headers)?;
+    let name = body
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'name'"))?
+        .to_string();
+    let path = body
+        .get("path")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&name)
+        .to_string();
+    let config = body
+        .get("config")
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "{}".to_string());
+
+    if let Some(yrp) = &state.yrp {
+        let created_at = chrono::Utc::now().to_rfc3339();
+        let id = yrp
+            .create_database_replicated(&name, &path, &config, created_at)
+            .await
+            .map_err(control_propose_err)?;
+        Ok(Json(json!({ "id": id, "name": name, "replicated": true })))
+    } else {
+        let id = tokio::task::spawn_blocking({
+            let control = state.control.clone();
+            let (name, path) = (name.clone(), path.clone());
+            move || control.lock().create_database(&name, &path)
+        })
+        .await
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        Ok(Json(json!({ "id": id, "name": name, "replicated": false })))
+    }
+}
+
+/// POST /v1/admin/tokens — mint a token for a database, replicated (RFC
+/// 029). Body: `{"database_id": N}` or `{"database": "name"}`, optional
+/// `"label"`. Master-token gated. Returns `{"token"}` — the plaintext is
+/// shown ONCE and never stored; only its SHA-256 hash is replicated
+/// (Invariant 3).
+async fn admin_create_token(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<Value>,
+) -> AppResult {
+    require_master_token(&state, &headers)?;
+    let db_id = if let Some(id) = body.get("database_id").and_then(|v| v.as_i64()) {
+        id
+    } else if let Some(dbname) = body.get("database").and_then(|v| v.as_str()) {
+        let rec = tokio::task::spawn_blocking({
+            let control = state.control.clone();
+            let dbname = dbname.to_string();
+            move || control.lock().get_database(&dbname)
+        })
+        .await
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        rec.ok_or_else(|| app_error(StatusCode::NOT_FOUND, format!("no database '{dbname}'")))?
+            .id
+    } else {
+        return Err(app_error(
+            StatusCode::BAD_REQUEST,
+            "provide 'database_id' or 'database'",
+        ));
+    };
+    let label = body
+        .get("label")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let raw = crate::auth::generate_token();
+    let hash = crate::auth::hash_token(&raw);
+
+    if let Some(yrp) = &state.yrp {
+        let op = crate::yrp::control_op::ControlOp::CreateToken {
+            db_id,
+            token_hash: hash,
+            label,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        };
+        yrp.propose_control(&op)
+            .await
+            .map_err(control_propose_err)?;
+        Ok(Json(
+            json!({ "token": raw, "database_id": db_id, "replicated": true }),
+        ))
+    } else {
+        tokio::task::spawn_blocking({
+            let control = state.control.clone();
+            move || control.lock().create_token(&hash, db_id, &label)
+        })
+        .await
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        Ok(Json(
+            json!({ "token": raw, "database_id": db_id, "replicated": false }),
+        ))
+    }
+}
+
+/// POST /v1/admin/tokens/revoke — revoke a token, replicated (RFC 029).
+/// Body: `{"token": "ydb_..."}` or `{"hash": "..."}`. Master-token gated.
+/// Because revocation replicates, a token revoked on the leader is refused
+/// cluster-wide (the auth-read barrier that makes this instantaneous on
+/// every node lands in RFC 029 increment 2).
+async fn admin_revoke_token(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<Value>,
+) -> AppResult {
+    require_master_token(&state, &headers)?;
+    let hash = if let Some(t) = body.get("token").and_then(|v| v.as_str()) {
+        crate::auth::hash_token(t)
+    } else if let Some(h) = body.get("hash").and_then(|v| v.as_str()) {
+        h.to_string()
+    } else {
+        return Err(app_error(
+            StatusCode::BAD_REQUEST,
+            "provide 'token' or 'hash'",
+        ));
+    };
+
+    if let Some(yrp) = &state.yrp {
+        let op = crate::yrp::control_op::ControlOp::RevokeToken {
+            token_hash: hash,
+            revoked_at: chrono::Utc::now().to_rfc3339(),
+        };
+        yrp.propose_control(&op)
+            .await
+            .map_err(control_propose_err)?;
+        Ok(Json(json!({ "revoked": true, "replicated": true })))
+    } else {
+        let revoked = tokio::task::spawn_blocking({
+            let control = state.control.clone();
+            move || control.lock().revoke_token(&hash)
+        })
+        .await
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        Ok(Json(json!({ "revoked": revoked, "replicated": false })))
+    }
+}
+
 /// GET /v1/admin/control-snapshot — returns a full snapshot of the control
 /// plane (databases + active tokens) for replication to followers.
 ///
@@ -3017,12 +3197,22 @@ fn require_master_token(state: &AppState, headers: &axum::http::HeaderMap) -> Re
             }
         }
     }
+    // In yrp mode the master/bootstrap secret lives on the YRP handle
+    // (`state.cluster` may be `None`) — accept it there too. This is the
+    // RFC 029 bootstrap-admin credential.
+    if let Some(ref yrp) = state.yrp {
+        if let Some(ref secret) = yrp.cluster_secret {
+            if token == secret.as_str() {
+                return Ok(());
+            }
+        }
+    }
     // Single-node mode without a configured cluster secret: deny outright.
     // Safer than auto-allowing any valid bearer; debug endpoints SHOULD
     // require explicit operator opt-in via cluster_secret.
     Err(app_error(
         StatusCode::FORBIDDEN,
-        "debug endpoints require the cluster master token",
+        "control-plane admin requires the cluster master token",
     ))
 }
 
@@ -5038,6 +5228,12 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/v1/cluster/topology", get(yrp_topology))
         .route("/admin", get(admin_studio))
         .route("/v1/admin/control-snapshot", get(control_snapshot))
+        // RFC 029: replicated control-plane admin (master-token gated).
+        // Databases + tokens minted here commit through YRP and apply on
+        // every node, so identity survives failover.
+        .route("/v1/admin/databases", post(admin_create_database))
+        .route("/v1/admin/tokens", post(admin_create_token))
+        .route("/v1/admin/tokens/revoke", post(admin_revoke_token))
         .route("/v1/admin/snapshot", post(admin_snapshot))
         // RFC 027 / v0.8.24 — autonomous-maintenance operator surface.
         .route("/v1/admin/maintenance/run", post(admin_maintenance_run))

--- a/crates/yantrikdb-server/src/main.rs
+++ b/crates/yantrikdb-server/src/main.rs
@@ -1826,8 +1826,13 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
                     compact_after_entries: cfg.yrp.compact_after_entries,
                     leader_retain_entries: cfg.yrp.leader_retain_entries,
                 };
-                let handle = crate::yrp::runtime::spawn(runtime_cfg, local.clone(), applier)
-                    .map_err(|e| anyhow::anyhow!("YRP assembly failed: {e}"))?;
+                let handle = crate::yrp::runtime::spawn(
+                    runtime_cfg,
+                    local.clone(),
+                    applier,
+                    control.clone(),
+                )
+                .map_err(|e| anyhow::anyhow!("YRP assembly failed: {e}"))?;
                 tracing::info!(
                     node_id = cfg.cluster.node_id,
                     cluster_id = cfg.yrp.cluster_id,

--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -259,6 +259,84 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
         admin.text().await.unwrap().contains("YantrikDB"),
         "/admin must serve the studio page"
     );
+
+    // ── RFC 029: control-plane replication ──────────────────────────
+    // A database + token minted on the LEADER via the replicated admin
+    // endpoints (master-token gated) must materialize on the FOLLOWER's
+    // control.db — closing the exact gap (per-node tokens don't survive
+    // failover) that made an enterprise cluster undeployable.
+    let (st, resp) = post_json(
+        &leader.base,
+        SECRET,
+        "/v1/admin/databases",
+        &json!({ "name": "rfc029db" }),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::OK, "admin create db: {resp}");
+    assert_eq!(resp["replicated"], json!(true), "must replicate: {resp}");
+    let db_id = resp["id"].as_i64().expect("db id");
+
+    let (st, resp) = post_json(
+        &leader.base,
+        SECRET,
+        "/v1/admin/tokens",
+        &json!({ "database_id": db_id }),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::OK, "admin mint token: {resp}");
+    let minted = resp["token"].as_str().expect("token").to_string();
+    let minted_hash = crate::auth::hash_token(&minted);
+
+    // The FOLLOWER's control.db resolves the replicated token to the same
+    // database id — i.e. `ControlDbAuthProvider` on the follower will now
+    // authenticate a token minted on the leader (the auth path IS
+    // `validate_token`). This is the headline RFC 029 guarantee.
+    let poll_follower_token = |want: Option<i64>| {
+        let follower_control = follower.state.control.clone();
+        let hash = minted_hash.clone();
+        async move {
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+            loop {
+                let got = follower_control.lock().validate_token(&hash).unwrap();
+                if got == want {
+                    return;
+                }
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "follower control.db never converged: got {got:?}, want {want:?}"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+    };
+    poll_follower_token(Some(db_id)).await;
+
+    // Control writes funnel through the leader: a control write against the
+    // FOLLOWER is refused (leader redirect), exactly like a data write.
+    let (st, _) = post_json(
+        &follower.base,
+        SECRET,
+        "/v1/admin/databases",
+        &json!({ "name": "should-redirect" }),
+    )
+    .await;
+    assert_eq!(
+        st,
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "follower must redirect control writes to the leader"
+    );
+
+    // Revocation replicates too: revoke on the leader → the follower stops
+    // resolving the token.
+    let (st, _) = post_json(
+        &leader.base,
+        SECRET,
+        "/v1/admin/tokens/revoke",
+        &json!({ "token": minted }),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::OK, "admin revoke");
+    poll_follower_token(None).await;
 }
 
 async fn spawn_node_on(node_id: u64, peers: Vec<YrpPeer>, port: u16) -> Node {
@@ -338,6 +416,7 @@ async fn spawn_node_inner(node_id: u64, peers: Vec<YrpPeer>, port: u16) -> Node 
         },
         local.clone(),
         applier,
+        control.clone(),
     )
     .expect("yrp spawn");
     let commit_log: Arc<dyn crate::commit::MutationCommitter> =

--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -337,6 +337,50 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
     .await;
     assert_eq!(st, reqwest::StatusCode::OK, "admin revoke");
     poll_follower_token(None).await;
+
+    // Hardening (review F2): a duplicate database name is a 409, not a
+    // phantom-id success.
+    let (st, _) = post_json(
+        &leader.base,
+        SECRET,
+        "/v1/admin/databases",
+        &json!({ "name": "rfc029db" }),
+    )
+    .await;
+    assert_eq!(
+        st,
+        reqwest::StatusCode::CONFLICT,
+        "duplicate db name must 409, not return a phantom id"
+    );
+
+    // Hardening (review F3): a token mint against a nonexistent database_id
+    // is rejected at the handler — it must NEVER reach apply (an FK failure
+    // there would fail-stop the apply worker on every node).
+    let (st, _) = post_json(
+        &leader.base,
+        SECRET,
+        "/v1/admin/tokens",
+        &json!({ "database_id": 999_999 }),
+    )
+    .await;
+    assert_eq!(
+        st,
+        reqwest::StatusCode::NOT_FOUND,
+        "token mint for a bogus db id must be refused, not wedge the cluster"
+    );
+    // Prove the cluster is still healthy after the rejected bad-id mint —
+    // apply did not fail-stop; a normal write still replicates.
+    let body_after = json!({
+        "text": "post-hardening write still replicates",
+        "embedding": emb2,
+        "idempotency_key": "yrp-e2e-key-after",
+    });
+    let (st, resp) = post_json(&leader.base, &leader.token, "/v1/remember", &body_after).await;
+    assert_eq!(
+        st,
+        reqwest::StatusCode::OK,
+        "cluster must still accept writes after a rejected bad mint: {resp}"
+    );
 }
 
 async fn spawn_node_on(node_id: u64, peers: Vec<YrpPeer>, port: u16) -> Node {

--- a/crates/yantrikdb-server/src/yrp/control_op.rs
+++ b/crates/yantrikdb-server/src/yrp/control_op.rs
@@ -1,0 +1,207 @@
+//! RFC 029 — control-plane replication grammar + apply.
+//!
+//! Control mutations (create database / mint token / revoke token) ride the
+//! **same** YRP log as data ops, as [`super::replica::Payload::Control`]
+//! entries, and are applied to every node's `control.db` by
+//! [`ControlApplySink`]. The per-node `control.db` thus becomes the
+//! *materialized state of the replicated control log*: a token minted on the
+//! leader exists on every follower and survives failover — closing the #1
+//! enterprise-grade blocker (RFC 029 §The gap).
+//!
+//! ## Determinism + idempotency
+//!
+//! - **`db_id` is leader-assigned** and carried in the op, so every node
+//!   inserts the identical id (per-node AUTOINCREMENT would diverge). Mirrors
+//!   [`crate::control::ControlDb::import_snapshot`]'s explicit-id insert.
+//! - **Timestamps are leader-assigned** (RFC-3339 strings in the op) so every
+//!   node stores the same `created_at`/`revoked_at` — never `datetime('now')`
+//!   at apply, which would differ per node.
+//! - Apply is **idempotent on the natural key** (`databases.id`/name,
+//!   `tokens.hash`) via `INSERT OR IGNORE`, so crash-replay of an
+//!   already-durable index is a no-op — no separate op-id table needed.
+//! - **Verifier material only**: `CreateToken` carries the SHA-256 token
+//!   *hash*, never the plaintext (RFC 029 Invariant 3).
+//!
+//! ## Fail-stop
+//!
+//! A control apply error is returned as `Err` from the sink, which the apply
+//! worker treats as fail-stop — the node stops applying (data too) and an
+//! operator intervenes, rather than serving possibly-stale authorization
+//! (RFC 029 Invariant 2). Because control and data share one apply marker, a
+//! node is either caught up on the whole log or not; there is no independent
+//! "control lag" to reason about.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+
+use crate::control::ControlDb;
+
+/// A replicated control-plane mutation. serde_json-encoded into
+/// `Payload::Control` (serde_json, not bincode — the grammar is small and
+/// human-auditable, matching the data-plane [`super::op::YrpOp`] choice).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ControlOp {
+    /// Create a database/tenant. `db_id` is leader-assigned (module docs).
+    CreateDatabase {
+        db_id: i64,
+        name: String,
+        path: String,
+        /// Serialized JSON config; `"{}"` when unset.
+        config: String,
+        /// Leader RFC-3339 timestamp, replicated so all nodes agree.
+        created_at: String,
+    },
+    /// Register a token by its SHA-256 hash (never plaintext).
+    CreateToken {
+        db_id: i64,
+        token_hash: String,
+        label: String,
+        created_at: String,
+    },
+    /// Revoke a token by hash.
+    RevokeToken {
+        token_hash: String,
+        revoked_at: String,
+    },
+}
+
+impl ControlOp {
+    pub fn encode(&self) -> Result<Vec<u8>, String> {
+        serde_json::to_vec(self).map_err(|e| format!("encode ControlOp: {e}"))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, String> {
+        serde_json::from_slice(bytes).map_err(|e| format!("decode ControlOp: {e}"))
+    }
+
+    /// The protocol-level claim key for exactly-once proposal, derived from
+    /// the op's natural identity. Prefixed (`ctl:*`) so it lives in a
+    /// disjoint region of the same u64 claim space the data plane uses for
+    /// idempotency keys — a retried `CreateToken`/`RevokeToken` dedupes
+    /// against the original entry rather than double-applying.
+    pub fn claim_key(&self) -> u64 {
+        let mut buf = Vec::new();
+        match self {
+            ControlOp::CreateDatabase { db_id, name, .. } => {
+                buf.extend_from_slice(b"ctl:createdb:");
+                buf.extend_from_slice(&db_id.to_le_bytes());
+                buf.extend_from_slice(name.as_bytes());
+            }
+            ControlOp::CreateToken { token_hash, .. } => {
+                buf.extend_from_slice(b"ctl:createtok:");
+                buf.extend_from_slice(token_hash.as_bytes());
+            }
+            ControlOp::RevokeToken { token_hash, .. } => {
+                buf.extend_from_slice(b"ctl:revoketok:");
+                buf.extend_from_slice(token_hash.as_bytes());
+            }
+        }
+        super::op::fnv1a64(&buf)
+    }
+}
+
+/// Applies replicated [`ControlOp`]s to the node's `control.db`. Held by the
+/// data-plane apply pipeline ([`super::engine_sink::EngineApplySink`]) and
+/// invoked on every committed `Payload::Control` entry, in log order, on
+/// every node. A control apply error is surfaced as `Err` (fail-stop).
+pub struct ControlApplySink {
+    control: Arc<Mutex<ControlDb>>,
+}
+
+impl ControlApplySink {
+    pub fn new(control: Arc<Mutex<ControlDb>>) -> Self {
+        Self { control }
+    }
+
+    /// Apply one control op to `control.db`. Idempotent (safe to replay).
+    pub fn apply(&self, op: &ControlOp) -> Result<(), String> {
+        let db = self.control.lock();
+        match op {
+            ControlOp::CreateDatabase {
+                db_id,
+                name,
+                path,
+                config,
+                created_at,
+            } => db
+                .apply_create_database(*db_id, name, path, config, created_at)
+                .map(|_| ())
+                .map_err(|e| format!("control apply CreateDatabase({name}): {e}")),
+            ControlOp::CreateToken {
+                db_id,
+                token_hash,
+                label,
+                created_at,
+            } => db
+                .apply_create_token(token_hash, *db_id, label, created_at)
+                .map(|_| ())
+                .map_err(|e| format!("control apply CreateToken(db={db_id}): {e}")),
+            ControlOp::RevokeToken {
+                token_hash,
+                revoked_at,
+            } => db
+                .apply_revoke_token(token_hash, revoked_at)
+                .map(|_| ())
+                .map_err(|e| format!("control apply RevokeToken: {e}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn control_op_round_trips() {
+        let op = ControlOp::CreateToken {
+            db_id: 7,
+            token_hash: "abc123".into(),
+            label: "svc".into(),
+            created_at: "2026-07-27T00:00:00Z".into(),
+        };
+        let bytes = op.encode().unwrap();
+        assert_eq!(ControlOp::decode(&bytes).unwrap(), op);
+    }
+
+    #[test]
+    fn claim_keys_are_distinct_per_identity() {
+        let a = ControlOp::CreateToken {
+            db_id: 1,
+            token_hash: "h1".into(),
+            label: String::new(),
+            created_at: String::new(),
+        };
+        let b = ControlOp::RevokeToken {
+            token_hash: "h1".into(),
+            revoked_at: String::new(),
+        };
+        // Same hash, different op kind → different claim key (create vs
+        // revoke must not dedupe against each other).
+        assert_ne!(a.claim_key(), b.claim_key());
+    }
+
+    #[test]
+    fn apply_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = ControlDb::open(&tmp.path().join("control.db")).unwrap();
+        let id = db.next_database_id().unwrap();
+        db.apply_create_database(id, "acme", "/dev/null", "{}", "2026-07-27T00:00:00Z")
+            .unwrap();
+        let sink = ControlApplySink::new(Arc::new(Mutex::new(db)));
+        let tok = ControlOp::CreateToken {
+            db_id: id,
+            token_hash: "deadbeef".into(),
+            label: "t".into(),
+            created_at: "2026-07-27T00:00:00Z".into(),
+        };
+        // Apply twice — the second is a no-op, not an error.
+        sink.apply(&tok).unwrap();
+        sink.apply(&tok).unwrap();
+        assert_eq!(
+            sink.control.lock().validate_token("deadbeef").unwrap(),
+            Some(id)
+        );
+    }
+}

--- a/crates/yantrikdb-server/src/yrp/engine_sink.rs
+++ b/crates/yantrikdb-server/src/yrp/engine_sink.rs
@@ -267,6 +267,10 @@ pub struct EngineApplySink {
     committer: Arc<dyn MutationCommitter>,
     applier: Arc<dyn Applier>,
     outcomes: Arc<OutcomeStore>,
+    /// RFC 029: applies `Payload::Control` entries to `control.db`. `None`
+    /// on the pure data-plane wiring (tests); `Some` in the production
+    /// runtime, where control ops ride the same log + apply marker.
+    control: Option<Arc<super::control_op::ControlApplySink>>,
 }
 
 impl EngineApplySink {
@@ -279,7 +283,16 @@ impl EngineApplySink {
             committer,
             applier,
             outcomes,
+            control: None,
         }
+    }
+
+    /// Attach the RFC 029 control-plane sink so committed `Payload::Control`
+    /// entries are applied to `control.db`. Without it, a control entry is a
+    /// fail-stop (a control op reached a node with no control sink wired).
+    pub fn with_control(mut self, control: Arc<super::control_op::ControlApplySink>) -> Self {
+        self.control = Some(control);
+        self
     }
 }
 
@@ -296,6 +309,19 @@ impl ApplySink for EngineApplySink {
                 return Err(format!(
                     "Test payload {n} reached production sink at {index}"
                 ))
+            }
+            // RFC 029: control-plane op — apply to control.db, then advance
+            // the shared marker. Idempotent apply; an Err fail-stops the
+            // whole worker (Invariant 2: never serve stale authorization).
+            Payload::Control(b) => {
+                let op = super::control_op::ControlOp::decode(b)?;
+                self.control
+                    .as_ref()
+                    .ok_or_else(|| {
+                        format!("Payload::Control at {index} but no control sink wired")
+                    })?
+                    .apply(&op)?;
+                return self.outcomes.advance(index);
             }
             Payload::Op(b) => b,
         };

--- a/crates/yantrikdb-server/src/yrp/mod.rs
+++ b/crates/yantrikdb-server/src/yrp/mod.rs
@@ -28,6 +28,7 @@
 //!    index)` election freshness, never a watermark.
 
 pub mod bootstrap;
+pub mod control_op;
 pub mod driver;
 pub mod engine_sink;
 pub mod op;

--- a/crates/yantrikdb-server/src/yrp/replica.rs
+++ b/crates/yantrikdb-server/src/yrp/replica.rs
@@ -74,6 +74,15 @@ pub enum Payload {
     /// a retry answered from the claims table recovers its outcome from
     /// the entry itself.
     Op(Vec<u8>),
+    /// A serialized control-plane mutation (`super::control_op::ControlOp`,
+    /// RFC 029) applied to `control.db` on every node — the replicated
+    /// identity/authorization plane (tokens, databases). A *distinct*
+    /// variant rather than a re-wrapping of [`Op`], so a mixed-version
+    /// cluster keeps replicating **data** ops unchanged; only nodes that
+    /// understand control ops are ever sent them (the operator upgrades
+    /// every node before the first replicated control op is minted —
+    /// RFC 029 bootstrap).
+    Control(Vec<u8>),
 }
 
 /// Test-only ergonomic comparison against the sim's numeric payloads:

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -101,6 +101,13 @@ pub struct YrpHandle {
     /// Local commit log — the retained source of truth the backfill serve
     /// path joins against the outcome store (RFC 028 Phase C).
     local: Arc<dyn MutationCommitter>,
+    /// The node's control.db (RFC 029): read to allocate leader-assigned
+    /// database ids before proposing a `CreateDatabase` control op.
+    control: Arc<parking_lot::Mutex<crate::control::ControlDb>>,
+    /// Serializes control-plane database creates so two concurrent creates
+    /// on the leader never allocate the same id (RFC 029). Held across
+    /// allocate → propose → apply, so create N+1 sees create N's row.
+    control_propose_lock: tokio::sync::Mutex<()>,
     /// `Some(reasons)` while quarantined (or after a fatal driver exit);
     /// `None` when replicating normally. The health surface reports it;
     /// the write path refuses on it.
@@ -297,6 +304,85 @@ impl YrpHandle {
         self.wait_outcome(index).await
     }
 
+    /// Propose a control-plane op (RFC 029) and wait until it is durably
+    /// applied on this node. Returns the applied YRP index. Maps
+    /// `NotLeader`/`Timeout` exactly like [`propose_and_wait`]; control ops
+    /// write no outcome row, so it waits on the shared apply marker directly
+    /// (the marker crossing `index` IS the durability + apply signal). A
+    /// retried op with the same natural identity dedupes via its claim key
+    /// and resolves to the original entry's index.
+    pub async fn propose_control(
+        &self,
+        op: &super::control_op::ControlOp,
+    ) -> Result<u64, YrpProposeError> {
+        if let Some(reasons) = self.quarantine_reasons() {
+            return Err(YrpProposeError::Unavailable(format!(
+                "node quarantined: {reasons:?}"
+            )));
+        }
+        let bytes = op.encode().map_err(YrpProposeError::Unavailable)?;
+        let (tx, rx) = oneshot::channel();
+        self.owner_tx
+            .send(DriverEvent::Propose {
+                key: op.claim_key(),
+                payload: Payload::Control(bytes),
+                reply: tx,
+            })
+            .map_err(|_| YrpProposeError::Unavailable("YRP driver not running".into()))?;
+        let outcome = tokio::time::timeout(PROPOSE_TIMEOUT, rx)
+            .await
+            .map_err(|_| YrpProposeError::Timeout)?
+            .map_err(|_| YrpProposeError::Unavailable("YRP driver dropped reply".into()))?;
+        let index = match outcome {
+            ProposeOutcome::Applied { index } | ProposeOutcome::Duplicate { index } => index,
+            ProposeOutcome::Retry => {
+                let (leader_id, leader_addr) = self.leader_hint();
+                return Err(YrpProposeError::NotLeader {
+                    leader_id,
+                    leader_addr,
+                });
+            }
+        };
+        let deadline = tokio::time::Instant::now() + PROPOSE_TIMEOUT;
+        while self.outcomes.applied() < index {
+            if tokio::time::Instant::now() >= deadline {
+                return Err(YrpProposeError::Timeout);
+            }
+            tokio::time::sleep(OUTCOME_POLL).await;
+        }
+        Ok(index)
+    }
+
+    /// Create a database as a replicated control op (RFC 029). Allocates a
+    /// leader-assigned id under a serializing lock — held across the propose
+    /// and apply so a concurrent create sees this one's row and picks the
+    /// next id — then returns the id once every node will apply the same one.
+    /// Errors map like [`propose_control`]: a follower answers `NotLeader`
+    /// with the leader's address for redirect.
+    pub async fn create_database_replicated(
+        &self,
+        name: &str,
+        path: &str,
+        config: &str,
+        created_at: String,
+    ) -> Result<i64, YrpProposeError> {
+        let _guard = self.control_propose_lock.lock().await;
+        let db_id = self
+            .control
+            .lock()
+            .next_database_id()
+            .map_err(|e| YrpProposeError::Unavailable(format!("allocate db id: {e}")))?;
+        let op = super::control_op::ControlOp::CreateDatabase {
+            db_id,
+            name: name.to_string(),
+            path: path.to_string(),
+            config: config.to_string(),
+            created_at,
+        };
+        self.propose_control(&op).await?;
+        Ok(db_id)
+    }
+
     /// Wait for the durable-apply marker to cover `index`, then read its
     /// outcome. (An `Applied` reply already implies coverage; `Duplicate`
     /// may race a lagging apply worker — poll briefly.)
@@ -324,6 +410,7 @@ pub fn spawn(
     cfg: YrpRuntimeConfig,
     local: Arc<dyn MutationCommitter>,
     applier: Arc<dyn Applier>,
+    control: Arc<parking_lot::Mutex<crate::control::ControlDb>>,
 ) -> Result<Arc<YrpHandle>, String> {
     if cfg.cluster_id == 0 {
         return Err("[yrp] cluster_id must be non-zero".into());
@@ -453,6 +540,8 @@ pub fn spawn(
         peer_http,
         cluster_secret: cfg.cluster_secret.clone(),
         local: local.clone(),
+        control: control.clone(),
+        control_propose_lock: tokio::sync::Mutex::new(()),
         quarantine: std::sync::RwLock::new(None),
     });
 
@@ -461,7 +550,8 @@ pub fn spawn(
     // `status.backfill_target > applied`.
     tokio::spawn(run_backfill_task(handle.clone(), owner_tx.clone()));
 
-    let sink = EngineApplySink::new(local, applier, outcomes.clone());
+    let control_sink = Arc::new(super::control_op::ControlApplySink::new(control));
+    let sink = EngineApplySink::new(local, applier, outcomes.clone()).with_control(control_sink);
     tokio::spawn(run_apply_worker(Box::new(sink), apply_rx, owner_tx.clone()));
     spawn_ticker(owner_tx.clone(), Duration::from_millis(cfg.tick_ms.max(1)));
 

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -88,6 +88,24 @@ pub enum YrpProposeError {
     Unavailable(String),
 }
 
+/// Failures of a replicated control-plane write (RFC 029), richer than a
+/// bare propose error so the HTTP layer can distinguish a duplicate (409)
+/// from a redirect (503) from a genuine divergence (500).
+#[derive(Debug)]
+pub enum ControlWriteError {
+    /// The database name already exists — a create is a 409, not a phantom
+    /// success (review F2).
+    AlreadyExists,
+    /// The op committed but the expected row is absent after apply — a
+    /// claim-key collision or divergence (review F2 failover / F5). Fail
+    /// closed: never report success for a write that did not take effect.
+    Diverged(String),
+    /// A local error (e.g. control.db unreadable) before/after propose.
+    Internal(String),
+    /// Underlying propose failure (NotLeader redirect / Timeout / etc.).
+    Propose(YrpProposeError),
+}
+
 /// What the HTTP layer holds for a YRP node.
 pub struct YrpHandle {
     pub node_id: NodeId,
@@ -353,25 +371,34 @@ impl YrpHandle {
         Ok(index)
     }
 
-    /// Create a database as a replicated control op (RFC 029). Allocates a
-    /// leader-assigned id under a serializing lock — held across the propose
-    /// and apply so a concurrent create sees this one's row and picks the
-    /// next id — then returns the id once every node will apply the same one.
-    /// Errors map like [`propose_control`]: a follower answers `NotLeader`
-    /// with the leader's address for redirect.
+    /// Create a database as a replicated control op (RFC 029). The
+    /// serializing lock is held across name-check → allocate → propose →
+    /// apply, so a concurrent create both (a) sees this one's row and picks
+    /// the next id, and (b) sees an existing name and 409s rather than
+    /// silently no-op'ing on the id-PK `INSERT OR IGNORE`. The returned id
+    /// is READ BACK from `control.db` after apply, so it is always the id a
+    /// caller can actually use — never the pre-allocated guess (review F2).
     pub async fn create_database_replicated(
         &self,
         name: &str,
         path: &str,
         config: &str,
         created_at: String,
-    ) -> Result<i64, YrpProposeError> {
+    ) -> Result<i64, ControlWriteError> {
         let _guard = self.control_propose_lock.lock().await;
-        let db_id = self
-            .control
-            .lock()
-            .next_database_id()
-            .map_err(|e| YrpProposeError::Unavailable(format!("allocate db id: {e}")))?;
+        // Name-existence + id allocation under the guard, so a concurrent
+        // create can neither duplicate the name nor race the id.
+        let db_id = {
+            let db = self.control.lock();
+            if db
+                .database_exists(name)
+                .map_err(|e| ControlWriteError::Internal(format!("name check: {e}")))?
+            {
+                return Err(ControlWriteError::AlreadyExists);
+            }
+            db.next_database_id()
+                .map_err(|e| ControlWriteError::Internal(format!("allocate db id: {e}")))?
+        };
         let op = super::control_op::ControlOp::CreateDatabase {
             db_id,
             name: name.to_string(),
@@ -379,8 +406,88 @@ impl YrpHandle {
             config: config.to_string(),
             created_at,
         };
-        self.propose_control(&op).await?;
-        Ok(db_id)
+        self.propose_control(&op)
+            .await
+            .map_err(ControlWriteError::Propose)?;
+        // Verify-after-apply: the row must exist with our name. Return its
+        // actual id (the truth), and fail closed if it is missing (a claim
+        // collision that deduped our op away — review F2/F5).
+        match self
+            .control
+            .lock()
+            .get_database(name)
+            .map_err(|e| ControlWriteError::Internal(format!("read-back: {e}")))?
+        {
+            Some(rec) => Ok(rec.id),
+            None => Err(ControlWriteError::Diverged(format!(
+                "CreateDatabase({name}) committed but no row after apply"
+            ))),
+        }
+    }
+
+    /// Mint a token as a replicated control op (RFC 029), verifying after
+    /// apply that the hash actually resolves to `db_id` — fail closed on a
+    /// claim-key collision that would otherwise report a token that
+    /// authenticates nowhere (review F5). The caller must have already
+    /// verified `db_id` exists (else apply FK-fails and fail-stops the
+    /// node — review F3).
+    pub async fn create_token_replicated(
+        &self,
+        db_id: i64,
+        token_hash: String,
+        label: String,
+        created_at: String,
+    ) -> Result<(), ControlWriteError> {
+        let op = super::control_op::ControlOp::CreateToken {
+            db_id,
+            token_hash: token_hash.clone(),
+            label,
+            created_at,
+        };
+        self.propose_control(&op)
+            .await
+            .map_err(ControlWriteError::Propose)?;
+        let resolved = self
+            .control
+            .lock()
+            .validate_token(&token_hash)
+            .map_err(|e| ControlWriteError::Internal(format!("verify token: {e}")))?;
+        if resolved == Some(db_id) {
+            Ok(())
+        } else {
+            Err(ControlWriteError::Diverged(
+                "CreateToken committed but token does not resolve after apply".into(),
+            ))
+        }
+    }
+
+    /// Revoke a token as a replicated control op (RFC 029), verifying after
+    /// apply that the token no longer resolves — fail closed if it still
+    /// authenticates (a collision that deduped the revoke away — review F5).
+    pub async fn revoke_token_replicated(
+        &self,
+        token_hash: String,
+        revoked_at: String,
+    ) -> Result<(), ControlWriteError> {
+        let op = super::control_op::ControlOp::RevokeToken {
+            token_hash: token_hash.clone(),
+            revoked_at,
+        };
+        self.propose_control(&op)
+            .await
+            .map_err(ControlWriteError::Propose)?;
+        let resolved = self
+            .control
+            .lock()
+            .validate_token(&token_hash)
+            .map_err(|e| ControlWriteError::Internal(format!("verify revoke: {e}")))?;
+        if resolved.is_none() {
+            Ok(())
+        } else {
+            Err(ControlWriteError::Diverged(
+                "RevokeToken committed but token still resolves after apply".into(),
+            ))
+        }
     }
 
     /// Wait for the durable-apply marker to cover `index`, then read its
@@ -434,6 +541,19 @@ pub fn spawn(
             "[yrp] log compaction ENABLED: beyond-GC stragglers rejoin without \
              engine backfill for the compacted range until Phase C \
              (engine-checkpoint transfer). Not recommended in production."
+        );
+        // RFC 029: control ops (tokens/databases) write no outcome row and
+        // are not yet carried in the snapshot, so a compacted range that
+        // contains a control op cannot be backfilled — a rejoining/new node
+        // would be stuck engine-incomplete and could miss a token revoke.
+        // Control-plane replication is only correctness-safe with compaction
+        // DISABLED until the snapshot carries control state (RFC 029 inc 2).
+        tracing::error!(
+            compact_after = cfg.compact_after_entries,
+            "[yrp] compaction + RFC 029 control-plane replication is NOT safe: \
+             control ops in a compacted range are lost to rejoiners. Set \
+             compact_after_entries = 0 until RFC 029 increment 2 (control \
+             state in the snapshot) ships."
         );
     }
 

--- a/crates/yantrikdb-server/src/yrp/testkit.rs
+++ b/crates/yantrikdb-server/src/yrp/testkit.rs
@@ -217,6 +217,7 @@ pub async fn spawn_node(
         },
         local.clone(),
         applier,
+        control.clone(),
     )
     .expect("yrp spawn");
     let commit_log: Arc<dyn crate::commit::MutationCommitter> =

--- a/docs/rfcs/rfc_029_control_plane_replication.md
+++ b/docs/rfcs/rfc_029_control_plane_replication.md
@@ -109,6 +109,36 @@ control ops once the cluster is up. This is why `cluster_secret` stays a
 peer/bootstrap credential and is **not** promoted to a data-plane token
 (consistent with the finding corrected in the docs this cycle).
 
+## Increment 1 (shipped) vs increment 2 (follow-up)
+
+**Increment 1** delivers the replication mechanism: the `Payload::Control`
+log entry, the `ControlOp` grammar, `ControlApplySink` (idempotent,
+leader-assigned ids/timestamps, verifier-hash only), `propose_control`
+with verify-after-apply, and the master-token-gated admin endpoints. A
+token minted on the leader authenticates on every follower and survives
+failover — proven in the 2-node HTTP cluster test.
+
+Two **safety boundaries** hold increment 1 to the correctness bar (from an
+adversarial review):
+
+- **Compaction MUST be disabled** (`compact_after_entries = 0`, the
+  production default). Control ops write no outcome row and are not yet
+  carried in the YRP snapshot, so a compacted range containing a control op
+  cannot be backfilled — a rejoining node would be stuck engine-incomplete
+  and could miss a revoke. Enabling compaction now logs a loud `error!`.
+  **Increment 2** carries control state in the snapshot (and/or gives
+  control ops backfillable outcome rows), lifting this restriction.
+- **Upgrade every node before minting the first control op** (bootstrap
+  rule). A pre-`Control` binary rejects a `Payload::Control` AppendEntries
+  (fail-safe — no misapply, HTTP 400) but then cannot advance past that
+  index, stalling replication to it. Increment 2 gates control-op proposal
+  behind a capability bit so a half-upgraded cluster refuses to mint one.
+
+Increment 2 also adds the **auth-read barrier** (instantaneous cluster-wide
+revocation — until then revocation is bounded-staleness eventually
+consistent within replication lag) and the parallel `control_incomplete`
+health gate.
+
 ## Out of scope (follow-ups)
 
 External identity (OIDC/SSO/JWT) layers *on top of* this — it maps an


### PR DESCRIPTION
Closes the **#1 enterprise-grade blocker**: auth tokens and databases lived in a per-node `control.db`, so a token minted on the leader did not exist on followers and did not survive failover. An enterprise cluster whose identity/authorization doesn't survive failover isn't deployable.

This makes the **control plane replicate through the same YRP consensus as the data plane** (RFC 029, codex verdict A — one consensus group, reuse the proven machinery).

## What ships (increment 1 — the replication mechanism)
- **`Payload::Control(Vec<u8>)`** — a *distinct* log-entry variant (not a re-wrap of `Op`), so a mixed-version cluster keeps replicating **data** ops unchanged.
- **`ControlOp`** `{CreateDatabase, CreateToken, RevokeToken}` + **`ControlApplySink`** applying to `control.db` in log order on every node. Leader-assigned ids + timestamps (carried in the op) → every node writes the identical row; apply is idempotent on the natural key (`INSERT OR IGNORE`). **Verifier hash only, never plaintext** (Invariant 3).
- Control + data share **one apply marker**: a node is caught up on the whole log or not, and a control-apply error **fail-stops** the worker (Invariant 2 — never serve stale authorization).
- **`propose_control`** + `create_database_replicated` / `create_token_replicated` / `revoke_token_replicated` — serialize id allocation and **verify-after-apply**.
- Master-token-gated admin endpoints: **`POST /v1/admin/databases`, `/v1/admin/tokens`, `/v1/admin/tokens/revoke`**. Followers redirect control writes to the leader.

## Validation
2-node HTTP cluster test proves the headline guarantee end-to-end: a database + token minted on the **leader** resolves on the **follower's** `control.db` (the auth path *is* `validate_token`), a control write on the follower is redirected, and a revoke on the leader propagates. Full suite green.

## Security review
Because this is the auth path across a cluster, I ran an adversarial review before merge. It confirmed the core sound (id-allocation guard genuinely spans allocate→propose→apply; plaintext never stored/logged/re-returned; `require_master_token` denies by default; follower never forks state) and surfaced five edge-of-log defects, **all fixed in this PR**:

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| F3 | HIGH (avail) | bogus `database_id` → FK-fail at apply → **cluster-wide fail-stop** | validate db exists before propose → 404 |
| F2 | HIGH | duplicate name → `INSERT OR IGNORE` no-op but **phantom id** returned | name-check inside the lock (409) + return **read-back** id |
| F5 | LOW | claim-key collision → silent phantom success | **verify-after-apply**, fail closed |
| F1 | (config-gated) | compaction loses control ops (no snapshot/backfill yet) | loud `error!` guard + RFC: compaction MUST stay off (default) until inc 2 |
| F4 | MEDIUM | pre-`Control` node stalls on a control entry (fail-*safe*, no misapply) | documented upgrade-order rule; capability-gate is inc 2 |

New tests assert 409-on-duplicate, 404-on-bogus-id, and that the cluster **stays writable** after a rejected bad mint (proving no fail-stop).

## Increment 2 (follow-up, not in this PR)
Auth-read barrier (instantaneous cluster-wide revocation; until then revocation is bounded-staleness eventually consistent within replication lag), `control_incomplete` health gate, control state in the snapshot (lifts the compaction restriction), and capability-gated control-op proposal.

Refs RFC 029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
