### PR TITLE
feat(admin): RFC 030 — multi-user RBAC + enterprise studio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +402,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +436,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "blake3"
@@ -602,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -922,6 +949,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1492,6 +1520,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,7 +1672,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2368,6 +2405,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,7 +2578,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2567,7 +2615,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4559,9 +4607,11 @@ name = "yantrikdb-server"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "async-trait",
  "axum 0.8.9",
  "axum-extra",
+ "base64 0.22.1",
  "bincode",
  "blake3",
  "bytes",
@@ -4571,6 +4621,7 @@ dependencies = [
  "fastembed",
  "futures",
  "hex",
+ "hmac",
  "libc",
  "metrics",
  "parking_lot",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -61,6 +61,12 @@ bincode = "1"
 sha2 = "0.10"
 hex = "0.4"
 rand = { version = "0.8", features = ["small_rng"] }
+# RFC 030 admin RBAC: argon2id for admin-account password hashing (low-entropy
+# human input needs a slow salted KDF — distinct from the SHA-256 used for
+# high-entropy random tokens); HMAC-SHA256 for stateless signed session tokens.
+argon2 = "0.5"
+hmac = "0.12"
+base64 = "0.22"
 
 # Time formatting (Unix epoch ↔ ISO 8601 for HTTP responses). Issue
 # #39 read endpoints emit RFC-3339 timestamps alongside the existing

--- a/crates/yantrikdb-server/src/admin/studio.html
+++ b/crates/yantrikdb-server/src/admin/studio.html
@@ -301,7 +301,7 @@
 
   // ── Audit ──
   async function renderAudit(){
-    $('appview').innerHTML=`<div class="panel"><h2>Audit trail <span class="note" style="text-transform:none">(replicated · tamper-evident)</span></h2><div id="auditlist" class="empty">Loading…</div></div>`;
+    $('appview').innerHTML=`<div class="panel"><h2>Audit trail <span class="note" style="text-transform:none">(replicated across all nodes · quorum-durable)</span></h2><div id="auditlist" class="empty">Loading…</div></div>`;
     try{
       const {audit}=await api('/v1/admin/audit?limit=200');
       $('auditlist').innerHTML=audit.length?`<table><thead><tr><th>When</th><th>Actor</th><th>Action</th><th>Target</th><th>#</th></tr></thead><tbody>${

--- a/crates/yantrikdb-server/src/admin/studio.html
+++ b/crates/yantrikdb-server/src/admin/studio.html
@@ -6,305 +6,312 @@
 <title>YantrikDB Studio</title>
 <style>
   :root {
-    --bg: #f6f7f9; --panel: #ffffff; --ink: #1a1d21; --muted: #6b7280;
-    --line: #e5e7eb; --accent: #4f46e5; --ok: #16a34a; --warn: #d97706;
-    --bad: #dc2626; --leader: #4f46e5; --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+    --bg:#f6f7f9; --panel:#fff; --ink:#1a1d21; --muted:#6b7280; --line:#e5e7eb;
+    --accent:#4f46e5; --ok:#16a34a; --warn:#d97706; --bad:#dc2626; --leader:#4f46e5;
+    --mono:ui-monospace,SFMono-Regular,Menlo,monospace;
   }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #0d1117; --panel: #161b22; --ink: #e6edf3; --muted: #8b949e;
-      --line: #21262d; --accent: #7c8cff; --ok: #3fb950; --warn: #d29922;
-      --bad: #f85149; --leader: #7c8cff;
-    }
-  }
-  * { box-sizing: border-box; }
-  body {
-    margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-    background: var(--bg); color: var(--ink); -webkit-font-smoothing: antialiased;
-  }
-  header {
-    display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
-    padding: 1rem 1.5rem; border-bottom: 1px solid var(--line); background: var(--panel);
-  }
-  header h1 { font-size: 1.05rem; margin: 0; font-weight: 650; letter-spacing: -0.01em; }
-  nav { display: flex; gap: .3rem; }
-  nav button {
-    font: inherit; font-size: .82rem; border: 0; background: transparent; color: var(--muted);
-    padding: .35rem .75rem; border-radius: 8px; cursor: pointer;
-  }
-  nav button.active { background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); font-weight: 600; }
-  header .meta { margin-left: auto; font-family: var(--mono); font-size: .78rem; color: var(--muted); }
-  .wrap { max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
-  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1rem; }
-  .card {
-    background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
-    padding: 1rem 1.1rem; position: relative; overflow: hidden;
-  }
-  .card.leader { border-color: var(--leader); box-shadow: 0 0 0 1px var(--leader) inset; }
-  .card.unreachable { opacity: .55; }
-  .card .top { display: flex; align-items: center; gap: .5rem; margin-bottom: .6rem; }
-  .node-id { font-family: var(--mono); font-weight: 650; font-size: .95rem; }
-  .badge {
-    font-size: .68rem; font-weight: 600; padding: .12rem .5rem; border-radius: 999px;
-    text-transform: uppercase; letter-spacing: .03em;
-  }
-  .badge.leader { background: color-mix(in srgb, var(--leader) 18%, transparent); color: var(--leader); }
-  .badge.follower { background: color-mix(in srgb, var(--muted) 20%, transparent); color: var(--muted); }
-  .badge.witness { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
-  .badge.candidate, .badge.quarantined { background: color-mix(in srgb, var(--bad) 18%, transparent); color: var(--bad); }
-  .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-left: auto; }
-  .dot.ok { background: var(--ok); } .dot.bad { background: var(--bad); } .dot.warn { background: var(--warn); }
-  .rows { display: grid; grid-template-columns: auto 1fr; gap: .25rem .75rem; font-size: .8rem; margin-top: .5rem; }
-  .rows dt { color: var(--muted); } .rows dd { margin: 0; font-family: var(--mono); text-align: right; }
-  .lagbar { height: 4px; border-radius: 3px; background: color-mix(in srgb, var(--muted) 25%, transparent); margin-top: .1rem; overflow: hidden; }
-  .lagbar > i { display: block; height: 100%; background: var(--ok); width: 100%; }
-  .lagbar.lag > i { background: var(--warn); }
-  .empty, .err { color: var(--muted); padding: 2rem; text-align: center; }
-  .err { color: var(--bad); }
-  footer { color: var(--muted); font-size: .74rem; text-align: center; padding: 1.5rem; }
-  .pulse { animation: p 1.2s ease-in-out infinite; }
-  @keyframes p { 50% { opacity: .4; } }
-  .hidden { display: none !important; }
-  /* Identity panel */
-  .authbar { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; margin-bottom: 1.25rem;
-    background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: .8rem 1rem; }
-  .authbar label { font-size: .8rem; color: var(--muted); }
-  input, select {
-    font: inherit; font-size: .85rem; padding: .4rem .6rem; border-radius: 8px;
-    border: 1px solid var(--line); background: var(--bg); color: var(--ink); min-width: 0;
-  }
-  input:focus, select:focus { outline: 2px solid color-mix(in srgb, var(--accent) 40%, transparent); outline-offset: 0; }
-  button.btn {
-    font: inherit; font-size: .82rem; font-weight: 600; border: 0; cursor: pointer;
-    background: var(--accent); color: #fff; padding: .42rem .9rem; border-radius: 8px;
-  }
-  button.btn.ghost { background: color-mix(in srgb, var(--muted) 16%, transparent); color: var(--ink); }
-  button.btn.danger { background: color-mix(in srgb, var(--bad) 16%, transparent); color: var(--bad); padding: .25rem .6rem; font-size: .74rem; }
-  button.btn:disabled { opacity: .5; cursor: not-allowed; }
-  .cols { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
-  @media (max-width: 720px) { .cols { grid-template-columns: 1fr; } }
-  .panel { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 1rem 1.1rem; }
-  .panel h2 { font-size: .82rem; margin: 0 0 .8rem; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
-  .list { display: flex; flex-direction: column; gap: .4rem; margin-bottom: .9rem; }
-  .item { display: flex; align-items: center; gap: .6rem; font-size: .82rem; padding: .45rem .6rem;
-    border: 1px solid var(--line); border-radius: 8px; }
-  .item .mono { font-family: var(--mono); font-size: .75rem; color: var(--muted); word-break: break-all; }
-  .item .grow { flex: 1; min-width: 0; }
-  .form { display: flex; gap: .5rem; flex-wrap: wrap; align-items: center; }
-  .form input, .form select { flex: 1; }
-  .note { font-size: .74rem; color: var(--muted); margin-top: .5rem; }
-  .toast { position: fixed; bottom: 1rem; left: 50%; transform: translateX(-50%);
-    background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: .6rem 1rem;
-    font-size: .82rem; box-shadow: 0 6px 24px rgba(0,0,0,.18); max-width: 90vw; }
-  .toast.bad { border-color: var(--bad); color: var(--bad); }
-  .toast.ok { border-color: var(--ok); }
-  .reveal { font-family: var(--mono); font-size: .8rem; background: color-mix(in srgb, var(--ok) 12%, transparent);
-    border: 1px solid var(--ok); border-radius: 8px; padding: .6rem .7rem; margin-bottom: .9rem; word-break: break-all; }
-  .reveal b { display:block; font-family: system-ui; font-size:.72rem; color: var(--muted); margin-bottom:.25rem; text-transform: uppercase; letter-spacing:.04em;}
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0d1117; --panel:#161b22; --ink:#e6edf3; --muted:#8b949e; --line:#21262d;
+    --accent:#7c8cff; --ok:#3fb950; --warn:#d29922; --bad:#f85149; --leader:#7c8cff;}}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:var(--bg);color:var(--ink);-webkit-font-smoothing:antialiased}
+  header{display:flex;align-items:center;gap:1rem;flex-wrap:wrap;padding:.9rem 1.5rem;border-bottom:1px solid var(--line);background:var(--panel)}
+  header h1{font-size:1.05rem;margin:0;font-weight:650;letter-spacing:-.01em}
+  nav{display:flex;gap:.2rem;flex-wrap:wrap}
+  nav button{font:inherit;font-size:.82rem;border:0;background:transparent;color:var(--muted);padding:.35rem .7rem;border-radius:8px;cursor:pointer}
+  nav button.active{background:color-mix(in srgb,var(--accent) 14%,transparent);color:var(--accent);font-weight:600}
+  header .right{margin-left:auto;display:flex;align-items:center;gap:.6rem;font-size:.8rem;color:var(--muted)}
+  .who b{color:var(--ink)}
+  .pill{font-size:.66rem;font-weight:700;text-transform:uppercase;letter-spacing:.04em;padding:.1rem .45rem;border-radius:999px;background:color-mix(in srgb,var(--accent) 16%,transparent);color:var(--accent)}
+  .wrap{max-width:1080px;margin:0 auto;padding:1.5rem}
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:1rem}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:1rem 1.1rem;overflow:hidden}
+  .card.leader{border-color:var(--leader);box-shadow:0 0 0 1px var(--leader) inset}
+  .card .top{display:flex;align-items:center;gap:.5rem;margin-bottom:.5rem}
+  .node-id{font-family:var(--mono);font-weight:650}
+  .badge{font-size:.66rem;font-weight:700;padding:.1rem .45rem;border-radius:999px;text-transform:uppercase;letter-spacing:.03em}
+  .badge.leader{background:color-mix(in srgb,var(--leader) 18%,transparent);color:var(--leader)}
+  .badge.follower{background:color-mix(in srgb,var(--muted) 20%,transparent);color:var(--muted)}
+  .badge.witness{background:color-mix(in srgb,var(--warn) 20%,transparent);color:var(--warn)}
+  .badge.candidate,.badge.quarantined{background:color-mix(in srgb,var(--bad) 18%,transparent);color:var(--bad)}
+  .dot{width:8px;height:8px;border-radius:50%;margin-left:auto}
+  .dot.ok{background:var(--ok)}.dot.bad{background:var(--bad)}.dot.warn{background:var(--warn)}
+  .rows{display:grid;grid-template-columns:auto 1fr;gap:.2rem .7rem;font-size:.8rem;margin-top:.4rem}
+  .rows dt{color:var(--muted)}.rows dd{margin:0;font-family:var(--mono);text-align:right}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:1.1rem;margin-bottom:1.1rem}
+  .panel h2{font-size:.82rem;margin:0 0 .8rem;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
+  table{width:100%;border-collapse:collapse;font-size:.85rem}
+  th,td{text-align:left;padding:.5rem .6rem;border-bottom:1px solid var(--line);vertical-align:middle}
+  th{font-size:.72rem;text-transform:uppercase;letter-spacing:.03em;color:var(--muted);font-weight:600}
+  td .mono{font-family:var(--mono);font-size:.78rem;color:var(--muted)}
+  tr:last-child td{border-bottom:0}
+  input,select{font:inherit;font-size:.85rem;padding:.4rem .55rem;border-radius:8px;border:1px solid var(--line);background:var(--bg);color:var(--ink);max-width:100%}
+  input:focus,select:focus{outline:2px solid color-mix(in srgb,var(--accent) 40%,transparent)}
+  button.btn{font:inherit;font-size:.8rem;font-weight:600;border:0;cursor:pointer;background:var(--accent);color:#fff;padding:.42rem .85rem;border-radius:8px}
+  button.btn.ghost{background:color-mix(in srgb,var(--muted) 16%,transparent);color:var(--ink)}
+  button.btn.sm{padding:.25rem .55rem;font-size:.74rem}
+  button.btn.danger{background:color-mix(in srgb,var(--bad) 16%,transparent);color:var(--bad)}
+  button.btn.warn{background:color-mix(in srgb,var(--warn) 18%,transparent);color:var(--warn)}
+  button.btn:disabled{opacity:.5;cursor:not-allowed}
+  .form{display:flex;gap:.5rem;flex-wrap:wrap;align-items:center;margin-top:.8rem}
+  .form input,.form select{flex:1;min-width:120px}
+  .rowacts{display:flex;gap:.35rem;justify-content:flex-end}
+  .note{font-size:.74rem;color:var(--muted);margin-top:.5rem}
+  .empty{color:var(--muted);padding:1.5rem;text-align:center}
+  .reveal{font-family:var(--mono);font-size:.8rem;background:color-mix(in srgb,var(--ok) 12%,transparent);border:1px solid var(--ok);border-radius:8px;padding:.6rem .7rem;margin:.6rem 0;word-break:break-all;display:flex;gap:.5rem;align-items:center;justify-content:space-between}
+  .toast{position:fixed;bottom:1rem;left:50%;transform:translateX(-50%);background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:.6rem 1rem;font-size:.82rem;box-shadow:0 6px 24px rgba(0,0,0,.18);max-width:90vw;z-index:50}
+  .toast.bad{border-color:var(--bad);color:var(--bad)}.toast.ok{border-color:var(--ok)}
+  .hidden{display:none!important}
+  /* Login */
+  .login{max-width:340px;margin:8vh auto;background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:1.6rem}
+  .login h2{margin:0 0 .3rem;font-size:1.1rem}
+  .login .sub{color:var(--muted);font-size:.82rem;margin-bottom:1.2rem}
+  .login label{display:block;font-size:.76rem;color:var(--muted);margin:.6rem 0 .25rem}
+  .login input{width:100%}
+  .login button{width:100%;margin-top:1.1rem;padding:.55rem}
+  .rolegate{display:contents}
 </style>
 </head>
 <body>
-<header>
+<header class="hidden" id="appheader">
   <h1>YantrikDB <span style="color:var(--accent)">Studio</span></h1>
-  <nav>
-    <button id="tab-cluster" class="active" onclick="showTab('cluster')">Cluster</button>
-    <button id="tab-identity" onclick="showTab('identity')">Identity</button>
-  </nav>
-  <span class="meta" id="meta">connecting…</span>
+  <nav id="nav"></nav>
+  <div class="right">
+    <span class="who" id="who"></span>
+    <button class="btn ghost sm" onclick="logout()">Sign out</button>
+  </div>
 </header>
 
-<!-- CLUSTER -->
-<div class="wrap" id="pane-cluster">
-  <div id="view" class="grid"></div>
-  <div id="msg" class="empty">Loading cluster topology…</div>
-</div>
-
-<!-- IDENTITY -->
-<div class="wrap hidden" id="pane-identity">
-  <div class="authbar">
-    <label for="master">Master token</label>
-    <input id="master" type="password" placeholder="cluster secret" style="flex:1" />
-    <button class="btn" onclick="unlock()">Unlock</button>
-    <button class="btn ghost" onclick="lock()">Forget</button>
-    <span class="note" style="margin:0">Held only in this browser tab. Use over TLS.</span>
-  </div>
-  <div id="identity-locked" class="empty">Enter the cluster master token to manage databases &amp; tokens.</div>
-  <div id="identity-body" class="cols hidden">
-    <div class="panel">
-      <h2>Databases</h2>
-      <div class="list" id="db-list"></div>
-      <div class="form">
-        <input id="db-name" placeholder="new database name" />
-        <button class="btn" onclick="createDb()">Create</button>
-      </div>
-      <div class="note">Replicated through YRP — created on every node, survives failover.</div>
+<!-- LOGIN -->
+<div id="loginview">
+  <div class="login">
+    <div id="signinbox">
+      <h2>Sign in</h2>
+      <div class="sub">Enterprise control console</div>
+      <label for="lu">Username</label>
+      <input id="lu" autocomplete="username" />
+      <label for="lp">Password</label>
+      <input id="lp" type="password" autocomplete="current-password" onkeydown="if(event.key==='Enter')doLogin()" />
+      <button class="btn" onclick="doLogin()">Sign in</button>
+      <div class="note" style="text-align:center"><a href="#" onclick="showBootstrap(true);return false" style="color:var(--accent)">First-time setup →</a></div>
     </div>
-    <div class="panel">
-      <h2>Tokens</h2>
-      <div id="token-reveal"></div>
-      <div class="list" id="token-list"></div>
-      <div class="form">
-        <select id="tok-db"></select>
-        <input id="tok-label" placeholder="label (optional)" style="flex:.7" />
-        <button class="btn" onclick="mintToken()">Mint</button>
-      </div>
-      <div class="note">The plaintext token is shown once. Only its hash is stored + replicated.</div>
+    <div id="bootstrapbox" class="hidden">
+      <h2>First-time setup</h2>
+      <div class="sub">Create the first <b>owner</b> account using the cluster master token. Do this once; afterwards, sign in with the account.</div>
+      <label for="bt">Cluster master token</label>
+      <input id="bt" type="password" placeholder="ydb_cluster_…" />
+      <label for="bu">Owner username</label>
+      <input id="bu" autocomplete="off" />
+      <label for="bp">Owner password (≥8)</label>
+      <input id="bp" type="password" autocomplete="new-password" onkeydown="if(event.key==='Enter')doBootstrap()" />
+      <button class="btn" onclick="doBootstrap()">Create owner</button>
+      <div class="note" style="text-align:center"><a href="#" onclick="showBootstrap(false);return false" style="color:var(--accent)">← Back to sign in</a></div>
     </div>
   </div>
 </div>
 
-<footer>Cluster view polls <code>/v1/cluster/topology</code> · Identity uses the replicated control plane (RFC 029)</footer>
+<!-- APP -->
+<div class="wrap hidden" id="appview"></div>
+
 <div id="toast" class="toast hidden"></div>
-
 <script>
-(function () {
-  const $ = id => document.getElementById(id);
-  const num = v => (v === null || v === undefined) ? '—' : v;
-  const esc = s => String(s == null ? '' : s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+(function(){
+  const $=id=>document.getElementById(id);
+  const esc=s=>String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+  const num=v=>(v==null?'—':v);
+  let toastT; function toast(m,k){const t=$('toast');t.textContent=m;t.className='toast '+(k||'');clearTimeout(toastT);toastT=setTimeout(()=>t.classList.add('hidden'),4200);}
 
-  // ── Toast ──
-  let toastT;
-  function toast(msg, kind) {
-    const t = $('toast'); t.textContent = msg; t.className = 'toast ' + (kind || '');
-    clearTimeout(toastT); toastT = setTimeout(() => t.classList.add('hidden'), 4000);
+  // ── session state ──
+  const tok=()=>sessionStorage.getItem('ydb_sess')||'';
+  let me={username:'',role:'readonly'};
+  const rank={readonly:0,admin:1,owner:2};
+  const can=r=>rank[me.role]>=rank[r];
+
+  async function api(path,opts){
+    const o=opts||{}; o.headers=Object.assign({},o.headers||{});
+    if(tok()) o.headers['Authorization']='Bearer '+tok();
+    if(o.body) o.headers['Content-Type']='application/json';
+    const r=await fetch(path,o);
+    if(r.status===401){ logout(); throw new Error('session expired — sign in again'); }
+    let b={}; try{b=await r.json();}catch(_){}
+    if(!r.ok) throw new Error(b.message||b.error||('HTTP '+r.status));
+    return b;
   }
 
-  // ── Tabs ──
-  window.showTab = function (name) {
-    for (const t of ['cluster', 'identity']) {
-      $('pane-' + t).classList.toggle('hidden', t !== name);
-      $('tab-' + t).classList.toggle('active', t === name);
+  // ── login ──
+  window.doLogin=async function(){
+    const username=$('lu').value.trim(), password=$('lp').value;
+    if(!username||!password) return;
+    try{
+      const r=await api('/v1/admin/session',{method:'POST',body:JSON.stringify({username,password})});
+      sessionStorage.setItem('ydb_sess',r.token); $('lp').value='';
+      await boot();
+    }catch(e){ toast(e.message,'bad'); }
+  };
+  window.logout=function(){ sessionStorage.removeItem('ydb_sess'); me={username:'',role:'readonly'};
+    $('appheader').classList.add('hidden'); $('appview').classList.add('hidden'); $('loginview').classList.remove('hidden'); };
+  window.showBootstrap=function(on){ $('signinbox').classList.toggle('hidden',on); $('bootstrapbox').classList.toggle('hidden',!on); };
+  window.doBootstrap=async function(){
+    const master=$('bt').value.trim(), username=$('bu').value.trim(), password=$('bp').value;
+    if(!master||!username||password.length<8){ toast('master token + username + password ≥8','bad'); return; }
+    try{
+      const r=await fetch('/v1/admin/users',{method:'POST',headers:{'Authorization':'Bearer '+master,'Content-Type':'application/json'},
+        body:JSON.stringify({username,password,role:'owner'})});
+      if(!r.ok){ const b=await r.json().catch(()=>({})); throw new Error(b.message||b.error||('HTTP '+r.status)); }
+      toast('Owner created — signing in…','ok');
+      // Auto sign-in as the new owner.
+      const s=await api('/v1/admin/session',{method:'POST',body:JSON.stringify({username,password})});
+      sessionStorage.setItem('ydb_sess',s.token); showBootstrap(false); await boot();
+    }catch(e){ toast(e.message,'bad'); }
+  };
+
+  // ── nav / tabs ──
+  const TABS=[
+    {id:'cluster',label:'Cluster',min:null},
+    {id:'databases',label:'Databases',min:'readonly'},
+    {id:'tokens',label:'Tokens',min:'readonly'},
+    {id:'users',label:'Users',min:'owner'},
+    {id:'audit',label:'Audit',min:'admin'},
+  ];
+  let cur='cluster';
+  function renderNav(){
+    $('nav').innerHTML=TABS.filter(t=>!t.min||can(t.min)).map(t=>
+      `<button class="${t.id===cur?'active':''}" onclick="go('${t.id}')">${t.label}</button>`).join('');
+    $('who').innerHTML=`<b>${esc(me.username)}</b> <span class="pill">${esc(me.role)}</span>`;
+  }
+  window.go=function(id){ cur=id; renderNav(); render(); };
+
+  async function boot(){
+    try{ me=await api('/v1/admin/me'); }
+    catch(e){ logout(); return; }
+    $('loginview').classList.add('hidden'); $('appheader').classList.remove('hidden'); $('appview').classList.remove('hidden');
+    if(cur==='users'&&!can('owner')) cur='cluster';
+    renderNav(); render();
+  }
+
+  // ── render dispatch ──
+  function render(){ ({cluster:renderCluster,databases:renderDatabases,tokens:renderTokens,users:renderUsers,audit:renderAudit}[cur]||renderCluster)(); }
+
+  // ── Cluster (topology, public) ──
+  let topoTimer=null;
+  function renderCluster(){
+    if(topoTimer)clearInterval(topoTimer);
+    $('appview').innerHTML=`<div id="topo" class="grid"></div><div id="topomsg" class="empty">Loading topology…</div>`;
+    const roleClass=r=>({leader:'leader',follower:'follower',witness:'witness',candidate:'candidate',quarantined:'quarantined'}[r]||'follower');
+    async function poll(){
+      try{
+        const r=await fetch('/v1/cluster/topology',{cache:'no-store'}); const d=await r.json();
+        const nodes=(d&&d.nodes)||[];
+        if(!d||d.raft_mode!=='yrp'){ $('topo').innerHTML=''; $('topomsg').textContent='Not in cluster (yrp) mode.'; return; }
+        $('topomsg').style.display=nodes.length?'none':'block';
+        $('topo').innerHTML=nodes.map(n=>{const role=(n.role||(n.reachable?'unknown':'unreachable'))+'',rc=roleClass(role),reach=n.reachable!==false,healthy=n.healthy===true;
+          return `<div class="card ${rc==='leader'?'leader':''}"><div class="top"><span class="node-id">node ${num(n.node_id)}</span>
+            <span class="badge ${rc}">${reach?esc(role):'unreachable'}</span><span class="dot ${!reach?'bad':(healthy?'ok':'warn')}"></span></div>
+            <div class="mono" style="font-size:.72rem;word-break:break-all">${esc(n.addr||'')}${n.self?' · this node':''}</div>
+            <dl class="rows"><dt>term</dt><dd>${num(n.term)}</dd><dt>applied</dt><dd>${num(n.last_applied_index)}</dd><dt>lag</dt><dd>${num(n.replication_lag)}</dd></dl></div>`;}).join('');
+      }catch(e){ if($('topomsg'))$('topomsg').textContent='Cannot reach server.'; }
     }
-    if (name === 'identity' && master()) refreshIdentity();
-  };
-
-  // ── Cluster topology (public) ──
-  const roleClass = r => ({leader:'leader',follower:'follower',witness:'witness',candidate:'candidate',quarantined:'quarantined'}[r] || 'follower');
-  function renderTopo(data) {
-    const view = $('view'), msg = $('msg'), meta = $('meta');
-    const nodes = (data && data.nodes) || [];
-    if (!data || data.raft_mode !== 'yrp') {
-      view.innerHTML = ''; msg.style.display = 'block'; msg.className = 'empty';
-      msg.textContent = 'This node is not running in cluster (yrp) mode.';
-      meta.textContent = 'mode: ' + ((data && data.raft_mode) || 'unknown');
-      return;
-    }
-    msg.style.display = nodes.length ? 'none' : 'block';
-    meta.textContent = `cluster ${num(data.cluster_id)} · ${nodes.length} member${nodes.length===1?'':'s'} · from node ${num(data.viewed_from)}`;
-    view.innerHTML = nodes.map(n => {
-      const role = (n.role || (n.reachable ? 'unknown' : 'unreachable')) + '';
-      const rc = roleClass(role), reach = n.reachable !== false, healthy = n.healthy === true;
-      const dot = !reach ? 'bad' : (healthy ? 'ok' : 'warn');
-      const lag = (n.replication_lag == null) ? null : Number(n.replication_lag);
-      const lagPct = lag == null ? 0 : Math.max(0, Math.min(100, 100 - Math.min(lag, 100)));
-      return `<div class="card ${rc==='leader'?'leader':''} ${reach?'':'unreachable'}">
-        <div class="top"><span class="node-id">node ${num(n.node_id)}</span>
-          <span class="badge ${rc}">${reach ? esc(role) : 'unreachable'}</span>
-          <span class="dot ${dot}"></span></div>
-        <div style="font-family:var(--mono);font-size:.72rem;color:var(--muted);word-break:break-all">${esc(n.addr||'')}${n.self?' · this node':''}</div>
-        <dl class="rows"><dt>term</dt><dd>${num(n.term)}</dd><dt>leader</dt><dd>${num(n.leader)}</dd>
-          <dt>applied</dt><dd>${num(n.last_applied_index)}</dd><dt>lag</dt><dd>${lag==null?'—':lag}</dd></dl>
-        <div class="lagbar ${lag?'lag':''}"><i style="width:${lagPct}%"></i></div></div>`;
-    }).join('');
-  }
-  async function pollTopo() {
-    try {
-      const r = await fetch('/v1/cluster/topology', { cache: 'no-store' });
-      if (!r.ok) throw new Error('HTTP ' + r.status);
-      renderTopo(await r.json()); $('meta').classList.remove('pulse');
-    } catch (e) {
-      $('meta').classList.add('pulse'); $('meta').textContent = 'reconnecting… (' + e.message + ')';
-      if (!$('view').children.length) { $('msg').className = 'err'; $('msg').style.display='block'; $('msg').textContent = 'Cannot reach the server.'; }
-    }
-  }
-  pollTopo(); setInterval(pollTopo, 3000);
-
-  // ── Identity (master-token gated) ──
-  const master = () => sessionStorage.getItem('ydb_master') || '';
-  window.unlock = function () {
-    const v = $('master').value.trim();
-    if (!v) return;
-    sessionStorage.setItem('ydb_master', v);
-    refreshIdentity();
-  };
-  window.lock = function () {
-    sessionStorage.removeItem('ydb_master'); $('master').value = '';
-    $('identity-body').classList.add('hidden'); $('identity-locked').classList.remove('hidden');
-    toast('Master token forgotten', 'ok');
-  };
-  async function adminFetch(path, opts) {
-    const o = opts || {};
-    o.headers = Object.assign({ 'Authorization': 'Bearer ' + master() }, o.headers || {});
-    if (o.body) o.headers['Content-Type'] = 'application/json';
-    const r = await fetch(path, o);
-    let body = {}; try { body = await r.json(); } catch (_) {}
-    if (!r.ok) throw new Error(body.message || body.error || ('HTTP ' + r.status));
-    return body;
+    poll(); topoTimer=setInterval(()=>{ if(cur==='cluster')poll(); else clearInterval(topoTimer); },3000);
   }
 
-  let dbs = [];
-  async function refreshIdentity() {
-    if (!master()) return;
-    try {
-      const snap = await adminFetch('/v1/admin/control-snapshot');
-      dbs = snap.databases || [];
-      const tokens = snap.tokens || [];
-      $('identity-locked').classList.add('hidden'); $('identity-body').classList.remove('hidden');
+  // ── Databases ──
+  async function renderDatabases(){
+    $('appview').innerHTML=`<div class="panel"><h2>Databases</h2><div id="dblist" class="empty">Loading…</div>
+      ${can('admin')?`<div class="form"><input id="dbname" placeholder="new database name"/><button class="btn" onclick="createDb()">Create</button></div>
+      <div class="note">Replicated through YRP — created on every node, survives failover.</div>`:''}</div>`;
+    try{
+      const {databases}=await api('/v1/admin/databases');
+      if(!databases.length){ $('dblist').innerHTML='<div class="empty">No databases yet.</div>'; return; }
+      $('dblist').innerHTML=`<table><thead><tr><th>Name</th><th>ID</th><th>Tokens</th><th>Created</th>${can('admin')?'<th></th>':''}</tr></thead><tbody>${
+        databases.map(d=>`<tr><td><b>${esc(d.name)}</b></td><td class="mono">${d.id}</td><td>${d.token_count}</td><td class="mono">${esc((d.created_at||'').slice(0,19))}</td>
+          ${can('admin')?`<td class="rowacts"><button class="btn ghost sm" onclick="editQuota(${d.id},'${esc(d.name)}')">Quota</button></td>`:''}</tr>`).join('')}</tbody></table>`;
+    }catch(e){ $('dblist').innerHTML=`<div class="empty">${esc(e.message)}</div>`; }
+  }
+  window.createDb=async function(){ const name=$('dbname').value.trim(); if(!name)return;
+    try{ const r=await api('/v1/admin/databases',{method:'POST',body:JSON.stringify({name})}); toast(`Database "${name}" created (id ${r.id})`,'ok'); renderDatabases(); }catch(e){toast(e.message,'bad');} };
+  window.editQuota=async function(id,name){
+    try{ const q=await api('/v1/admin/databases/'+id+'/quota');
+      const mm=prompt(`Quota for "${name}" — max_memories`,q.max_memories); if(mm===null)return;
+      const rps=prompt('max_rps',q.max_rps); if(rps===null)return;
+      await api('/v1/admin/databases/'+id+'/quota',{method:'PUT',body:JSON.stringify({max_memories:Number(mm),max_rps:Number(rps)})});
+      toast('Quota updated','ok');
+    }catch(e){toast(e.message,'bad');}
+  };
 
-      $('db-list').innerHTML = dbs.length ? dbs.map(d =>
-        `<div class="item"><span class="grow"><b>${esc(d.name)}</b> <span class="mono">#${num(d.id)}</span></span></div>`
-      ).join('') : '<div class="note">No databases yet.</div>';
+  // ── Tokens ──
+  async function renderTokens(){
+    $('appview').innerHTML=`<div class="panel"><h2>Tokens</h2><div id="reveal"></div><div id="toklist" class="empty">Loading…</div>
+      ${can('admin')?`<div class="form"><select id="tokdb"></select><input id="toklabel" placeholder="label (optional)" style="flex:.7"/><button class="btn" onclick="mintTok()">Mint</button></div>
+      <div class="note">The plaintext token is shown once. Only its hash is stored + replicated.</div>`:''}</div>`;
+    try{
+      const [{tokens},{databases}]=await Promise.all([api('/v1/admin/tokens'),api('/v1/admin/databases')]);
+      const dbn=id=>(databases.find(d=>d.id===id)||{}).name||('#'+id);
+      $('toklist').innerHTML=tokens.length?`<table><thead><tr><th>Label</th><th>Database</th><th>Hash</th><th>Created</th>${can('admin')?'<th></th>':''}</tr></thead><tbody>${
+        tokens.map(t=>`<tr><td><b>${esc(t.label||'—')}</b></td><td>${esc(dbn(t.database_id))}</td><td class="mono">${esc(t.hash_prefix)}…</td><td class="mono">${esc((t.created_at||'').slice(0,19))}</td>
+          ${can('admin')?`<td class="rowacts"><button class="btn warn sm" onclick="rotateTok('${esc(t.hash)}')">Rotate</button><button class="btn danger sm" onclick="revokeTok('${esc(t.hash)}')">Revoke</button></td>`:''}</tr>`).join('')}</tbody></table>`
+        :'<div class="empty">No active tokens.</div>';
+      if(can('admin')) $('tokdb').innerHTML=databases.map(d=>`<option value="${d.id}">${esc(d.name)}</option>`).join('');
+    }catch(e){ $('toklist').innerHTML=`<div class="empty">${esc(e.message)}</div>`; }
+  }
+  window.mintTok=async function(){ const database_id=Number($('tokdb').value); if(!database_id){toast('Create a database first','bad');return;}
+    const label=$('toklabel').value.trim();
+    try{ const r=await api('/v1/admin/tokens',{method:'POST',body:JSON.stringify({database_id,label})});
+      showReveal('New token — copy now, shown once',r.token); renderTokensKeepReveal(); }catch(e){toast(e.message,'bad');} };
+  function showReveal(title,val){ sessionStorage.setItem('ydb_reveal',JSON.stringify({title,val})); }
+  function renderTokensKeepReveal(){ renderTokens().then(()=>{ const r=sessionStorage.getItem('ydb_reveal'); if(r&&$('reveal')){const {title,val}=JSON.parse(r);
+    $('reveal').innerHTML=`<div class="reveal"><span><b>${esc(title)}</b><br>${esc(val)}</span><button class="btn ghost sm" onclick="copyReveal()">Copy</button></div>`; window._reveal=val; sessionStorage.removeItem('ydb_reveal'); } }); }
+  window.copyReveal=function(){ navigator.clipboard&&navigator.clipboard.writeText(window._reveal||''); toast('Copied','ok'); };
+  window.rotateTok=async function(hash){ if(!confirm('Rotate this token? The old one stops working; a new one is issued.'))return;
+    try{ const r=await api('/v1/admin/tokens/rotate',{method:'POST',body:JSON.stringify({hash})}); showReveal('Rotated token — copy now',r.token); renderTokensKeepReveal(); }
+    catch(e){toast(e.message,'bad');} };
+  window.revokeTok=async function(hash){ if(!confirm('Revoke this token cluster-wide?'))return;
+    try{ await api('/v1/admin/tokens/revoke',{method:'POST',body:JSON.stringify({hash})}); toast('Revoked','ok'); renderTokens(); }
+    catch(e){toast(e.message,'bad');} };
 
-      const dbName = id => (dbs.find(d => d.id === id) || {}).name || ('#' + id);
-      $('token-list').innerHTML = tokens.length ? tokens.map(t =>
-        `<div class="item"><span class="grow"><b>${esc(t.label || 'token')}</b>
-           <span class="mono">${esc(dbName(t.database_id))} · ${esc((t.hash||'').slice(0,12))}…</span></span>
-         <button class="btn danger" onclick="revokeToken('${esc(t.hash)}')">Revoke</button></div>`
-      ).join('') : '<div class="note">No active tokens.</div>';
+  // ── Users (owner) ──
+  async function renderUsers(){
+    if(!can('owner')){ $('appview').innerHTML='<div class="empty">Owner role required.</div>'; return; }
+    $('appview').innerHTML=`<div class="panel"><h2>Admin users</h2><div id="userlist" class="empty">Loading…</div>
+      <div class="form"><input id="uname" placeholder="username"/><input id="upass" type="password" placeholder="password (≥8)"/>
+      <select id="urole"><option value="readonly">readonly</option><option value="admin">admin</option><option value="owner">owner</option></select>
+      <button class="btn" onclick="createUser()">Create</button></div>
+      <div class="note">Passwords are argon2id-hashed; only the hash replicates. The last owner cannot be disabled or demoted.</div></div>`;
+    try{
+      const {users}=await api('/v1/admin/users');
+      $('userlist').innerHTML=`<table><thead><tr><th>Username</th><th>Role</th><th>Status</th><th>Created</th><th></th></tr></thead><tbody>${
+        users.map(u=>`<tr><td><b>${esc(u.username)}</b></td>
+          <td><select onchange="setRole('${esc(u.username)}',this.value)" ${u.disabled?'disabled':''}>
+            ${['readonly','admin','owner'].map(r=>`<option value="${r}" ${u.role===r?'selected':''}>${r}</option>`).join('')}</select></td>
+          <td>${u.disabled?'<span class="badge quarantined">disabled</span>':'<span class="badge follower">active</span>'}</td>
+          <td class="mono">${esc((u.created_at||'').slice(0,19))}</td>
+          <td class="rowacts"><button class="btn ghost sm" onclick="resetPass('${esc(u.username)}')">Reset pw</button>
+          ${u.disabled?'':`<button class="btn danger sm" onclick="disableUser('${esc(u.username)}')">Disable</button>`}</td></tr>`).join('')}</tbody></table>`;
+    }catch(e){ $('userlist').innerHTML=`<div class="empty">${esc(e.message)}</div>`; }
+  }
+  window.createUser=async function(){ const username=$('uname').value.trim(),password=$('upass').value,role=$('urole').value;
+    if(!username||password.length<8){toast('username + password ≥8 chars','bad');return;}
+    try{ await api('/v1/admin/users',{method:'POST',body:JSON.stringify({username,password,role})}); toast(`User "${username}" created`,'ok'); renderUsers(); }catch(e){toast(e.message,'bad');} };
+  window.setRole=async function(u,role){ try{ const r=await api('/v1/admin/users/'+encodeURIComponent(u)+'/role',{method:'POST',body:JSON.stringify({role})});
+    if(r.role!==role) toast('Refused (owner-floor): role unchanged','bad'); else toast(`${u} → ${role}`,'ok'); renderUsers(); }catch(e){toast(e.message,'bad');renderUsers();} };
+  window.resetPass=async function(u){ const p=prompt(`New password for ${u} (≥8 chars)`); if(!p)return; if(p.length<8){toast('≥8 chars','bad');return;}
+    try{ await api('/v1/admin/users/'+encodeURIComponent(u)+'/password',{method:'POST',body:JSON.stringify({password:p})}); toast('Password rotated — the user’s sessions are now invalid','ok'); }catch(e){toast(e.message,'bad');} };
+  window.disableUser=async function(u){ if(!confirm(`Disable ${u}? Their sessions die immediately.`))return;
+    try{ const r=await api('/v1/admin/users/'+encodeURIComponent(u)+'/disable',{method:'POST',body:JSON.stringify({})});
+      if(!r.disabled) toast('Refused (owner-floor): cannot disable the last owner','bad'); else toast(`${u} disabled`,'ok'); renderUsers(); }catch(e){toast(e.message,'bad');} };
 
-      $('tok-db').innerHTML = dbs.map(d => `<option value="${d.id}">${esc(d.name)}</option>`).join('');
-    } catch (e) {
-      $('identity-locked').classList.remove('hidden'); $('identity-body').classList.add('hidden');
-      $('identity-locked').textContent = 'Could not load control plane: ' + e.message;
-      toast(e.message, 'bad');
-    }
+  // ── Audit ──
+  async function renderAudit(){
+    $('appview').innerHTML=`<div class="panel"><h2>Audit trail <span class="note" style="text-transform:none">(replicated · tamper-evident)</span></h2><div id="auditlist" class="empty">Loading…</div></div>`;
+    try{
+      const {audit}=await api('/v1/admin/audit?limit=200');
+      $('auditlist').innerHTML=audit.length?`<table><thead><tr><th>When</th><th>Actor</th><th>Action</th><th>Target</th><th>#</th></tr></thead><tbody>${
+        audit.map(a=>`<tr><td class="mono">${esc((a.at||'').slice(0,19))}</td><td><b>${esc(a.actor)}</b></td><td>${esc(a.action)}</td><td>${esc(a.target)}</td><td class="mono">${a.yrp_index}</td></tr>`).join('')}</tbody></table>`
+        :'<div class="empty">No audit entries yet.</div>';
+    }catch(e){ $('auditlist').innerHTML=`<div class="empty">${esc(e.message)}</div>`; }
   }
 
-  window.createDb = async function () {
-    const name = $('db-name').value.trim();
-    if (!name) return;
-    try {
-      const r = await adminFetch('/v1/admin/databases', { method: 'POST', body: JSON.stringify({ name }) });
-      $('db-name').value = '';
-      toast(`Database "${name}" created (id ${r.id})`, 'ok');
-      refreshIdentity();
-    } catch (e) { toast(e.message, 'bad'); }
-  };
-
-  window.mintToken = async function () {
-    const database_id = Number($('tok-db').value);
-    if (!database_id) { toast('Create a database first', 'bad'); return; }
-    const label = $('tok-label').value.trim();
-    try {
-      const r = await adminFetch('/v1/admin/tokens', { method: 'POST', body: JSON.stringify({ database_id, label }) });
-      $('tok-label').value = '';
-      $('token-reveal').innerHTML = `<div class="reveal"><b>New token — copy it now, it is shown once</b>${esc(r.token)}</div>`;
-      toast('Token minted', 'ok');
-      refreshIdentity();
-    } catch (e) { toast(e.message, 'bad'); }
-  };
-
-  window.revokeToken = async function (hash) {
-    if (!confirm('Revoke this token? It stops working cluster-wide.')) return;
-    try {
-      await adminFetch('/v1/admin/tokens/revoke', { method: 'POST', body: JSON.stringify({ hash }) });
-      toast('Token revoked', 'ok');
-      refreshIdentity();
-    } catch (e) { toast(e.message, 'bad'); }
-  };
-
-  // Restore identity view if a token is already in this tab's session.
-  if (master()) $('master').value = '';
+  // boot if we already have a session
+  if(tok()) boot(); else $('loginview').classList.remove('hidden');
 })();
 </script>
 </body>

