### PR TITLE
feat(yrp): RFC 029 inc2-A — control-freshness auth gate (fail closed when behind)

### DIFF
--- a/crates/yantrikdb-server/src/auth/middleware.rs
+++ b/crates/yantrikdb-server/src/auth/middleware.rs
@@ -57,6 +57,17 @@ pub async fn require_authenticated_principal(
             )
         })?;
 
+    // RFC 029 inc2: a node that has not caught up on the replicated control
+    // log must not authenticate — it may not yet have applied a committed
+    // token revoke (Invariant 1, fail closed).
+    if let Some(reason) = crate::server::control_auth_stale(&state) {
+        return Err(api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            ApiErrorCode::ClusterUnavailable,
+            format!("control plane not ready for auth: {reason}"),
+        ));
+    }
+
     let outcome = state
         .auth_provider
         .authenticate(&token)

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -285,6 +285,17 @@ fn resolve_engine(
         }
     }
 
+    // RFC 029 inc2: refuse data-plane auth on a node that has not caught up
+    // on the replicated control log — it may not yet have applied a
+    // committed token revoke (fail closed). The master-token path above is
+    // intentionally exempt so operators can still reach a catching-up node.
+    if let Some(reason) = crate::server::control_auth_stale(state) {
+        return Err(app_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("control plane not ready for auth: {reason}"),
+        ));
+    }
+
     let token_hash = auth::hash_token(token);
     let control = state.control.lock();
     let db_id = control