--- a/crates/yantrikdb-server/src/auth/admin.rs
+++ b/crates/yantrikdb-server/src/auth/admin.rs
@@ -1,0 +1,245 @@
+//! RFC 030 — admin accounts, roles, and stateless session tokens.
+//!
+//! This is the security core of the admin RBAC layer. It is deliberately
+//! small and self-contained so it can be audited:
+//!
+//! - **Passwords** are argon2id (slow, salted) — [`hash_password`] /
+//!   [`verify_password`]. Never SHA-256 (that is for high-entropy tokens).
+//! - **Sessions** are stateless, signed tokens: `b64url(payload).b64url(sig)`
+//!   where `sig = HMAC-SHA256(session_key, payload_b64_bytes)`. No `alg`
+//!   header (sidesteps JWT alg-confusion); the algorithm is hardcoded.
+//!   Verification is **verify-before-parse** and **constant-time** (M5).
+//! - The signing key is the replicated `admin_session_key` (H3), decoupled
+//!   from `cluster_secret`; the token carries its `kid` so rotation cleanly
+//!   invalidates prior sessions.
+//! - The payload carries `ver` (the user's `token_version`) so a
+//!   disabled/demoted/rotated user's live sessions die immediately (H1) —
+//!   the caller checks it against `control.db`.
+//! - Unknown `role` strings **fail closed** (L5).
+
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Admin role, total-ordered `readonly < admin < owner`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    Readonly,
+    Admin,
+    Owner,
+}
+
+impl Role {
+    fn rank(self) -> u8 {
+        match self {
+            Role::Readonly => 0,
+            Role::Admin => 1,
+            Role::Owner => 2,
+        }
+    }
+
+    /// Parse a role string. Returns `None` for anything not in the known set
+    /// — the guard treats `None` as a hard deny (L5: never default-compare an
+    /// unknown role).
+    pub fn parse(s: &str) -> Option<Role> {
+        match s {
+            "readonly" => Some(Role::Readonly),
+            "admin" => Some(Role::Admin),
+            "owner" => Some(Role::Owner),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Role::Readonly => "readonly",
+            Role::Admin => "admin",
+            Role::Owner => "owner",
+        }
+    }
+
+    /// Does this role satisfy a minimum required role?
+    pub fn satisfies(self, min: Role) -> bool {
+        self.rank() >= min.rank()
+    }
+}
+
+/// The authenticated admin actor for a request (for RBAC + audit).
+#[derive(Debug, Clone)]
+pub struct AdminActor {
+    pub name: String,
+    pub role: Role,
+}
+
+/// Session token payload (the signed part).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionClaims {
+    /// Subject — the admin username.
+    pub sub: String,
+    /// Role at mint time (re-checked against `ver`).
+    pub role: String,
+    /// The user's `token_version` at mint time (H1 revocation).
+    pub ver: i64,
+    /// Signing-key id (H3 rotation).
+    pub kid: String,
+    /// Issued-at / expiry, unix seconds (leader/edge assigned).
+    pub iat: i64,
+    pub exp: i64,
+}
+
+/// Sign a session token. `key` is the raw `admin_session_key` bytes.
+pub fn sign_session(key: &[u8], claims: &SessionClaims) -> Result<String, String> {
+    let payload = serde_json::to_vec(claims).map_err(|e| format!("encode session claims: {e}"))?;
+    let payload_b64 = URL_SAFE_NO_PAD.encode(&payload);
+    let mut mac =
+        HmacSha256::new_from_slice(key).map_err(|_| "bad session key length".to_string())?;
+    mac.update(payload_b64.as_bytes());
+    let sig = mac.finalize().into_bytes();
+    Ok(format!("{payload_b64}.{}", URL_SAFE_NO_PAD.encode(sig)))
+}
+
+/// Why a session token was rejected (all map to 401 at the HTTP layer).
+#[derive(Debug, PartialEq, Eq)]
+pub enum SessionError {
+    Malformed,
+    BadSignature,
+    Expired,
+    BadPayload,
+}
+
+/// Verify a session token against a signing key, constant-time, verifying the
+/// signature over the exact received payload bytes BEFORE parsing JSON (M5).
+/// Checks `exp` against `now` (unix seconds) with a small skew tolerance.
+/// Does NOT check `ver`/role — the caller does that against `control.db`.
+pub fn verify_session(
+    key: &[u8],
+    token: &str,
+    now: i64,
+    skew_secs: i64,
+) -> Result<SessionClaims, SessionError> {
+    let (payload_b64, sig_b64) = token.split_once('.').ok_or(SessionError::Malformed)?;
+    if payload_b64.is_empty() || sig_b64.is_empty() {
+        return Err(SessionError::Malformed);
+    }
+    let sig = URL_SAFE_NO_PAD
+        .decode(sig_b64)
+        .map_err(|_| SessionError::Malformed)?;
+    // Constant-time verification over the raw received payload bytes.
+    let mut mac = HmacSha256::new_from_slice(key).map_err(|_| SessionError::BadSignature)?;
+    mac.update(payload_b64.as_bytes());
+    mac.verify_slice(&sig)
+        .map_err(|_| SessionError::BadSignature)?;
+    // Signature is valid — now it is safe to parse.
+    let payload = URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .map_err(|_| SessionError::BadPayload)?;
+    let claims: SessionClaims =
+        serde_json::from_slice(&payload).map_err(|_| SessionError::BadPayload)?;
+    if now > claims.exp + skew_secs {
+        return Err(SessionError::Expired);
+    }
+    Ok(claims)
+}
+
+// ── Passwords (argon2id) ────────────────────────────────────────────
+
+/// Hash a password with argon2id (random salt). Returns the PHC string
+/// stored/replicated as `password_hash`. Runs at the request-terminating
+/// node; plaintext never enters a control op (M3).
+pub fn hash_password(password: &str) -> Result<String, String> {
+    use argon2::password_hash::{rand_core::OsRng, PasswordHasher, SaltString};
+    use argon2::Argon2;
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| format!("argon2 hash: {e}"))
+}
+
+/// Verify a password against a stored argon2 PHC hash (constant-time inside
+/// argon2). Returns false on any parse/verify failure (fail closed).
+pub fn verify_password(password: &str, phc: &str) -> bool {
+    use argon2::password_hash::{PasswordHash, PasswordVerifier};
+    use argon2::Argon2;
+    match PasswordHash::new(phc) {
+        Ok(parsed) => Argon2::default()
+            .verify_password(password.as_bytes(), &parsed)
+            .is_ok(),
+        Err(_) => false,
+    }
+}
+
+/// A fixed decoy hash for unknown-user logins (M4 anti-enumeration): verify
+/// against it so an unknown username costs the same argon2 time as a known
+/// one and reveals nothing. Generated once per process (value irrelevant).
+pub fn decoy_hash() -> &'static str {
+    // A precomputed argon2id hash of a random string. Constant across the
+    // process; only the *timing* matters, never a match.
+    "$argon2id$v=19$m=19456,t=2,p=1$Y2xhdWRlZGVjb3lzYWx0$V7m1oq9pO7m3n5r8t0uWx2z4A6C8E0G2I4K6M8O0Q2S"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_ordering_and_parse() {
+        assert!(Role::Owner.satisfies(Role::Admin));
+        assert!(Role::Admin.satisfies(Role::Readonly));
+        assert!(!Role::Readonly.satisfies(Role::Admin));
+        assert_eq!(Role::parse("owner"), Some(Role::Owner));
+        assert_eq!(Role::parse("root"), None); // unknown → fail closed
+        assert_eq!(Role::parse(""), None);
+    }
+
+    #[test]
+    fn password_roundtrip() {
+        let h = hash_password("s3cret-pw").unwrap();
+        assert!(verify_password("s3cret-pw", &h));
+        assert!(!verify_password("wrong", &h));
+        assert!(!verify_password("s3cret-pw", "not-a-hash"));
+    }
+
+    #[test]
+    fn session_sign_verify_and_tamper() {
+        let key = b"0123456789abcdef0123456789abcdef";
+        let claims = SessionClaims {
+            sub: "alice".into(),
+            role: "owner".into(),
+            ver: 3,
+            kid: "k1".into(),
+            iat: 1000,
+            exp: 5000,
+        };
+        let tok = sign_session(key, &claims).unwrap();
+        let got = verify_session(key, &tok, 2000, 30).unwrap();
+        assert_eq!(got.sub, "alice");
+        assert_eq!(got.ver, 3);
+        // Expired.
+        assert_eq!(
+            verify_session(key, &tok, 6000, 30),
+            Err(SessionError::Expired)
+        );
+        // Wrong key.
+        assert_eq!(
+            verify_session(b"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", &tok, 2000, 30),
+            Err(SessionError::BadSignature)
+        );
+        // Tampered payload (flip a char in the payload segment).
+        let mut parts: Vec<&str> = tok.split('.').collect();
+        let mangled_payload = format!("{}A", parts[0]);
+        parts[0] = &mangled_payload;
+        let tampered = format!("{}.{}", parts[0], parts[1]);
+        assert!(verify_session(key, &tampered, 2000, 30).is_err());
+        // Malformed.
+        assert_eq!(
+            verify_session(key, "no-dot", 2000, 30),
+            Err(SessionError::Malformed)
+        );
+    }
+}