--- a/crates/yantrikdb-server/src/server.rs
+++ b/crates/yantrikdb-server/src/server.rs
@@ -78,6 +78,35 @@ pub struct AppState {
 /// Default: 256 (tokio's default blocking pool is 512, shed at 50%).
 pub const MAX_INFLIGHT: u32 = 256;
 
+/// RFC 029 inc2 — control-plane freshness gate (Invariant 1: control-
+/// incomplete ⇒ not auth-eligible).
+///
+/// Because tokens/databases now replicate through YRP (RFC 029) and share
+/// the data plane's apply marker, a node that is **quarantined** or still
+/// **backfilling** the replicated log may not yet have applied a committed
+/// token *revoke*. Such a node must refuse to authenticate data-plane
+/// tokens — fail closed rather than honor a token the cluster has revoked.
+///
+/// Returns `Some(reason)` when authentication must be refused (HTTP 503).
+/// Steady-state followers are caught up and pass. The residual window
+/// between a revoke's commit and its replication to an otherwise-caught-up
+/// follower is bounded by replication lag (documented bounded staleness);
+/// closing it fully would require a consensus round-trip per auth check,
+/// which is deliberately out of scope for the hot read path.
+///
+/// The operator/bootstrap master token bypasses this gate at its call site
+/// so a catching-up node stays reachable for diagnostics.
+pub fn control_auth_stale(state: &AppState) -> Option<String> {
+    let yrp = state.yrp.as_ref()?;
+    if let Some(reasons) = yrp.quarantine_reasons() {
+        return Some(format!("node quarantined: {reasons:?}"));
+    }
+    if yrp.engine_incomplete() {
+        return Some("node is catching up on the replicated control log".to_string());
+    }
+    None
+}
+
 pub async fn run_wire_server(
     listener: TcpListener,
     state: Arc<AppState>,

--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -339,6 +339,14 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
     assert_eq!(st, reqwest::StatusCode::OK, "admin revoke");
     poll_follower_token(None).await;
 
+    // RFC 029 inc2: the control-freshness gate must NOT fire on a healthy,
+    // caught-up follower — auth stays available (fail-closed only when the
+    // node is quarantined or backfilling).
+    assert!(
+        crate::server::control_auth_stale(&follower.state).is_none(),
+        "healthy follower must be auth-eligible (freshness gate false-positive)"
+    );
+
     // Hardening (review F2): a duplicate database name is a 409, not a
     // phantom-id success.
     let (st, _) = post_json(

--- a/docs/rfcs/rfc_029_control_plane_replication.md
+++ b/docs/rfcs/rfc_029_control_plane_replication.md
@@ -134,10 +134,43 @@ adversarial review):
   index, stalling replication to it. Increment 2 gates control-op proposal
   behind a capability bit so a half-upgraded cluster refuses to mint one.
 
-Increment 2 also adds the **auth-read barrier** (instantaneous cluster-wide
-revocation — until then revocation is bounded-staleness eventually
-consistent within replication lag) and the parallel `control_incomplete`
-health gate.
+### Increment 2 — status
+
+**Shipped (inc2-A): the control-freshness auth gate.** A node that is
+quarantined or still backfilling the replicated log refuses to authenticate
+data-plane tokens (HTTP 503, fail closed) — Invariant 1, "control-incomplete
+⇒ not auth-eligible." Implemented as `server::control_auth_stale` gating
+`resolve_engine` and the principal auth middleware, reading the existing
+`quarantine`/`engine_incomplete` signals (no consensus round-trip on the hot
+path). The operator/bootstrap master token is exempt at its call site so a
+catching-up node stays reachable for diagnostics.
+
+This gives cluster-wide revocation consistency for the state that matters:
+a node never authenticates a token while it *knows* it is behind. The
+residual window — a revoke committed on the leader but not yet replicated to
+an otherwise-caught-up follower — is bounded by replication lag (sub-second
+in practice). Closing it to *zero* would require a consensus round-trip per
+auth check (a linearizable read barrier on every request); that strict mode
+is deliberately deferred as opt-in, not the default hot-path cost.
+
+**Deferred, with reasons (do NOT rush these into a release):**
+
+- **Control state in the snapshot (closes F1).** This changes the
+  `Snapshot`/`DurableState`/rejoin-`Grant` **bincode** wire+persist format,
+  which is positional and not cross-version tolerant — a rolling upgrade
+  (mixed v_old/v_new nodes exchanging snapshots, or v_new reading a
+  v_old-written `DurableState`) would break without explicit versioning.
+  Until it lands with a versioned envelope, **compaction MUST stay disabled**
+  (the production default) — the operational mitigation for F1.
+- **Capability-gated control-op proposal (F4).** The capability mechanism
+  gates on advertised `supported` bits, but production nodes advertise
+  `u32::MAX` ("support everything"), so the gate is vacuous for the current
+  transition — an old node falsely claims support. Making it real means
+  advertising a *precise* capability mask instead of `u32::MAX`, which also
+  affects election-safety gating, and it only protects *future* upgrades.
+  For the current transition the operational rule (upgrade every node before
+  minting the first control op) is the actual mitigation, and it holds by
+  construction during a controlled rolling redeploy.
 
 ## Out of scope (follow-ups)
 


### PR DESCRIPTION
RFC 029 increment 2, part A — the **control-freshness auth gate** (Invariant 1: *control-incomplete ⇒ not auth-eligible*).

Now that tokens/databases replicate through YRP (#77), a node that hasn't caught up on the control log could still honor a token the cluster has **revoked**. This closes that: a node that is **quarantined** or still **backfilling** refuses to authenticate data-plane tokens (**503, fail closed**).

## How
- `server::control_auth_stale(state)` returns `Some(reason)` when the node is quarantined or `engine_incomplete`, gating both `resolve_engine` (legacy inline auth) and the principal auth middleware.
- Reads the **existing** `quarantine`/`engine_incomplete` signals — **no consensus round-trip on the hot auth path**.
- The operator/bootstrap **master token is exempt** at its call site, so a catching-up node stays reachable for diagnostics.
- Non-yrp / single-node: no-op (`None`).

## Consistency scope (honest)
This gives cluster-wide revocation consistency for the state that matters — a node never authenticates while it *knows* it's behind. The residual window (a revoke committed on the leader but not yet replicated to an otherwise-caught-up follower) is **bounded by replication lag** (sub-second). Zero-window strict revocation would cost a consensus round-trip per auth check; that's deferred as opt-in, not the default hot-path cost.

## Validation
Full suite green. The 2-node cluster test asserts a healthy follower stays auth-eligible (no freshness false-positive).

## Deferred (with reasons — see RFC 029 §Increment 2)
- **inc2-B control-in-snapshot (F1):** changes the bincode `Snapshot`/`DurableState`/`Grant` format — a rolling-upgrade hazard without explicit versioning. Compaction-off (the default) is the F1 mitigation meanwhile.
- **inc2-C capability-gate (F4):** vacuous while nodes advertise `supported=u32::MAX`; upgrade-order is the F4 mitigation for the current transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