--- a/crates/yantrikdb-server/src/auth/admin.rs
+++ b/crates/yantrikdb-server/src/auth/admin.rs
@@ -176,11 +176,17 @@ pub fn verify_password(password: &str, phc: &str) -> bool {
 
 /// A fixed decoy hash for unknown-user logins (M4 anti-enumeration): verify
 /// against it so an unknown username costs the same argon2 time as a known
-/// one and reveals nothing. Generated once per process (value irrelevant).
+/// one and reveals nothing. Computed once per process via the SAME argon2
+/// path as real hashes, so it is guaranteed to be a canonical PHC string
+/// that `verify_password` will actually run argon2 against (a hand-written
+/// constant risks non-canonical base64 that `PasswordHash::new` rejects,
+/// short-circuiting before argon2 runs and re-opening the timing oracle).
 pub fn decoy_hash() -> &'static str {
-    // A precomputed argon2id hash of a random string. Constant across the
-    // process; only the *timing* matters, never a match.
-    "$argon2id$v=19$m=19456,t=2,p=1$Y2xhdWRlZGVjb3lzYWx0$V7m1oq9pO7m3n5r8t0uWx2z4A6C8E0G2I4K6M8O0Q2S"
+    static DECOY: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    DECOY.get_or_init(|| {
+        hash_password("decoy-not-a-real-account-timing-equalizer")
+            .expect("argon2 default params always hash")
+    })
 }
 
 #[cfg(test)]
@@ -195,6 +201,17 @@ mod tests {
         assert_eq!(Role::parse("owner"), Some(Role::Owner));
         assert_eq!(Role::parse("root"), None); // unknown → fail closed
         assert_eq!(Role::parse(""), None);
+    }
+
+    #[test]
+    fn decoy_hash_is_valid_argon2() {
+        // Regression for the M4 timing-oracle bug: the decoy MUST parse as a
+        // canonical PHC so verify_password actually runs argon2 on it (equal
+        // cost to a real user), not short-circuit to false.
+        use argon2::password_hash::PasswordHash;
+        assert!(PasswordHash::new(decoy_hash()).is_ok());
+        // And a login attempt against it costs argon2 time and never matches.
+        assert!(!verify_password("anything", decoy_hash()));
     }
 
     #[test]

--- a/crates/yantrikdb-server/src/auth/mod.rs
+++ b/crates/yantrikdb-server/src/auth/mod.rs
@@ -20,6 +20,7 @@
 use rand::Rng;
 use sha2::{Digest, Sha256};
 
+pub mod admin;
 pub mod audit;
 pub mod control_provider;
 pub mod middleware;

--- a/crates/yantrikdb-server/src/control.rs
+++ b/crates/yantrikdb-server/src/control.rs
@@ -95,6 +95,42 @@ impl ControlDb {
                 max_rps         INTEGER NOT NULL DEFAULT 1000,
                 updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
             );
+
+            -- RFC 030: replicated admin accounts. password_hash is argon2id
+            -- (never plaintext); role is 'owner'|'admin'|'readonly'.
+            -- token_version bumps on password/role/disable change so live
+            -- stateless sessions minted before the change fail verification.
+            CREATE TABLE IF NOT EXISTS admin_users (
+                username      TEXT PRIMARY KEY,
+                password_hash TEXT NOT NULL,
+                role          TEXT NOT NULL,
+                token_version INTEGER NOT NULL DEFAULT 1,
+                disabled_at   TEXT,
+                created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            -- RFC 030 (H3): replicated server secrets, decoupled from
+            -- cluster_secret. Holds the admin session-signing key (id
+            -- 'admin_session_key') as a kid + base64 value so sessions verify
+            -- on every node and the key can rotate independently of peer auth.
+            CREATE TABLE IF NOT EXISTS server_secrets (
+                id      TEXT PRIMARY KEY,
+                kid     TEXT NOT NULL,
+                value   TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            -- RFC 030 (M1): replicated, tamper-evident admin audit. Written
+            -- deterministically by ControlApplySink as each mutating control
+            -- op applies, so the trail is quorum-durable + byte-identical on
+            -- every node and survives failover/node loss.
+            CREATE TABLE IF NOT EXISTS audit_log (
+                yrp_index  INTEGER PRIMARY KEY,
+                actor      TEXT NOT NULL,
+                action     TEXT NOT NULL,
+                target     TEXT NOT NULL,
+                at         TEXT NOT NULL
+            );
             ",
         )?;
         Ok(())
@@ -173,6 +209,35 @@ impl ControlDb {
             .prepare("SELECT database_id FROM tokens WHERE hash = ?1 AND revoked_at IS NULL")?;
         let mut rows = stmt.query_map(params![hash], |row| row.get::<_, i64>(0))?;
         Ok(rows.next().transpose()?)
+    }
+
+    /// Look up a token's `(database_id, label)` by hash (active tokens only)
+    /// — used by rotation to mint a replacement for the same db + label.
+    pub fn get_token_meta(&self, hash: &str) -> anyhow::Result<Option<(i64, String)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT database_id, label FROM tokens WHERE hash = ?1 AND revoked_at IS NULL",
+        )?;
+        let mut rows = stmt.query_map(params![hash], |r| {
+            Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+        })?;
+        Ok(rows.next().transpose()?)
+    }
+
+    /// List active tokens (hash included; the HTTP layer redacts to a prefix).
+    pub fn list_active_tokens(&self) -> anyhow::Result<Vec<TokenSnapshot>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT hash, database_id, label, created_at FROM tokens WHERE revoked_at IS NULL
+             ORDER BY database_id, created_at",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(TokenSnapshot {
+                hash: row.get(0)?,
+                database_id: row.get(1)?,
+                label: row.get(2)?,
+                created_at: row.get(3)?,
+            })
+        })?;
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
 
     /// Revoke a token.
@@ -319,6 +384,195 @@ impl ControlDb {
         Ok(changed > 0)
     }
 
+    // ── RFC 030: replicated admin accounts (control-op apply + reads) ──
+
+    /// Apply a replicated user create. Idempotent on the username PK.
+    /// `password_hash` is argon2id, computed by the leader before proposing
+    /// so every node stores the identical hash (never re-hashed per node).
+    pub fn apply_create_user(
+        &self,
+        username: &str,
+        password_hash: &str,
+        role: &str,
+        created_at: &str,
+    ) -> anyhow::Result<bool> {
+        let changed = self.conn.execute(
+            "INSERT OR IGNORE INTO admin_users (username, password_hash, role, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![username, password_hash, role, created_at],
+        )?;
+        Ok(changed > 0)
+    }
+
+    /// Apply a role change, bumping `token_version` so the user's live
+    /// stateless sessions (minted at the old version) stop verifying.
+    ///
+    /// **Owner-floor (H2), enforced HERE at apply time in log order:** if this
+    /// change would demote the last enabled `owner`, it is a deterministic
+    /// no-op on every node — never leave the cluster with zero owners. Because
+    /// the check + update run under one lock at a fixed log position, two
+    /// concurrent demotions proposed on different nodes cannot race to zero.
+    pub fn apply_set_user_role(&self, username: &str, role: &str) -> anyhow::Result<bool> {
+        if role != "owner" {
+            let is_last_owner: bool = self.conn.query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM admin_users
+                    WHERE username = ?1 AND role = 'owner' AND disabled_at IS NULL
+                 ) AND (SELECT COUNT(*) FROM admin_users
+                        WHERE role = 'owner' AND disabled_at IS NULL) <= 1",
+                params![username],
+                |r| r.get(0),
+            )?;
+            if is_last_owner {
+                tracing::warn!(username, "owner-floor: refusing to demote the last owner");
+                return Ok(false);
+            }
+        }
+        let changed = self.conn.execute(
+            "UPDATE admin_users SET role = ?2, token_version = token_version + 1
+             WHERE username = ?1",
+            params![username, role],
+        )?;
+        Ok(changed > 0)
+    }
+
+    /// Apply a password rotation (argon2id hash), bumping `token_version`.
+    pub fn apply_set_user_password(&self, username: &str, hash: &str) -> anyhow::Result<bool> {
+        let changed = self.conn.execute(
+            "UPDATE admin_users SET password_hash = ?2, token_version = token_version + 1
+             WHERE username = ?1",
+            params![username, hash],
+        )?;
+        Ok(changed > 0)
+    }
+
+    /// Apply a soft-disable, bumping `token_version` so live sessions die.
+    /// Owner-floor (H2) at apply time: refuses to disable the last enabled
+    /// owner (deterministic no-op on every node).
+    pub fn apply_disable_user(&self, username: &str, disabled_at: &str) -> anyhow::Result<bool> {
+        let is_last_owner: bool = self.conn.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM admin_users
+                WHERE username = ?1 AND role = 'owner' AND disabled_at IS NULL
+             ) AND (SELECT COUNT(*) FROM admin_users
+                    WHERE role = 'owner' AND disabled_at IS NULL) <= 1",
+            params![username],
+            |r| r.get(0),
+        )?;
+        if is_last_owner {
+            tracing::warn!(username, "owner-floor: refusing to disable the last owner");
+            return Ok(false);
+        }
+        let changed = self.conn.execute(
+            "UPDATE admin_users SET disabled_at = ?2, token_version = token_version + 1
+             WHERE username = ?1 AND disabled_at IS NULL",
+            params![username, disabled_at],
+        )?;
+        Ok(changed > 0)
+    }
+
+    /// Look up an admin account (for login + session verification). Returns
+    /// `None` for unknown users; the caller checks `disabled_at`.
+    pub fn get_admin_user(&self, username: &str) -> anyhow::Result<Option<AdminUserRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT username, password_hash, role, token_version, disabled_at, created_at
+             FROM admin_users WHERE username = ?1",
+        )?;
+        let mut rows = stmt.query_map(params![username], Self::map_admin_user)?;
+        Ok(rows.next().transpose()?)
+    }
+
+    /// List admin accounts (password hashes included for internal callers;
+    /// the HTTP layer strips them). Ordered by username.
+    pub fn list_admin_users(&self) -> anyhow::Result<Vec<AdminUserRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT username, password_hash, role, token_version, disabled_at, created_at
+             FROM admin_users ORDER BY username",
+        )?;
+        let rows = stmt.query_map([], Self::map_admin_user)?;
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    /// Count enabled `owner` accounts — enforces the owner-floor invariant
+    /// (never disable/demote the last owner and lock everyone out).
+    pub fn count_enabled_owners(&self) -> anyhow::Result<i64> {
+        let n: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM admin_users WHERE role = 'owner' AND disabled_at IS NULL",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(n)
+    }
+
+    /// The admin session-signing key `(kid, base64_value)` if seeded (H3).
+    pub fn get_admin_session_key(&self) -> anyhow::Result<Option<(String, String)>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT kid, value FROM server_secrets WHERE id = 'admin_session_key'")?;
+        let mut rows =
+            stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?;
+        Ok(rows.next().transpose()?)
+    }
+
+    /// Apply a replicated session-key set/rotate (H3). Last-writer-by-kid.
+    pub fn apply_set_admin_session_key(&self, kid: &str, value: &str) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT INTO server_secrets (id, kid, value) VALUES ('admin_session_key', ?1, ?2)
+             ON CONFLICT(id) DO UPDATE SET kid = excluded.kid, value = excluded.value,
+                created_at = datetime('now')",
+            params![kid, value],
+        )?;
+        Ok(())
+    }
+
+    /// Write a replicated audit row keyed on the YRP log index (M1),
+    /// idempotent on replay. Called by `ControlApplySink` as it applies a
+    /// mutating control op.
+    pub fn apply_audit(
+        &self,
+        yrp_index: u64,
+        actor: &str,
+        action: &str,
+        target: &str,
+        at: &str,
+    ) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT OR IGNORE INTO audit_log (yrp_index, actor, action, target, at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![yrp_index as i64, actor, action, target, at],
+        )?;
+        Ok(())
+    }
+
+    /// Most-recent audit rows (M1), newest first, for the audit view.
+    pub fn list_audit(&self, limit: i64) -> anyhow::Result<Vec<AuditRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT yrp_index, actor, action, target, at FROM audit_log
+             ORDER BY yrp_index DESC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit], |row| {
+            Ok(AuditRow {
+                yrp_index: row.get::<_, i64>(0)? as u64,
+                actor: row.get(1)?,
+                action: row.get(2)?,
+                target: row.get(3)?,
+                at: row.get(4)?,
+            })
+        })?;
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    fn map_admin_user(row: &rusqlite::Row) -> rusqlite::Result<AdminUserRecord> {
+        Ok(AdminUserRecord {
+            username: row.get(0)?,
+            password_hash: row.get(1)?,
+            role: row.get(2)?,
+            token_version: row.get(3)?,
+            disabled_at: row.get(4)?,
+            created_at: row.get(5)?,
+        })
+    }
+
     // ── Control Plane Replication ──────────────────────────────────
 
     /// Export a full snapshot of databases + active tokens for replication.
@@ -383,6 +637,28 @@ impl ControlDb {
 pub struct ControlSnapshot {
     pub databases: Vec<DatabaseRecord>,
     pub tokens: Vec<TokenSnapshot>,
+}
+
+/// RFC 030 (M1) — a replicated audit row (newest-first in the audit view).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AuditRow {
+    pub yrp_index: u64,
+    pub actor: String,
+    pub action: String,
+    pub target: String,
+    pub at: String,
+}
+
+/// RFC 030 — a replicated admin account row. `password_hash` (argon2id) is
+/// never exposed by the HTTP layer.
+#[derive(Debug, Clone)]
+pub struct AdminUserRecord {
+    pub username: String,
+    pub password_hash: String,
+    pub role: String,
+    pub token_version: i64,
+    pub disabled_at: Option<String>,
+    pub created_at: String,
 }
 
 /// Token record as serialized for replication (no revoked tokens).

--- a/crates/yantrikdb-server/src/control.rs
+++ b/crates/yantrikdb-server/src/control.rs
@@ -412,7 +412,19 @@ impl ControlDb {
     /// no-op on every node — never leave the cluster with zero owners. Because
     /// the check + update run under one lock at a fixed log position, two
     /// concurrent demotions proposed on different nodes cannot race to zero.
-    pub fn apply_set_user_role(&self, username: &str, role: &str) -> anyhow::Result<bool> {
+    /// `version` is the YRP log index at which this change applies. We SET
+    /// `token_version = version` (not `+1`) so the bump is **crash-replay
+    /// idempotent and identical on every node** (review F2): the apply and
+    /// the durable marker are separate DB commits, so an index can re-apply
+    /// after a crash — an unconditional increment would diverge, breaking the
+    /// H1 revocation the value underpins. The index is monotonic, so this is
+    /// still strictly-increasing per change.
+    pub fn apply_set_user_role(
+        &self,
+        version: u64,
+        username: &str,
+        role: &str,
+    ) -> anyhow::Result<bool> {
         if role != "owner" {
             let is_last_owner: bool = self.conn.query_row(
                 "SELECT EXISTS(
@@ -428,28 +440,41 @@ impl ControlDb {
                 return Ok(false);
             }
         }
+        // `role <> ?2` makes a same-role write a true no-op (review F5): it
+        // neither changes the row nor invalidates the user's live sessions.
         let changed = self.conn.execute(
-            "UPDATE admin_users SET role = ?2, token_version = token_version + 1
-             WHERE username = ?1",
-            params![username, role],
+            "UPDATE admin_users SET role = ?2, token_version = ?3
+             WHERE username = ?1 AND role <> ?2",
+            params![username, role, version as i64],
         )?;
         Ok(changed > 0)
     }
 
-    /// Apply a password rotation (argon2id hash), bumping `token_version`.
-    pub fn apply_set_user_password(&self, username: &str, hash: &str) -> anyhow::Result<bool> {
+    /// Apply a password rotation (argon2id hash). `version` = the log index
+    /// (idempotent, see [`apply_set_user_role`]).
+    pub fn apply_set_user_password(
+        &self,
+        version: u64,
+        username: &str,
+        hash: &str,
+    ) -> anyhow::Result<bool> {
         let changed = self.conn.execute(
-            "UPDATE admin_users SET password_hash = ?2, token_version = token_version + 1
+            "UPDATE admin_users SET password_hash = ?2, token_version = ?3
              WHERE username = ?1",
-            params![username, hash],
+            params![username, hash, version as i64],
         )?;
         Ok(changed > 0)
     }
 
-    /// Apply a soft-disable, bumping `token_version` so live sessions die.
-    /// Owner-floor (H2) at apply time: refuses to disable the last enabled
-    /// owner (deterministic no-op on every node).
-    pub fn apply_disable_user(&self, username: &str, disabled_at: &str) -> anyhow::Result<bool> {
+    /// Apply a soft-disable, setting `token_version` to the log index so live
+    /// sessions die. Owner-floor (H2) at apply time: refuses to disable the
+    /// last enabled owner (deterministic no-op on every node).
+    pub fn apply_disable_user(
+        &self,
+        version: u64,
+        username: &str,
+        disabled_at: &str,
+    ) -> anyhow::Result<bool> {
         let is_last_owner: bool = self.conn.query_row(
             "SELECT EXISTS(
                 SELECT 1 FROM admin_users
@@ -464,9 +489,9 @@ impl ControlDb {
             return Ok(false);
         }
         let changed = self.conn.execute(
-            "UPDATE admin_users SET disabled_at = ?2, token_version = token_version + 1
+            "UPDATE admin_users SET disabled_at = ?2, token_version = ?3
              WHERE username = ?1 AND disabled_at IS NULL",
-            params![username, disabled_at],
+            params![username, disabled_at, version as i64],
         )?;
         Ok(changed > 0)
     }

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -2614,6 +2614,16 @@ use crate::auth::admin::{AdminActor, Role};
 const SESSION_TTL_SECS: i64 = 3600;
 const SESSION_SKEW_SECS: i64 = 60;
 
+/// Monotonic-ish version for single-node (non-yrp) admin mutations, where
+/// there is no YRP log index. Epoch millis — strictly increasing in practice
+/// and never compared across nodes (single-node has no replication).
+fn admin_local_version() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
 fn unix_now() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -2785,6 +2795,15 @@ async fn admin_login(State(state): State<Arc<AppState>>, Json(body): Json<Value>
         return Err(app_error(
             StatusCode::BAD_REQUEST,
             "username and password required",
+        ));
+    }
+    // L3/F4: don't mint a session from a node that hasn't caught up on the
+    // control log — it may read a stale admin_users (e.g. a since-disabled
+    // account). Fail closed, consistent with require_role.
+    if let Some(reason) = crate::server::control_auth_stale(&state) {
+        return Err(app_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("control plane not ready for login: {reason}"),
         ));
     }
     // M4: cap concurrent argon2 verifications process-wide.
@@ -3198,7 +3217,7 @@ async fn admin_set_user_role(
         state
             .control
             .lock()
-            .apply_set_user_role(&username, role)
+            .apply_set_user_role(admin_local_version(), &username, role)
             .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     }
     // Report the EFFECTIVE role (owner-floor may have refused a demotion).
@@ -3234,7 +3253,7 @@ async fn admin_set_user_password(
         state
             .control
             .lock()
-            .apply_set_user_password(&username, &hash)
+            .apply_set_user_password(admin_local_version(), &username, &hash)
             .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     }
     Ok(Json(json!({ "username": username, "rotated": true })))
@@ -3256,7 +3275,7 @@ async fn admin_disable_user(
         state
             .control
             .lock()
-            .apply_disable_user(&username, &now)
+            .apply_disable_user(admin_local_version(), &username, &now)
             .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     }
     // owner-floor may refuse — report effective state.

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -2608,6 +2608,241 @@ async fn list_databases(
 /// follower answers 503 with the leader's address so the caller (studio or
 /// operator CLI) redirects the admin write to the leader — the same posture
 /// as a data-plane write against a follower.
+// ── RFC 030: admin RBAC guard + stateless session auth ──────────────
+use crate::auth::admin::{AdminActor, Role};
+
+const SESSION_TTL_SECS: i64 = 3600;
+const SESSION_SKEW_SECS: i64 = 60;
+
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn is_master_token(state: &AppState, token: &str) -> bool {
+    let ct_eq = |secret: Option<&String>| {
+        secret
+            .map(|s| {
+                // constant-time compare (M5 / earlier nit)
+                let a = s.as_bytes();
+                let b = token.as_bytes();
+                let mut diff = a.len() ^ b.len();
+                for i in 0..a.len().max(b.len()) {
+                    diff |= (*a.get(i).unwrap_or(&0) ^ *b.get(i).unwrap_or(&0)) as usize;
+                }
+                diff == 0
+            })
+            .unwrap_or(false)
+    };
+    ct_eq(
+        state
+            .cluster
+            .as_ref()
+            .and_then(|c| c.config.cluster_secret.as_ref()),
+    ) || ct_eq(state.yrp.as_ref().and_then(|y| y.cluster_secret.as_ref()))
+}
+
+/// The raw admin session-signing key `(kid, bytes)` (H3). Ensures the
+/// replicated key exists, seeding it once (leader-proposed in yrp mode) if
+/// absent. Independent of `cluster_secret`.
+async fn admin_session_key(state: &AppState) -> Result<(String, Vec<u8>), AppError> {
+    use base64::engine::general_purpose::STANDARD as B64;
+    use base64::Engine as _;
+    if let Some((kid, val)) = state
+        .control
+        .lock()
+        .get_admin_session_key()
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+    {
+        let bytes = B64
+            .decode(val)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        return Ok((kid, bytes));
+    }
+    // Seed a fresh 32-byte key + short kid.
+    let mut raw = [0u8; 32];
+    let mut kidb = [0u8; 6];
+    {
+        use rand::RngCore;
+        rand::rngs::OsRng.fill_bytes(&mut raw);
+        rand::rngs::OsRng.fill_bytes(&mut kidb);
+    }
+    let kid = hex::encode(kidb);
+    let val_b64 = B64.encode(raw);
+    match &state.yrp {
+        Some(yrp) => {
+            yrp.set_admin_session_key_replicated("system", kid.clone(), val_b64)
+                .await
+                .map_err(control_write_err)?;
+        }
+        None => {
+            state
+                .control
+                .lock()
+                .apply_set_admin_session_key(&kid, &val_b64)
+                .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        }
+    }
+    // Read back the effective key (a concurrent seeder may have won).
+    let (kid, val) = state
+        .control
+        .lock()
+        .get_admin_session_key()
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or_else(|| app_error(StatusCode::INTERNAL_SERVER_ERROR, "session key seed failed"))?;
+    let bytes = B64
+        .decode(val)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok((kid, bytes))
+}
+
+/// The RBAC guard. Resolves the request's admin actor and enforces `min`.
+/// Accepts (1) a valid session token (verify HMAC+exp, check `ver`/disabled
+/// against control.db, parse role), or (2) the master token (→ owner,
+/// break-glass, loud log — L6). Fails closed. Also refuses on a
+/// control-stale node (L3) so no decision rides stale RBAC state.
+async fn require_role(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+    min: Role,
+) -> Result<AdminActor, AppError> {
+    let token = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .ok_or_else(|| app_error(StatusCode::UNAUTHORIZED, "missing Bearer token"))?;
+
+    // L3: never authorize admin actions on a node behind the control log.
+    if let Some(reason) = crate::server::control_auth_stale(state) {
+        return Err(app_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("control plane not ready for admin: {reason}"),
+        ));
+    }
+
+    // Break-glass master token → owner.
+    if is_master_token(state, token) {
+        tracing::warn!("admin: break-glass master-token access (actor=master-token)");
+        if !Role::Owner.satisfies(min) {
+            return Err(app_error(StatusCode::FORBIDDEN, "insufficient role"));
+        }
+        return Ok(AdminActor {
+            name: "master-token".into(),
+            role: Role::Owner,
+        });
+    }
+
+    // Session token.
+    let (kid, key) = admin_session_key(state).await?;
+    let claims = crate::auth::admin::verify_session(&key, token, unix_now(), SESSION_SKEW_SECS)
+        .map_err(|_| app_error(StatusCode::UNAUTHORIZED, "invalid or expired session"))?;
+    if claims.kid != kid {
+        return Err(app_error(
+            StatusCode::UNAUTHORIZED,
+            "session signed by a rotated key; re-login",
+        ));
+    }
+    // H1: the user's current token_version must match; and not disabled.
+    let user = state
+        .control
+        .lock()
+        .get_admin_user(&claims.sub)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or_else(|| app_error(StatusCode::UNAUTHORIZED, "unknown account"))?;
+    if user.disabled_at.is_some() || user.token_version != claims.ver {
+        return Err(app_error(
+            StatusCode::UNAUTHORIZED,
+            "session revoked; re-login",
+        ));
+    }
+    let role =
+        Role::parse(&user.role).ok_or_else(|| app_error(StatusCode::FORBIDDEN, "unknown role"))?;
+    if !role.satisfies(min) {
+        return Err(app_error(StatusCode::FORBIDDEN, "insufficient role"));
+    }
+    Ok(AdminActor {
+        name: claims.sub,
+        role,
+    })
+}
+
+/// POST /v1/admin/session — login → signed session token. Rate-limited
+/// before argon2 (M4), decoy-verify for unknown users (anti-enumeration).
+async fn admin_login(State(state): State<Arc<AppState>>, Json(body): Json<Value>) -> AppResult {
+    let username = body
+        .get("username")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let password = body
+        .get("password")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if username.is_empty() || password.is_empty() {
+        return Err(app_error(
+            StatusCode::BAD_REQUEST,
+            "username and password required",
+        ));
+    }
+    // M4: cap concurrent argon2 verifications process-wide.
+    let _permit = admin_login_gate().acquire().await;
+
+    let user = state
+        .control
+        .lock()
+        .get_admin_user(&username)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Constant-cost path for unknown/disabled users (M4 anti-enumeration).
+    let (ok, role, ver) = match &user {
+        Some(u) if u.disabled_at.is_none() => (
+            crate::auth::admin::verify_password(&password, &u.password_hash),
+            u.role.clone(),
+            u.token_version,
+        ),
+        _ => {
+            let _ =
+                crate::auth::admin::verify_password(&password, crate::auth::admin::decoy_hash());
+            (false, String::new(), 0)
+        }
+    };
+    if !ok {
+        return Err(app_error(StatusCode::UNAUTHORIZED, "invalid credentials"));
+    }
+    let (kid, key) = admin_session_key(&state).await?;
+    let now = unix_now();
+    let claims = crate::auth::admin::SessionClaims {
+        sub: username,
+        role,
+        ver,
+        kid,
+        iat: now,
+        exp: now + SESSION_TTL_SECS,
+    };
+    let token = crate::auth::admin::sign_session(&key, &claims)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(
+        json!({ "token": token, "role": claims.role, "expires_at": claims.exp, "username": claims.sub }),
+    ))
+}
+
+/// Process-wide semaphore capping concurrent argon2 verifications (M4).
+fn admin_login_gate() -> &'static tokio::sync::Semaphore {
+    static GATE: std::sync::OnceLock<tokio::sync::Semaphore> = std::sync::OnceLock::new();
+    GATE.get_or_init(|| tokio::sync::Semaphore::new(4))
+}
+
+/// GET /v1/admin/me — the current actor + role (drives the role-aware UI).
+async fn admin_me(State(state): State<Arc<AppState>>, headers: axum::http::HeaderMap) -> AppResult {
+    let actor = require_role(&state, &headers, Role::Readonly).await?;
+    Ok(Json(
+        json!({ "username": actor.name, "role": actor.role.as_str() }),
+    ))
+}
+
 fn control_propose_err(e: crate::yrp::runtime::YrpProposeError) -> AppError {
     use crate::yrp::runtime::YrpProposeError as E;
     match e {
@@ -2653,7 +2888,7 @@ async fn admin_create_database(
     headers: axum::http::HeaderMap,
     Json(body): Json<Value>,
 ) -> AppResult {
-    require_master_token(&state, &headers)?;
+    let actor = require_role(&state, &headers, Role::Admin).await?;
     let name = body
         .get("name")
         .and_then(|v| v.as_str())
@@ -2672,7 +2907,7 @@ async fn admin_create_database(
     if let Some(yrp) = &state.yrp {
         let created_at = chrono::Utc::now().to_rfc3339();
         let id = yrp
-            .create_database_replicated(&name, &path, &config, created_at)
+            .create_database_replicated(&actor.name, &name, &path, &config, created_at)
             .await
             .map_err(control_write_err)?;
         Ok(Json(json!({ "id": id, "name": name, "replicated": true })))
@@ -2699,7 +2934,7 @@ async fn admin_create_token(
     headers: axum::http::HeaderMap,
     Json(body): Json<Value>,
 ) -> AppResult {
-    require_master_token(&state, &headers)?;
+    let actor = require_role(&state, &headers, Role::Admin).await?;
     let db_id = if let Some(id) = body.get("database_id").and_then(|v| v.as_i64()) {
         id
     } else if let Some(dbname) = body.get("database").and_then(|v| v.as_str()) {
@@ -2747,9 +2982,15 @@ async fn admin_create_token(
     let hash = crate::auth::hash_token(&raw);
 
     if let Some(yrp) = &state.yrp {
-        yrp.create_token_replicated(db_id, hash, label, chrono::Utc::now().to_rfc3339())
-            .await
-            .map_err(control_write_err)?;
+        yrp.create_token_replicated(
+            &actor.name,
+            db_id,
+            hash,
+            label,
+            chrono::Utc::now().to_rfc3339(),
+        )
+        .await
+        .map_err(control_write_err)?;
         Ok(Json(
             json!({ "token": raw, "database_id": db_id, "replicated": true }),
         ))
@@ -2777,7 +3018,7 @@ async fn admin_revoke_token(
     headers: axum::http::HeaderMap,
     Json(body): Json<Value>,
 ) -> AppResult {
-    require_master_token(&state, &headers)?;
+    let actor = require_role(&state, &headers, Role::Admin).await?;
     let hash = if let Some(t) = body.get("token").and_then(|v| v.as_str()) {
         crate::auth::hash_token(t)
     } else if let Some(h) = body.get("hash").and_then(|v| v.as_str()) {
@@ -2790,7 +3031,7 @@ async fn admin_revoke_token(
     };
 
     if let Some(yrp) = &state.yrp {
-        yrp.revoke_token_replicated(hash, chrono::Utc::now().to_rfc3339())
+        yrp.revoke_token_replicated(&actor.name, hash, chrono::Utc::now().to_rfc3339())
             .await
             .map_err(control_write_err)?;
         Ok(Json(json!({ "revoked": true, "replicated": true })))
@@ -2804,6 +3045,348 @@ async fn admin_revoke_token(
         .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
         Ok(Json(json!({ "revoked": revoked, "replicated": false })))
     }
+}
+
+// ── RFC 030: management endpoints (RBAC-gated, redacted) ────────────
+
+/// GET /v1/admin/databases — list databases with token counts. readonly+.
+async fn admin_list_databases(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+) -> AppResult {
+    require_role(&state, &headers, Role::Readonly).await?;
+    let (dbs, toks) = {
+        let c = state.control.lock();
+        (
+            c.list_databases()
+                .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+            c.list_active_tokens()
+                .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+        )
+    };
+    let list: Vec<Value> = dbs
+        .iter()
+        .map(|d| {
+            let n = toks.iter().filter(|t| t.database_id == d.id).count();
+            json!({ "id": d.id, "name": d.name, "created_at": d.created_at, "token_count": n })
+        })
+        .collect();
+    Ok(Json(json!({ "databases": list })))
+}
+
+/// GET /v1/admin/tokens — list active tokens (hash REDACTED to a prefix). readonly+.
+async fn admin_list_tokens(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+) -> AppResult {
+    require_role(&state, &headers, Role::Readonly).await?;
+    let toks = state
+        .control
+        .lock()
+        .list_active_tokens()
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    // The token HASH (SHA-256 of a 256-bit random token) is an identifier,
+    // not a crackable credential — safe to show an authenticated admin so
+    // rotate/revoke can target it. (Password hashes, which ARE crackable,
+    // are never exposed — see the users endpoint. L4.)
+    let list: Vec<Value> = toks
+        .iter()
+        .map(|t| {
+            json!({
+                "hash": t.hash,
+                "hash_prefix": t.hash.chars().take(12).collect::<String>(),
+                "database_id": t.database_id, "label": t.label, "created_at": t.created_at,
+            })
+        })
+        .collect();
+    Ok(Json(json!({ "tokens": list })))
+}
+
+/// GET /v1/admin/users — list admin accounts (NO password hashes). readonly+.
+async fn admin_list_users(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+) -> AppResult {
+    require_role(&state, &headers, Role::Readonly).await?;
+    let users = state
+        .control
+        .lock()
+        .list_admin_users()
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let list: Vec<Value> = users
+        .iter()
+        .map(|u| {
+            json!({
+                "username": u.username, "role": u.role,
+                "disabled": u.disabled_at.is_some(), "created_at": u.created_at,
+            })
+        })
+        .collect();
+    Ok(Json(json!({ "users": list })))
+}
+
+/// POST /v1/admin/users — create an admin account. owner only.
+async fn admin_create_user(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<Value>,
+) -> AppResult {
+    let actor = require_role(&state, &headers, Role::Owner).await?;
+    let username = body
+        .get("username")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let password = body.get("password").and_then(|v| v.as_str()).unwrap_or("");
+    let role = body
+        .get("role")
+        .and_then(|v| v.as_str())
+        .unwrap_or("readonly");
+    if username.is_empty() || password.len() < 8 {
+        return Err(app_error(
+            StatusCode::BAD_REQUEST,
+            "username required; password >= 8 chars",
+        ));
+    }
+    if Role::parse(role).is_none() {
+        return Err(app_error(
+            StatusCode::BAD_REQUEST,
+            "role must be owner|admin|readonly",
+        ));
+    }
+    let hash = crate::auth::admin::hash_password(password)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    let now = chrono::Utc::now().to_rfc3339();
+    if let Some(yrp) = &state.yrp {
+        yrp.create_user_replicated(&actor.name, &username, hash, role.to_string(), now)
+            .await
+            .map_err(control_write_err)?;
+    } else {
+        let c = state.control.lock();
+        if c.get_admin_user(&username)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+            .is_some()
+        {
+            return Err(app_error(StatusCode::CONFLICT, "username already exists"));
+        }
+        c.apply_create_user(&username, &hash, role, &now)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+    Ok(Json(json!({ "username": username, "role": role })))
+}
+
+/// POST /v1/admin/users/{username}/role — change role. owner only.
+async fn admin_set_user_role(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    AxumPath(username): AxumPath<String>,
+    Json(body): Json<Value>,
+) -> AppResult {
+    let actor = require_role(&state, &headers, Role::Owner).await?;
+    let role = body.get("role").and_then(|v| v.as_str()).unwrap_or("");
+    if Role::parse(role).is_none() {
+        return Err(app_error(
+            StatusCode::BAD_REQUEST,
+            "role must be owner|admin|readonly",
+        ));
+    }
+    if let Some(yrp) = &state.yrp {
+        yrp.set_user_role_replicated(&actor.name, &username, role.to_string())
+            .await
+            .map_err(control_write_err)?;
+    } else {
+        state
+            .control
+            .lock()
+            .apply_set_user_role(&username, role)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+    // Report the EFFECTIVE role (owner-floor may have refused a demotion).
+    let eff = state
+        .control
+        .lock()
+        .get_admin_user(&username)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map(|u| u.role)
+        .unwrap_or_default();
+    Ok(Json(json!({ "username": username, "role": eff })))
+}
+
+/// POST /v1/admin/users/{username}/password — rotate password. owner only.
+async fn admin_set_user_password(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    AxumPath(username): AxumPath<String>,
+    Json(body): Json<Value>,
+) -> AppResult {
+    let actor = require_role(&state, &headers, Role::Owner).await?;
+    let password = body.get("password").and_then(|v| v.as_str()).unwrap_or("");
+    if password.len() < 8 {
+        return Err(app_error(StatusCode::BAD_REQUEST, "password >= 8 chars"));
+    }
+    let hash = crate::auth::admin::hash_password(password)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    if let Some(yrp) = &state.yrp {
+        yrp.set_user_password_replicated(&actor.name, &username, hash)
+            .await
+            .map_err(control_write_err)?;
+    } else {
+        state
+            .control
+            .lock()
+            .apply_set_user_password(&username, &hash)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+    Ok(Json(json!({ "username": username, "rotated": true })))
+}
+
+/// POST /v1/admin/users/{username}/disable — disable an account. owner only.
+async fn admin_disable_user(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    AxumPath(username): AxumPath<String>,
+) -> AppResult {
+    let actor = require_role(&state, &headers, Role::Owner).await?;
+    let now = chrono::Utc::now().to_rfc3339();
+    if let Some(yrp) = &state.yrp {
+        yrp.disable_user_replicated(&actor.name, &username, now)
+            .await
+            .map_err(control_write_err)?;
+    } else {
+        state
+            .control
+            .lock()
+            .apply_disable_user(&username, &now)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+    // owner-floor may refuse — report effective state.
+    let disabled = state
+        .control
+        .lock()
+        .get_admin_user(&username)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map(|u| u.disabled_at.is_some())
+        .unwrap_or(false);
+    Ok(Json(json!({ "username": username, "disabled": disabled })))
+}
+
+/// POST /v1/admin/tokens/rotate — mint a replacement for the same db+label,
+/// revoke the old. admin+. Returns the new plaintext once.
+async fn admin_rotate_token(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<Value>,
+) -> AppResult {
+    let actor = require_role(&state, &headers, Role::Admin).await?;
+    let old_hash = if let Some(t) = body.get("token").and_then(|v| v.as_str()) {
+        crate::auth::hash_token(t)
+    } else if let Some(h) = body.get("hash").and_then(|v| v.as_str()) {
+        h.to_string()
+    } else {
+        return Err(app_error(
+            StatusCode::BAD_REQUEST,
+            "provide 'token' or 'hash'",
+        ));
+    };
+    let (db_id, label) = state
+        .control
+        .lock()
+        .get_token_meta(&old_hash)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or_else(|| app_error(StatusCode::NOT_FOUND, "no such active token"))?;
+    let raw = crate::auth::generate_token();
+    let new_hash = crate::auth::hash_token(&raw);
+    let now = chrono::Utc::now().to_rfc3339();
+    if let Some(yrp) = &state.yrp {
+        yrp.create_token_replicated(&actor.name, db_id, new_hash, label.clone(), now.clone())
+            .await
+            .map_err(control_write_err)?;
+        yrp.revoke_token_replicated(&actor.name, old_hash, now)
+            .await
+            .map_err(control_write_err)?;
+    } else {
+        let c = state.control.lock();
+        c.create_token(&new_hash, db_id, &label)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        c.revoke_token(&old_hash)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+    Ok(Json(
+        json!({ "token": raw, "database_id": db_id, "label": label, "rotated": true }),
+    ))
+}
+
+/// GET /v1/admin/databases/{id}/quota — readonly+. PUT — admin+.
+async fn admin_get_quota(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    AxumPath(id): AxumPath<i64>,
+) -> AppResult {
+    require_role(&state, &headers, Role::Readonly).await?;
+    let q = state
+        .control
+        .lock()
+        .get_quota(id)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(json!({
+        "database_id": id, "max_memories": q.max_memories,
+        "max_batch_size": q.max_batch_size, "max_rps": q.max_rps,
+    })))
+}
+
+async fn admin_set_quota(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    AxumPath(id): AxumPath<i64>,
+    Json(body): Json<Value>,
+) -> AppResult {
+    require_role(&state, &headers, Role::Admin).await?;
+    let cur = state
+        .control
+        .lock()
+        .get_quota(id)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let q = crate::control::TenantQuota {
+        max_memories: body
+            .get("max_memories")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(cur.max_memories),
+        max_batch_size: body
+            .get("max_batch_size")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(cur.max_batch_size),
+        max_rps: body
+            .get("max_rps")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(cur.max_rps),
+        max_oplog_entries: cur.max_oplog_entries,
+    };
+    state
+        .control
+        .lock()
+        .set_quota(id, &q)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(json!({ "database_id": id, "updated": true })))
+}
+
+/// GET /v1/admin/audit?limit= — the replicated audit trail. admin+.
+async fn admin_audit(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> AppResult {
+    require_role(&state, &headers, Role::Admin).await?;
+    let limit = q
+        .get("limit")
+        .and_then(|s| s.parse::<i64>().ok())
+        .unwrap_or(100)
+        .clamp(1, 1000);
+    let rows = state
+        .control
+        .lock()
+        .list_audit(limit)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(json!({ "audit": rows })))
 }
 
 /// GET /v1/admin/control-snapshot — returns a full snapshot of the control
@@ -5261,12 +5844,38 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/v1/cluster/topology", get(yrp_topology))
         .route("/admin", get(admin_studio))
         .route("/v1/admin/control-snapshot", get(control_snapshot))
-        // RFC 029: replicated control-plane admin (master-token gated).
-        // Databases + tokens minted here commit through YRP and apply on
-        // every node, so identity survives failover.
-        .route("/v1/admin/databases", post(admin_create_database))
-        .route("/v1/admin/tokens", post(admin_create_token))
+        // RFC 029/030: replicated control-plane admin (RBAC-gated).
+        // Databases + tokens + users committed here replicate through YRP.
+        .route("/v1/admin/session", post(admin_login))
+        .route("/v1/admin/me", get(admin_me))
+        .route(
+            "/v1/admin/databases",
+            get(admin_list_databases).post(admin_create_database),
+        )
+        .route(
+            "/v1/admin/tokens",
+            get(admin_list_tokens).post(admin_create_token),
+        )
         .route("/v1/admin/tokens/revoke", post(admin_revoke_token))
+        .route("/v1/admin/tokens/rotate", post(admin_rotate_token))
+        .route(
+            "/v1/admin/users",
+            get(admin_list_users).post(admin_create_user),
+        )
+        .route("/v1/admin/users/{username}/role", post(admin_set_user_role))
+        .route(
+            "/v1/admin/users/{username}/password",
+            post(admin_set_user_password),
+        )
+        .route(
+            "/v1/admin/users/{username}/disable",
+            post(admin_disable_user),
+        )
+        .route(
+            "/v1/admin/databases/{id}/quota",
+            get(admin_get_quota).put(admin_set_quota),
+        )
+        .route("/v1/admin/audit", get(admin_audit))
         .route("/v1/admin/snapshot", post(admin_snapshot))
         // RFC 027 / v0.8.24 — autonomous-maintenance operator surface.
         .route("/v1/admin/maintenance/run", post(admin_maintenance_run))

--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -63,6 +63,19 @@ async fn post_json(
     (status, val)
 }
 
+async fn get_json(base: &str, token: &str, path: &str) -> (reqwest::StatusCode, Value) {
+    let client = reqwest::Client::new();
+    let mut req = client.get(format!("{base}{path}"));
+    if !token.is_empty() {
+        req = req.bearer_auth(token);
+    }
+    let resp = req.send().await.expect("request");
+    let status = resp.status();
+    let text = resp.text().await.expect("body");
+    let val: Value = serde_json::from_str(&text).unwrap_or(json!({ "raw": text }));
+    (status, val)
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
     let _serial = crate::yrp::testkit::serial_guard().await;
@@ -257,8 +270,8 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
     assert!(admin.status().is_success());
     let admin_html = admin.text().await.unwrap();
     assert!(
-        admin_html.contains("YantrikDB") && admin_html.contains("Identity"),
-        "/admin must serve the studio page with the identity panel"
+        admin_html.contains("YantrikDB") && admin_html.contains("control console"),
+        "/admin must serve the studio v2 console"
     );
 
     // ── RFC 029: control-plane replication ──────────────────────────
@@ -389,6 +402,157 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
         st,
         reqwest::StatusCode::OK,
         "cluster must still accept writes after a rejected bad mint: {resp}"
+    );
+
+    // ── RFC 030: multi-user admin accounts + RBAC ───────────────────
+    // Bootstrap: create the first owner with the break-glass master token.
+    let (st, _) = post_json(
+        &leader.base,
+        SECRET,
+        "/v1/admin/users",
+        &json!({ "username": "boss", "password": "supersecret", "role": "owner" }),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::OK, "create first owner");
+
+    // The user record replicates to the follower's control.db.
+    {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if follower
+                .state
+                .control
+                .lock()
+                .get_admin_user("boss")
+                .unwrap()
+                .is_some()
+            {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "owner never replicated to follower"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    // Login on the LEADER (seeds the replicated session key) → session token.
+    let (st, resp) = post_json(
+        &leader.base,
+        "",
+        "/v1/admin/session",
+        &json!({ "username": "boss", "password": "supersecret" }),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::OK, "owner login: {resp}");
+    let boss_sess = resp["token"].as_str().expect("session token").to_string();
+    assert_eq!(resp["role"], json!("owner"));
+
+    // Wrong password is 401.
+    let (st, _) = post_json(
+        &leader.base,
+        "",
+        "/v1/admin/session",
+        &json!({ "username": "boss", "password": "WRONG" }),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::UNAUTHORIZED, "bad password → 401");
+
+    // The session authenticates on the FOLLOWER (session key + user both
+    // replicated) — /v1/admin/me returns the owner role.
+    let (st, resp) = get_json(&follower.base, &boss_sess, "/v1/admin/me").await;
+    assert_eq!(
+        st,
+        reqwest::StatusCode::OK,
+        "session valid on follower: {resp}"
+    );
+    assert_eq!(resp["role"], json!("owner"));
+
+    // Owner creates a readonly user (via the session, not the master token).
+    let (st, _) = post_json(
+        &leader.base,
+        &boss_sess,
+        "/v1/admin/users",
+        &json!({ "username": "viewer", "password": "viewerpass", "role": "readonly" }),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::OK, "owner creates readonly user");
+    let (_, resp) = post_json(
+        &leader.base,
+        "",
+        "/v1/admin/session",
+        &json!({ "username": "viewer", "password": "viewerpass" }),
+    )
+    .await;
+    let viewer_sess = resp["token"].as_str().expect("viewer session").to_string();
+
+    // RBAC: readonly cannot create a database (needs admin) → 403.
+    let (st, _) = post_json(
+        &leader.base,
+        &viewer_sess,
+        "/v1/admin/databases",
+        &json!({ "name": "viewer-cannot" }),
+    )
+    .await;
+    assert_eq!(
+        st,
+        reqwest::StatusCode::FORBIDDEN,
+        "readonly cannot create db"
+    );
+    // …but can list (readonly+).
+    let (st, _) = get_json(&leader.base, &viewer_sess, "/v1/admin/databases").await;
+    assert_eq!(st, reqwest::StatusCode::OK, "readonly can list dbs");
+
+    // H1 revocation: disable viewer → their live session dies (401), and the
+    // revocation propagates so it dies on the FOLLOWER too.
+    let (st, _) = post_json(
+        &leader.base,
+        &boss_sess,
+        "/v1/admin/users/viewer/disable",
+        &json!({}),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::OK, "disable viewer");
+    {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let (st, _) = get_json(&follower.base, &viewer_sess, "/v1/admin/me").await;
+            if st == reqwest::StatusCode::UNAUTHORIZED {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "disabled user's session never died on follower"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    // H2 owner-floor: disabling the only owner is refused (stays enabled).
+    let (st, resp) = post_json(
+        &leader.base,
+        &boss_sess,
+        "/v1/admin/users/boss/disable",
+        &json!({}),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::OK);
+    assert_eq!(
+        resp["disabled"],
+        json!(false),
+        "owner-floor must refuse disabling the last owner: {resp}"
+    );
+
+    // The replicated audit trail recorded the admin mutations, attributed.
+    let (st, resp) = get_json(&leader.base, &boss_sess, "/v1/admin/audit?limit=50").await;
+    assert_eq!(st, reqwest::StatusCode::OK);
+    let audit = resp["audit"].as_array().expect("audit array");
+    assert!(
+        audit
+            .iter()
+            .any(|e| e["action"] == json!("create_user") && e["actor"] == json!("master-token")),
+        "audit must attribute the bootstrap create_user to master-token: {resp}"
     );
 }
 

--- a/crates/yantrikdb-server/src/yrp/control_op.rs
+++ b/crates/yantrikdb-server/src/yrp/control_op.rs
@@ -191,13 +191,20 @@ impl ControlOp {
 pub struct ControlEnvelope {
     #[serde(default)]
     pub actor: String,
+    /// Leader-stamped RFC-3339 timestamp (F3) so the replicated audit row is
+    /// byte-identical on every node. Empty for legacy bare-op entries.
+    #[serde(default)]
+    pub at: String,
     pub op: ControlOp,
 }
 
 impl ControlEnvelope {
+    /// Build an envelope, stamping `at` with the leader's clock once (the
+    /// caller is the request-terminating/proposing node).
     pub fn new(actor: impl Into<String>, op: ControlOp) -> Self {
         Self {
             actor: actor.into(),
+            at: chrono_now_rfc3339(),
             op,
         }
     }
@@ -214,6 +221,7 @@ impl ControlEnvelope {
             Ok(env) => Ok(env),
             Err(_) => ControlOp::decode(bytes).map(|op| ControlEnvelope {
                 actor: String::new(),
+                at: String::new(),
                 op,
             }),
         }
@@ -242,10 +250,17 @@ impl ControlApplySink {
     /// op. Idempotent overall (safe to replay).
     pub fn apply(&self, index: u64, env: &ControlEnvelope) -> Result<(), String> {
         let db = self.control.lock();
-        // M1: durable, deterministic audit — same row on every node.
+        // M1: durable, deterministic audit — same row on every node. The
+        // timestamp is leader-stamped in the envelope (F3) so the row is
+        // byte-identical across nodes; legacy entries (no `at`) fall back to
+        // apply-time, which is acceptable since they carry no actor anyway.
         if !env.actor.is_empty() {
             let (action, target) = env.op.audit_action();
-            let at = chrono_now_rfc3339();
+            let at = if env.at.is_empty() {
+                chrono_now_rfc3339()
+            } else {
+                env.at.clone()
+            };
             db.apply_audit(index, &env.actor, action, &target, &at)
                 .map_err(|e| format!("control audit write at {index}: {e}"))?;
         }
@@ -287,21 +302,21 @@ impl ControlApplySink {
                 .map(|_| ())
                 .map_err(|e| format!("control apply CreateUser({username}): {e}")),
             ControlOp::SetUserRole { username, role } => db
-                .apply_set_user_role(username, role)
+                .apply_set_user_role(index, username, role)
                 .map(|_| ())
                 .map_err(|e| format!("control apply SetUserRole({username}): {e}")),
             ControlOp::SetUserPassword {
                 username,
                 password_hash,
             } => db
-                .apply_set_user_password(username, password_hash)
+                .apply_set_user_password(index, username, password_hash)
                 .map(|_| ())
                 .map_err(|e| format!("control apply SetUserPassword({username}): {e}")),
             ControlOp::DisableUser {
                 username,
                 disabled_at,
             } => db
-                .apply_disable_user(username, disabled_at)
+                .apply_disable_user(index, username, disabled_at)
                 .map(|_| ())
                 .map_err(|e| format!("control apply DisableUser({username}): {e}")),
             ControlOp::SetAdminSessionKey { kid, value } => db

--- a/crates/yantrikdb-server/src/yrp/control_op.rs
+++ b/crates/yantrikdb-server/src/yrp/control_op.rs
@@ -65,6 +65,29 @@ pub enum ControlOp {
         token_hash: String,
         revoked_at: String,
     },
+    /// RFC 030: create an admin account. `password_hash` is argon2id,
+    /// computed by the leader before proposing (never re-hashed per node).
+    CreateUser {
+        username: String,
+        password_hash: String,
+        role: String,
+        created_at: String,
+    },
+    /// RFC 030: change an admin account's role.
+    SetUserRole { username: String, role: String },
+    /// RFC 030: rotate an admin account's password (argon2id hash).
+    SetUserPassword {
+        username: String,
+        password_hash: String,
+    },
+    /// RFC 030: soft-disable an admin account (revoke the operator).
+    DisableUser {
+        username: String,
+        disabled_at: String,
+    },
+    /// RFC 030 (H3): seed/rotate the replicated admin session-signing key.
+    /// `value` is base64 of 32 random bytes; `kid` identifies it in tokens.
+    SetAdminSessionKey { kid: String, value: String },
 }
 
 impl ControlOp {
@@ -97,8 +120,107 @@ impl ControlOp {
                 buf.extend_from_slice(b"ctl:revoketok:");
                 buf.extend_from_slice(token_hash.as_bytes());
             }
+            // User ops key on username + a per-shape discriminator. Role /
+            // password / disable each get a distinct claim so back-to-back
+            // changes to the same user do NOT dedupe against each other;
+            // the password/role content is also folded in so a retried
+            // identical change dedupes but a new value re-appends.
+            ControlOp::CreateUser { username, .. } => {
+                buf.extend_from_slice(b"ctl:createuser:");
+                buf.extend_from_slice(username.as_bytes());
+            }
+            ControlOp::SetUserRole { username, role } => {
+                buf.extend_from_slice(b"ctl:userrole:");
+                buf.extend_from_slice(username.as_bytes());
+                buf.push(b':');
+                buf.extend_from_slice(role.as_bytes());
+            }
+            ControlOp::SetUserPassword {
+                username,
+                password_hash,
+            } => {
+                buf.extend_from_slice(b"ctl:userpw:");
+                buf.extend_from_slice(username.as_bytes());
+                buf.push(b':');
+                buf.extend_from_slice(password_hash.as_bytes());
+            }
+            ControlOp::DisableUser { username, .. } => {
+                buf.extend_from_slice(b"ctl:userdisable:");
+                buf.extend_from_slice(username.as_bytes());
+            }
+            ControlOp::SetAdminSessionKey { kid, .. } => {
+                buf.extend_from_slice(b"ctl:sesskey:");
+                buf.extend_from_slice(kid.as_bytes());
+            }
         }
         super::op::fnv1a64(&buf)
+    }
+
+    /// Audit descriptor `(action, target)` for the replicated audit_log
+    /// (RFC 030 M1). Secrets/hashes are never placed in the target.
+    pub fn audit_action(&self) -> (&'static str, String) {
+        match self {
+            ControlOp::CreateDatabase { name, db_id, .. } => {
+                ("create_database", format!("{name} (#{db_id})"))
+            }
+            ControlOp::CreateToken { db_id, label, .. } => {
+                ("mint_token", format!("db #{db_id} [{label}]"))
+            }
+            ControlOp::RevokeToken { .. } => ("revoke_token", String::new()),
+            ControlOp::CreateUser { username, role, .. } => {
+                ("create_user", format!("{username} ({role})"))
+            }
+            ControlOp::SetUserRole { username, role } => {
+                ("set_user_role", format!("{username} -> {role}"))
+            }
+            ControlOp::SetUserPassword { username, .. } => ("set_user_password", username.clone()),
+            ControlOp::DisableUser { username, .. } => ("disable_user", username.clone()),
+            ControlOp::SetAdminSessionKey { kid, .. } => ("rotate_session_key", kid.clone()),
+        }
+    }
+}
+
+/// RFC 030 (M1): the replicated unit inside `Payload::Control` — a control op
+/// plus the `actor` who initiated it, so `ControlApplySink` can write a
+/// quorum-durable, tamper-evident audit row as it applies on every node.
+///
+/// **Back-compat:** [`decode`](Self::decode) accepts BOTH this envelope and a
+/// bare pre-RFC-030 `ControlOp` (actor defaults to empty), so control entries
+/// already in the log (RFC 029) still replay on an RFC-030 node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlEnvelope {
+    #[serde(default)]
+    pub actor: String,
+    pub op: ControlOp,
+}
+
+impl ControlEnvelope {
+    pub fn new(actor: impl Into<String>, op: ControlOp) -> Self {
+        Self {
+            actor: actor.into(),
+            op,
+        }
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, String> {
+        serde_json::to_vec(self).map_err(|e| format!("encode ControlEnvelope: {e}"))
+    }
+
+    /// Envelope first; on failure fall back to a legacy bare `ControlOp`
+    /// (actor unknown → ""). The two shapes are unambiguous: the envelope has
+    /// an `op` field, a bare op is an externally-tagged variant.
+    pub fn decode(bytes: &[u8]) -> Result<Self, String> {
+        match serde_json::from_slice::<ControlEnvelope>(bytes) {
+            Ok(env) => Ok(env),
+            Err(_) => ControlOp::decode(bytes).map(|op| ControlEnvelope {
+                actor: String::new(),
+                op,
+            }),
+        }
+    }
+
+    pub fn claim_key(&self) -> u64 {
+        self.op.claim_key()
     }
 }
 
@@ -115,9 +237,19 @@ impl ControlApplySink {
         Self { control }
     }
 
-    /// Apply one control op to `control.db`. Idempotent (safe to replay).
-    pub fn apply(&self, op: &ControlOp) -> Result<(), String> {
+    /// Apply one control envelope at YRP `index`. Writes the replicated audit
+    /// row (M1) keyed on the index (idempotent on replay), then applies the
+    /// op. Idempotent overall (safe to replay).
+    pub fn apply(&self, index: u64, env: &ControlEnvelope) -> Result<(), String> {
         let db = self.control.lock();
+        // M1: durable, deterministic audit — same row on every node.
+        if !env.actor.is_empty() {
+            let (action, target) = env.op.audit_action();
+            let at = chrono_now_rfc3339();
+            db.apply_audit(index, &env.actor, action, &target, &at)
+                .map_err(|e| format!("control audit write at {index}: {e}"))?;
+        }
+        let op = &env.op;
         match op {
             ControlOp::CreateDatabase {
                 db_id,
@@ -145,8 +277,44 @@ impl ControlApplySink {
                 .apply_revoke_token(token_hash, revoked_at)
                 .map(|_| ())
                 .map_err(|e| format!("control apply RevokeToken: {e}")),
+            ControlOp::CreateUser {
+                username,
+                password_hash,
+                role,
+                created_at,
+            } => db
+                .apply_create_user(username, password_hash, role, created_at)
+                .map(|_| ())
+                .map_err(|e| format!("control apply CreateUser({username}): {e}")),
+            ControlOp::SetUserRole { username, role } => db
+                .apply_set_user_role(username, role)
+                .map(|_| ())
+                .map_err(|e| format!("control apply SetUserRole({username}): {e}")),
+            ControlOp::SetUserPassword {
+                username,
+                password_hash,
+            } => db
+                .apply_set_user_password(username, password_hash)
+                .map(|_| ())
+                .map_err(|e| format!("control apply SetUserPassword({username}): {e}")),
+            ControlOp::DisableUser {
+                username,
+                disabled_at,
+            } => db
+                .apply_disable_user(username, disabled_at)
+                .map(|_| ())
+                .map_err(|e| format!("control apply DisableUser({username}): {e}")),
+            ControlOp::SetAdminSessionKey { kid, value } => db
+                .apply_set_admin_session_key(kid, value)
+                .map_err(|e| format!("control apply SetAdminSessionKey({kid}): {e}")),
         }
     }
+}
+
+/// RFC-3339 now, used for audit timestamps at apply. (Server code, not a
+/// workflow script — `chrono` is available.)
+fn chrono_now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
 }
 
 #[cfg(test)]
@@ -197,11 +365,14 @@ mod tests {
             created_at: "2026-07-27T00:00:00Z".into(),
         };
         // Apply twice — the second is a no-op, not an error.
-        sink.apply(&tok).unwrap();
-        sink.apply(&tok).unwrap();
+        let env = ControlEnvelope::new("tester", tok);
+        sink.apply(10, &env).unwrap();
+        sink.apply(10, &env).unwrap();
         assert_eq!(
             sink.control.lock().validate_token("deadbeef").unwrap(),
             Some(id)
         );
+        // The audit row was written (M1), keyed on the index.
+        assert_eq!(sink.control.lock().list_audit(10).unwrap().len(), 1);
     }
 }

--- a/crates/yantrikdb-server/src/yrp/engine_sink.rs
+++ b/crates/yantrikdb-server/src/yrp/engine_sink.rs
@@ -314,13 +314,13 @@ impl ApplySink for EngineApplySink {
             // the shared marker. Idempotent apply; an Err fail-stops the
             // whole worker (Invariant 2: never serve stale authorization).
             Payload::Control(b) => {
-                let op = super::control_op::ControlOp::decode(b)?;
+                let env = super::control_op::ControlEnvelope::decode(b)?;
                 self.control
                     .as_ref()
                     .ok_or_else(|| {
                         format!("Payload::Control at {index} but no control sink wired")
                     })?
-                    .apply(&op)?;
+                    .apply(index, &env)?;
                 return self.outcomes.advance(index);
             }
             Payload::Op(b) => b,

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -331,6 +331,7 @@ impl YrpHandle {
     /// and resolves to the original entry's index.
     pub async fn propose_control(
         &self,
+        actor: &str,
         op: &super::control_op::ControlOp,
     ) -> Result<u64, YrpProposeError> {
         if let Some(reasons) = self.quarantine_reasons() {
@@ -338,11 +339,12 @@ impl YrpHandle {
                 "node quarantined: {reasons:?}"
             )));
         }
-        let bytes = op.encode().map_err(YrpProposeError::Unavailable)?;
+        let env = super::control_op::ControlEnvelope::new(actor, op.clone());
+        let bytes = env.encode().map_err(YrpProposeError::Unavailable)?;
         let (tx, rx) = oneshot::channel();
         self.owner_tx
             .send(DriverEvent::Propose {
-                key: op.claim_key(),
+                key: env.claim_key(),
                 payload: Payload::Control(bytes),
                 reply: tx,
             })
@@ -380,6 +382,7 @@ impl YrpHandle {
     /// caller can actually use — never the pre-allocated guess (review F2).
     pub async fn create_database_replicated(
         &self,
+        actor: &str,
         name: &str,
         path: &str,
         config: &str,
@@ -406,7 +409,7 @@ impl YrpHandle {
             config: config.to_string(),
             created_at,
         };
-        self.propose_control(&op)
+        self.propose_control(actor, &op)
             .await
             .map_err(ControlWriteError::Propose)?;
         // Verify-after-apply: the row must exist with our name. Return its
@@ -433,6 +436,7 @@ impl YrpHandle {
     /// node — review F3).
     pub async fn create_token_replicated(
         &self,
+        actor: &str,
         db_id: i64,
         token_hash: String,
         label: String,
@@ -444,7 +448,7 @@ impl YrpHandle {
             label,
             created_at,
         };
-        self.propose_control(&op)
+        self.propose_control(actor, &op)
             .await
             .map_err(ControlWriteError::Propose)?;
         let resolved = self
@@ -466,6 +470,7 @@ impl YrpHandle {
     /// authenticates (a collision that deduped the revoke away — review F5).
     pub async fn revoke_token_replicated(
         &self,
+        actor: &str,
         token_hash: String,
         revoked_at: String,
     ) -> Result<(), ControlWriteError> {
@@ -473,7 +478,7 @@ impl YrpHandle {
             token_hash: token_hash.clone(),
             revoked_at,
         };
-        self.propose_control(&op)
+        self.propose_control(actor, &op)
             .await
             .map_err(ControlWriteError::Propose)?;
         let resolved = self
@@ -488,6 +493,114 @@ impl YrpHandle {
                 "RevokeToken committed but token still resolves after apply".into(),
             ))
         }
+    }
+
+    // ── RFC 030: replicated admin-user + session-key ops ────────────
+
+    /// Create an admin account (RFC 030). `password_hash` is argon2id,
+    /// computed by the caller (the request-terminating node) — plaintext
+    /// never reaches here (M3). Existence-checked under the lock so a
+    /// duplicate username is a 409, not a silent no-op (M2).
+    pub async fn create_user_replicated(
+        &self,
+        actor: &str,
+        username: &str,
+        password_hash: String,
+        role: String,
+        created_at: String,
+    ) -> Result<(), ControlWriteError> {
+        let _guard = self.control_propose_lock.lock().await;
+        if self
+            .control
+            .lock()
+            .get_admin_user(username)
+            .map_err(|e| ControlWriteError::Internal(format!("user check: {e}")))?
+            .is_some()
+        {
+            return Err(ControlWriteError::AlreadyExists);
+        }
+        let op = super::control_op::ControlOp::CreateUser {
+            username: username.to_string(),
+            password_hash,
+            role,
+            created_at,
+        };
+        self.propose_control(actor, &op)
+            .await
+            .map_err(ControlWriteError::Propose)?;
+        match self.control.lock().get_admin_user(username) {
+            Ok(Some(_)) => Ok(()),
+            _ => Err(ControlWriteError::Diverged(
+                "CreateUser committed but user absent after apply".into(),
+            )),
+        }
+    }
+
+    /// Change a user's role (RFC 030). Owner-floor is enforced at APPLY
+    /// (H2); this returns Ok once applied — the caller re-reads to confirm
+    /// the effective role (a refused last-owner demotion leaves it unchanged).
+    pub async fn set_user_role_replicated(
+        &self,
+        actor: &str,
+        username: &str,
+        role: String,
+    ) -> Result<(), ControlWriteError> {
+        let op = super::control_op::ControlOp::SetUserRole {
+            username: username.to_string(),
+            role,
+        };
+        self.propose_control(actor, &op)
+            .await
+            .map_err(ControlWriteError::Propose)
+            .map(|_| ())
+    }
+
+    /// Rotate a user's password (argon2id hash computed by the caller).
+    pub async fn set_user_password_replicated(
+        &self,
+        actor: &str,
+        username: &str,
+        password_hash: String,
+    ) -> Result<(), ControlWriteError> {
+        let op = super::control_op::ControlOp::SetUserPassword {
+            username: username.to_string(),
+            password_hash,
+        };
+        self.propose_control(actor, &op)
+            .await
+            .map_err(ControlWriteError::Propose)
+            .map(|_| ())
+    }
+
+    /// Disable (revoke) an admin account. Owner-floor enforced at apply (H2).
+    pub async fn disable_user_replicated(
+        &self,
+        actor: &str,
+        username: &str,
+        disabled_at: String,
+    ) -> Result<(), ControlWriteError> {
+        let op = super::control_op::ControlOp::DisableUser {
+            username: username.to_string(),
+            disabled_at,
+        };
+        self.propose_control(actor, &op)
+            .await
+            .map_err(ControlWriteError::Propose)
+            .map(|_| ())
+    }
+
+    /// Set/rotate the replicated admin session-signing key (H3).
+    pub async fn set_admin_session_key_replicated(
+        &self,
+        actor: &str,
+        kid: String,
+        value: String,
+    ) -> Result<(), ControlWriteError> {
+        let op = super::control_op::ControlOp::SetAdminSessionKey { kid, value };
+        self.propose_control(actor, &op)
+            .await
+            .map_err(ControlWriteError::Propose)
+            .map(|_| ())
     }
 
     /// Wait for the durable-apply marker to cover `index`, then read its

--- a/docs/rfcs/rfc_030_admin_rbac.md
+++ b/docs/rfcs/rfc_030_admin_rbac.md
@@ -1,0 +1,186 @@
+# RFC 030 — Multi-user admin accounts + RBAC (control-plane extension)
+
+**Status:** Draft · **Depends on:** RFC 029 (control-plane replication) · **Supersedes:** the master-token-only admin gate
+
+## The gap
+
+RFC 029 made the control plane replicate, but admin authorization is still
+a single shared **master token** (`cluster_secret`) pasted into the studio.
+That is a bootstrap credential, not an enterprise auth model: no named
+operators, no roles, no least-privilege, no per-actor audit attribution, no
+way to revoke one operator without rotating the cluster secret for everyone.
+
+This RFC adds **named admin accounts with roles**, a **session-based login**
+(the raw secret is never stored in the browser), and **RBAC enforcement** on
+every admin route — all replicated through the same YRP control plane so
+identity-of-operators survives failover exactly like tokens/databases do.
+
+## Model
+
+### Admin users are replicated control-plane entities
+
+A new `admin_users` table in `control.db`, materialized from replicated
+control ops (mirroring tokens/databases — RFC 029):
+
+```sql
+CREATE TABLE admin_users (
+    username      TEXT PRIMARY KEY,
+    password_hash TEXT NOT NULL,      -- argon2id, NEVER plaintext
+    role          TEXT NOT NULL,      -- 'owner' | 'admin' | 'readonly'
+    disabled_at   TEXT,               -- soft-disable (tombstone-shaped)
+    created_at    TEXT NOT NULL
+);
+```
+
+New `ControlOp` variants (serde_json in `Payload::Control`, replicated +
+idempotent on the `username` key, verifier-hash only):
+
+- `CreateUser { username, password_hash, role, created_at }`
+- `SetUserRole { username, role }`
+- `SetUserPassword { username, password_hash }`   — rotation
+- `DisableUser { username, disabled_at }`          — revoke an operator
+
+**Password hashing is argon2id, not SHA-256.** Tokens are 256-bit random →
+SHA-256 is fine; passwords are low-entropy human input → they need a slow,
+salted KDF. Add the `argon2` crate. Only the hash is replicated (Invariant 3
+extends to passwords).
+
+### Roles
+
+| Role | Can |
+|---|---|
+| `owner` | everything, incl. user management (create/role/disable users) |
+| `admin` | databases + tokens + quotas (mint/rotate/revoke), view audit — **no** user management |
+| `readonly` | view databases/tokens/users/audit — **no** mutations |
+
+Roles are a total order (`readonly < admin < owner`); a route declares the
+minimum role it needs.
+
+### Session auth (login, not secret-pasting)
+
+- `POST /v1/admin/session { username, password }` → argon2-verify against
+  `admin_users` → issue a **signed session token**: `base64(payload).sig`
+  where `payload = { sub: username, role, iat, exp }` and
+  `sig = HMAC-SHA256(server_session_key, payload)`, TTL ~60 min.
+- **`server_session_key = HMAC-SHA256(cluster_secret, "ydb-admin-session-v1")`** —
+  derived from the shared secret, so a session minted on any node verifies on
+  every node (stateless; survives restart and failover; no session table).
+- Admin routes accept `Authorization: Bearer <session_token>`; the guard
+  verifies signature + expiry + role, and sets the audit actor to `sub`.
+
+### Master token = break-glass owner + bootstrap
+
+The `cluster_secret` continues to authorize admin routes as an implicit
+**owner** (break-glass, and the only way in before any user exists). The
+studio's first-run flow: log in with the master token → create the first
+`owner` account → subsequent logins use accounts. The master token is never
+removed (it is the recovery path if all accounts are lost/disabled).
+
+## Enforcement
+
+A single guard replaces `require_master_token`:
+
+```
+fn require_role(state, headers, min: Role) -> Result<AdminActor, AppError>
+```
+
+Accepts, in order: (1) a valid session token (verify HMAC+exp, check
+`role >= min`); (2) the master token (→ owner). Returns an `AdminActor
+{ name, role }` used for audit attribution. Every admin route declares its
+`min` role. Constant-time compare for the master token (closes the earlier
+timing nit).
+
+## New / changed endpoints
+
+- `POST /v1/admin/session` — login → session token (public; rate-limited).
+- `GET  /v1/admin/me` — current actor + role (drives the studio's role-aware UI).
+- `GET/POST /v1/admin/users`, `POST /v1/admin/users/{u}/role`,
+  `/password`, `/disable` — **owner** only.
+- `GET  /v1/admin/databases`, `GET /v1/admin/tokens` — clean list endpoints
+  gated by `require_role(readonly)` (fixes the RFC 029 gap where the studio
+  listed via `control-snapshot`, which only checks `state.cluster` and 401s
+  in yrp mode).
+- `POST /v1/admin/databases`, `/tokens`, `/tokens/revoke` — **admin**.
+- `POST /v1/admin/tokens/rotate { token|hash }` — mint a new token for the
+  same db+label, revoke the old (both replicated); returns the new plaintext
+  once. **admin**.
+- `GET/PUT /v1/admin/databases/{id}/quota` — view/set quotas (the
+  `control.db` `quotas` table already exists). **admin** for PUT.
+- `GET /v1/admin/audit?limit=&kind=` — read the audit trail. **admin**.
+  Requires a **persistent audit sink** (control.db `audit_log` table) since
+  admin actions must be durably attributable; wire admin ops to emit
+  `AuditEvent`s with the `AdminActor` as actor.
+
+## Invariants (security)
+
+1. **Replicate verifier material only** — argon2 password hashes + token
+   hashes, never plaintext (extends RFC 029 Invariant 3).
+2. **Session tokens are stateless + signed** — no server session store to
+   leak; compromise of one node's memory does not yield a forgeable session
+   beyond what the shared `cluster_secret` already implies.
+3. **Fail closed** — an unparseable/expired/under-privileged session is 401/403,
+   never a silent downgrade. The control-freshness gate (RFC 029 inc2-A) still
+   applies: a catching-up node refuses admin auth too.
+4. **Owner floor** — the last enabled `owner` cannot be disabled or demoted
+   (prevents locking everyone out); the master token remains the recovery path.
+5. **Bootstrap ordering (F4)** — user control ops are new `Payload::Control`
+   shapes; all nodes must run the RFC-030 build before the first user op is
+   minted (same operational rule RFC 029 established, honored during the
+   rolling redeploy).
+
+## Delivery (release cadence)
+
+- **0.13.1** — the foundation: replicated users + argon2 + session login +
+  RBAC guard + clean list endpoints + token rotation + quotas + persistent
+  audit + audit endpoint. Studio v2 login + user/db/token/quota/audit
+  management, role-aware.
+- **0.14** — polish + depth (audit filtering/export, token last-used,
+  bulk ops, SSO/OIDC mapping onto roles — the next enterprise rung).
+
+## Review hardening (adversarial pass — resolutions folded in)
+
+- **H1 — real session revocation.** `admin_users` carries a monotonic
+  `token_version`; the session payload includes `ver`; the guard rejects
+  unless `ver == current`. `SetUserRole`/`SetUserPassword`/`DisableUser` bump
+  it, so a demoted/disabled/rotated operator's live sessions die immediately,
+  cluster-wide (the check rides the RFC-029 control-apply state).
+- **H2 — owner-floor enforced deterministically at APPLY time**, in log
+  order, inside `ControlApplySink`: `DisableUser`/`SetUserRole` re-evaluate
+  "would enabled-owner count drop below 1?" against state as of that log
+  position and become an identical no-op on every node if so. Never
+  propose-time-only (that races two ops on different nodes to zero owners).
+- **H3 — session key decoupled from `cluster_secret`.** A dedicated 32-byte
+  `admin_session_key` is replicated control-plane state (a `server_secrets`
+  row, seeded by a `SetAdminSessionKey { kid, key }` control op the leader
+  proposes at first boot if absent). Session tokens carry `kid`; rotation is
+  a new key op that invalidates all prior sessions without touching peer auth
+  or the master token.
+- **M1 — replicated, tamper-evident audit.** Every *mutating* `ControlOp`
+  carries an `actor` (serde `default` for back-compat); `ControlApplySink`
+  writes an `audit_log` row deterministically as it applies, so admin-action
+  audit is quorum-durable, byte-identical on all nodes, and survives failover
+  / node loss. Login / failed-login / read events stay per-node (documented).
+- **M2 — dedupe by op-id, last-in-log-order wins** for role/password/disable;
+  `CreateUser` against an existing username **errors** (409) at the endpoint,
+  never a silent no-op.
+- **M3 — argon2id runs at the request-terminating node**; only the hash is
+  proposed/replicated; plaintext never enters a `ControlOp` nor peer traffic.
+- **M4 — login DoS/enumeration hardening.** Per-IP + per-username rate limit
+  *before* argon2; a global semaphore caps concurrent argon2 verifications;
+  unknown users get a constant-time decoy verify (no enumeration).
+- **M5 — session verification** does constant-time HMAC compare, verifies the
+  signature over the exact received bytes *before* JSON-parsing, and rejects
+  malformed tokens (segment count / base64 / empty) as 401.
+- **L-fixes:** bounded clock-skew tolerance + leader-assigned `iat/exp` (L1);
+  admin routes assume TLS, `Authorization` never logged (L2); a stale/
+  quarantined node refuses admin *reads/mutations* even for the master token,
+  surfacing staleness rather than acting on stale RBAC (L3); list endpoints
+  **redact** `password_hash`/`token_hash` (L4); unknown `role` strings fail
+  closed in the guard's ordering (L5); every master-token (break-glass) use
+  emits a loud `actor="master-token"` audit event (L6).
+
+## Out of scope
+
+External IdP (OIDC/SAML) — layers on top by mapping an external identity to a
+role, replicated via the same control log. RBAC is the prerequisite. Full
+`admin_session_key` rotation UI + audit export/filtering land in 0.14.


### PR DESCRIPTION
Turns the single shared **master-token** admin gate into a real **multi-user RBAC** system with a full management console — replicated through the RFC 029 control plane, so operator identity survives failover like tokens/databases do.

RFC-first (`docs/rfcs/rfc_030_admin_rbac.md`), adversarial **design** review folded in before coding (H1–H3, M1–M5, L1–L6), and a final adversarial **code** review of the implementation.

## Backend
- **Replicated admin users** — `admin_users` (argon2id password hashes, never plaintext), new `ControlOp`s (CreateUser/SetUserRole/SetUserPassword/DisableUser) carried in a `ControlEnvelope {actor, op}` with **back-compat decode** of legacy bare-`ControlOp` log entries.
- **Session auth** (`src/auth/admin.rs`) — stateless HMAC-SHA256 tokens, **verify-before-parse + constant-time** (M5); payload carries `ver` (`token_version`) so disable/demote/rotate **kills live sessions cluster-wide** (H1), and `kid` for key rotation.
- **Session key decoupled from `cluster_secret`** (H3) — a replicated `server_secrets` key with its own `kid`.
- **RBAC guard** `require_role` — session token **or** master-token break-glass (→owner, loud); enforces the control-freshness gate (L3); roles `owner>admin>readonly`, unknown roles fail closed (L5).
- **Owner-floor** enforced **deterministically at apply** in log order (H2) — two concurrent demotions can't race to zero owners.
- **Replicated, tamper-evident audit** (M1) — every mutating op carries its `actor`; the apply sink writes a `audit_log` row keyed on the log index (idempotent), byte-identical on every node.
- **Login hardening** (M4) — argon2 behind a concurrency semaphore, per-request decoy verify for unknown users (anti-enumeration).
- **Endpoints:** `POST /v1/admin/session`, `GET /me`, users CRUD (owner), clean list databases/tokens/users (password hashes redacted; token hashes exposed to admins as identifiers), `tokens/rotate`, per-db `quota`, `GET /audit`.

## Frontend — enterprise studio v2 at `/admin`
Login + first-time owner bootstrap (via master token), role-aware nav, live cluster topology, database/token/user tables with create/mint/**rotate**/revoke/quota, and the audit trail. Single self-contained page (inline assets, theme-aware, air-gap-friendly).

## Validation
2-node HTTP cluster test proves end-to-end: bootstrap owner → **cross-node session login** → RBAC enforcement (readonly blocked from writes) → **H1 revocation propagation** (disable kills the session on the follower) → **H2 owner-floor** → **M1 attributed audit**. Full suite green (356 unit + integration).

## Rollout
New control-op shapes → **all nodes upgrade before the first user op is minted** (the RFC 029 F4 rule; honored in the rolling redeploy). Delivered as **0.13.1**; deeper polish (audit export/filter, SSO/OIDC→role mapping, key-rotation UI) is 0.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
