### PR TITLE
feat(packs): RFC 031 — server-side clustered packs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +859,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +941,16 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -1019,6 +1062,31 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -1133,6 +1201,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -2464,6 +2538,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,6 +3025,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3274,6 +3376,16 @@ dependencies = [
  "byteorder",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -4567,14 +4679,15 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yantrikdb"
-version = "0.10.1"
-source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.10.1#db9f7655dd6f0fe8e0b8b7a5ed8d9d233a34279e"
+version = "0.11.2"
+source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.11.2#82c3fe63c04181ac0bc3e84b74cef5817982c397"
 dependencies = [
  "aes-gcm",
  "arc-swap",
  "base64 0.22.1",
  "blake3",
  "dashmap",
+ "ed25519-dalek",
  "hex",
  "js-sys",
  "model2vec-rs",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/main.rs"
 # provenance gate + schema v37 (correct→200, reembed-deferral→409). The engine
 # owns no timer thread — the host drives run_maintenance_cycle() cadence
 # (RFC 027 / #55); session_digest + chain_head wired in v0.8.25 (RFC 023 / #56).
-yantrikdb = { version = "0.10.1", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.10.1" }
+yantrikdb = { version = "0.11.2", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.11.2" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime

--- a/crates/yantrikdb-server/src/admin/studio.html
+++ b/crates/yantrikdb-server/src/admin/studio.html
@@ -170,6 +170,7 @@
     {id:'cluster',label:'Cluster',min:null},
     {id:'databases',label:'Databases',min:'readonly'},
     {id:'tokens',label:'Tokens',min:'readonly'},
+    {id:'packs',label:'Packs',min:'readonly'},
     {id:'users',label:'Users',min:'owner'},
     {id:'audit',label:'Audit',min:'admin'},
   ];
@@ -190,7 +191,7 @@
   }
 
   // ── render dispatch ──
-  function render(){ ({cluster:renderCluster,databases:renderDatabases,tokens:renderTokens,users:renderUsers,audit:renderAudit}[cur]||renderCluster)(); }
+  function render(){ ({cluster:renderCluster,databases:renderDatabases,tokens:renderTokens,packs:renderPacks,users:renderUsers,audit:renderAudit}[cur]||renderCluster)(); }
 
   // ── Cluster (topology, public) ──
   let topoTimer=null;
@@ -298,6 +299,55 @@
   window.disableUser=async function(u){ if(!confirm(`Disable ${u}? Their sessions die immediately.`))return;
     try{ const r=await api('/v1/admin/users/'+encodeURIComponent(u)+'/disable',{method:'POST',body:JSON.stringify({})});
       if(!r.disabled) toast('Refused (owner-floor): cannot disable the last owner','bad'); else toast(`${u} disabled`,'ok'); renderUsers(); }catch(e){toast(e.message,'bad');} };
+
+  // ── Packs ──
+  async function renderPacks(){
+    $('appview').innerHTML=`<div class="panel"><h2>Uploaded packs</h2><div id="packlist" class="empty">Loading…</div>
+      ${can('admin')?`<div class="form"><input type="file" id="packfile" accept=".ydbpack"/><button class="btn" onclick="uploadPack()">Upload</button></div>
+      <div class="note">A pack is a sealed .ydbpack a database mounts to gain knowledge. Files replicate to every node; mounts survive failover.</div>`:''}</div>
+      <div class="panel"><h2>Mount into a database</h2>
+        <div class="form"><select id="pack-db" onchange="loadDbPacks()"></select></div>
+        <div id="dbpacks" class="empty" style="margin-top:.8rem">Select a database.</div>
+      </div>`;
+    try{
+      const [{packs},{databases}]=await Promise.all([api('/v1/admin/packs'),api('/v1/admin/databases')]);
+      window._packs=packs; window._dbs=databases;
+      $('packlist').innerHTML=packs.length?`<table><thead><tr><th>Digest</th><th>Size</th></tr></thead><tbody>${
+        packs.map(p=>`<tr><td class="mono">${esc(p.digest.slice(0,16))}…</td><td class="mono">${(p.size/1024|0)} KB</td></tr>`).join('')}</tbody></table>`
+        :'<div class="empty">No packs uploaded yet.</div>';
+      $('pack-db').innerHTML=`<option value="">— choose database —</option>`+databases.map(d=>`<option value="${d.id}">${esc(d.name)}</option>`).join('');
+    }catch(e){ $('packlist').innerHTML=`<div class="empty">${esc(e.message)}</div>`; }
+  }
+  window.uploadPack=async function(){
+    const f=$('packfile').files[0]; if(!f){toast('Choose a .ydbpack file','bad');return;}
+    try{
+      const buf=await f.arrayBuffer();
+      const r=await fetch('/v1/admin/packs',{method:'POST',headers:{'Authorization':'Bearer '+tok(),'Content-Type':'application/octet-stream'},body:buf});
+      const b=await r.json().catch(()=>({})); if(!r.ok) throw new Error(b.message||b.error||('HTTP '+r.status));
+      toast(`Uploaded (${b.digest.slice(0,12)}…)`,'ok'); renderPacks();
+    }catch(e){toast(e.message,'bad');}
+  };
+  window.loadDbPacks=async function(){
+    const id=Number($('pack-db').value); if(!id){$('dbpacks').innerHTML='<div class="empty">Select a database.</div>';return;}
+    try{
+      const {manifest,status}=await api('/v1/admin/databases/'+id+'/packs');
+      const state=d=>status.mounted.includes(d)?'<span class="badge follower">mounted</span>'
+        :status.poisoned.includes(d)?'<span class="badge quarantined">poisoned</span>':'<span class="badge witness">pending</span>';
+      const mountedDigests=new Set(manifest.map(m=>m.pack_digest));
+      const avail=(window._packs||[]).filter(p=>!mountedDigests.has(p.digest));
+      $('dbpacks').innerHTML=`${manifest.length?`<table><thead><tr><th>Pack</th><th>Digest</th><th>State</th>${can('admin')?'<th></th>':''}</tr></thead><tbody>${
+        manifest.map(m=>`<tr><td><b>${esc(m.pack_name)}</b></td><td class="mono">${esc(m.pack_digest.slice(0,12))}…</td><td>${state(m.pack_digest)}</td>
+          ${can('admin')?`<td class="rowacts"><button class="btn danger sm" onclick="unmountPack(${id},'${esc(m.pack_digest)}')">Unmount</button></td>`:''}</tr>`).join('')}</tbody></table>`
+        :'<div class="empty">No packs mounted in this database.</div>'}
+        ${can('admin')&&avail.length?`<div class="form" style="margin-top:.8rem"><select id="mount-pick">${avail.map(p=>`<option value="${p.digest}">${esc(p.digest.slice(0,16))}…</option>`).join('')}</select>
+          <input id="mount-name" placeholder="label (optional)" style="flex:.7"/><button class="btn" onclick="mountPack(${id})">Mount</button></div>`:''}`;
+    }catch(e){ $('dbpacks').innerHTML=`<div class="empty">${esc(e.message)}</div>`; }
+  };
+  window.mountPack=async function(id){ const digest=$('mount-pick').value; const name=$('mount-name').value.trim();
+    try{ await api('/v1/admin/databases/'+id+'/packs',{method:'POST',body:JSON.stringify(name?{digest,name}:{digest})});
+      toast('Mount accepted — reconciling across the cluster','ok'); loadDbPacks(); }catch(e){toast(e.message,'bad');} };
+  window.unmountPack=async function(id,digest){ if(!confirm('Unmount this pack?'))return;
+    try{ await api('/v1/admin/databases/'+id+'/packs/'+digest,{method:'DELETE'}); toast('Unmount accepted','ok'); loadDbPacks(); }catch(e){toast(e.message,'bad');} };
 
   // ── Audit ──
   async function renderAudit(){

--- a/crates/yantrikdb-server/src/control.rs
+++ b/crates/yantrikdb-server/src/control.rs
@@ -131,6 +131,21 @@ impl ControlDb {
                 target     TEXT NOT NULL,
                 at         TEXT NOT NULL
             );
+
+            -- RFC 031: replicated pack MOUNT MANIFEST — the cluster's intent
+            -- of which pack (by content digest) is mounted into which database.
+            -- Deliberately NO foreign key / no validation (review H3): manifest
+            -- apply must be an unconditional idempotent UPSERT that can never
+            -- fail on committed input and fence the cluster. The large pack
+            -- FILES ride out-of-band (content-addressed store), never the log.
+            CREATE TABLE IF NOT EXISTS db_packs (
+                database_id  INTEGER NOT NULL,
+                pack_digest  TEXT NOT NULL,
+                pack_name    TEXT NOT NULL,
+                mounted_at   TEXT NOT NULL,
+                unmounted_at TEXT,
+                PRIMARY KEY (database_id, pack_digest)
+            );
             ",
         )?;
         Ok(())
@@ -587,6 +602,79 @@ impl ControlDb {
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
 
+    // ── RFC 031: pack mount manifest (unconditional, fail-stop-safe) ──
+
+    /// Apply a replicated `MountPack`: UPSERT the manifest row and CLEAR
+    /// `unmounted_at` (so a remount-after-unmount takes — L1). Unconditional:
+    /// no FK, no db-existence check, nothing that can fail on committed input
+    /// (H3). An orphaned row (db since gone) is harmless — the reconciler
+    /// no-ops it.
+    pub fn apply_mount_pack(
+        &self,
+        database_id: i64,
+        pack_digest: &str,
+        pack_name: &str,
+        mounted_at: &str,
+    ) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT INTO db_packs (database_id, pack_digest, pack_name, mounted_at, unmounted_at)
+             VALUES (?1, ?2, ?3, ?4, NULL)
+             ON CONFLICT(database_id, pack_digest) DO UPDATE SET
+                pack_name = excluded.pack_name, mounted_at = excluded.mounted_at,
+                unmounted_at = NULL",
+            params![database_id, pack_digest, pack_name, mounted_at],
+        )?;
+        Ok(())
+    }
+
+    /// Apply a replicated `UnmountPack`: soft-unmount (idempotent).
+    pub fn apply_unmount_pack(
+        &self,
+        database_id: i64,
+        pack_digest: &str,
+        unmounted_at: &str,
+    ) -> anyhow::Result<()> {
+        self.conn.execute(
+            "UPDATE db_packs SET unmounted_at = ?3
+             WHERE database_id = ?1 AND pack_digest = ?2 AND unmounted_at IS NULL",
+            params![database_id, pack_digest, unmounted_at],
+        )?;
+        Ok(())
+    }
+
+    /// Every ACTIVE (not-unmounted) mount in the manifest — the reconciler's
+    /// desired state across all databases.
+    pub fn active_pack_mounts(&self) -> anyhow::Result<Vec<PackMountRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT database_id, pack_digest, pack_name FROM db_packs
+             WHERE unmounted_at IS NULL ORDER BY database_id, pack_digest",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok(PackMountRow {
+                database_id: r.get(0)?,
+                pack_digest: r.get(1)?,
+                pack_name: r.get(2)?,
+            })
+        })?;
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    /// Active mounts for one database (pack-context / recall pending signal).
+    pub fn active_pack_mounts_for(&self, database_id: i64) -> anyhow::Result<Vec<PackMountRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT database_id, pack_digest, pack_name FROM db_packs
+             WHERE database_id = ?1 AND unmounted_at IS NULL ORDER BY pack_digest",
+        )?;
+        let rows = stmt.query_map(params![database_id], |r| {
+            Ok(PackMountRow {
+                database_id: r.get(0)?,
+                pack_digest: r.get(1)?,
+                pack_name: r.get(2)?,
+            })
+        })?;
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
     fn map_admin_user(row: &rusqlite::Row) -> rusqlite::Result<AdminUserRecord> {
         Ok(AdminUserRecord {
             username: row.get(0)?,
@@ -662,6 +750,14 @@ impl ControlDb {
 pub struct ControlSnapshot {
     pub databases: Vec<DatabaseRecord>,
     pub tokens: Vec<TokenSnapshot>,
+}
+
+/// RFC 031 — an active pack mount from the replicated manifest.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PackMountRow {
+    pub database_id: i64,
+    pub pack_digest: String,
+    pub pack_name: String,
 }
 
 /// RFC 030 (M1) — a replicated audit row (newest-first in the audit view).

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -3536,6 +3536,9 @@ async fn admin_pack_unmount(
     AxumPath((db_id, digest)): AxumPath<(i64, String)>,
 ) -> Result<(StatusCode, Json<Value>), AppError> {
     let actor = require_role(&state, &headers, Role::Admin).await?;
+    if !crate::pack_store::PackStore::is_valid_digest(&digest) {
+        return Err(app_error(StatusCode::BAD_REQUEST, "malformed digest"));
+    }
     let now = chrono::Utc::now().to_rfc3339();
     if let Some(yrp) = &state.yrp {
         yrp.unmount_pack_replicated(&actor.name, db_id, digest.clone(), now)
@@ -6133,7 +6136,13 @@ pub fn router(state: Arc<AppState>) -> Router {
         .merge(
             Router::new()
                 .route("/v1/admin/packs", post(admin_pack_upload))
+                // BOTH limits must be raised: tower-http's RequestBodyLimitLayer
+                // AND axum's own DefaultBodyLimit (default 2 MB), which governs
+                // the `Bytes` extractor independently (review H-2).
                 .layer(tower_http::limit::RequestBodyLimitLayer::new(
+                    PACK_MAX_UPLOAD_BYTES + 1024,
+                ))
+                .layer(axum::extract::DefaultBodyLimit::max(
                     PACK_MAX_UPLOAD_BYTES + 1024,
                 ))
                 .with_state(state),

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -470,6 +470,12 @@ async fn health(State(state): State<Arc<AppState>>) -> Json<Value> {
             payload["yrp_backfill_target"] = json!(s.backfill_target);
         }
     }
+    // RFC 031: pack reconcile rollup (per-db detail is on the admin endpoint).
+    // A best-effort liveness state — it does NOT flip status to unhealthy
+    // (review L3), just surfaces that some database has packs still settling.
+    if state.pack_status.any_incomplete() {
+        payload["packs_incomplete"] = json!(true);
+    }
     Json(payload)
 }
 
@@ -3408,6 +3414,183 @@ async fn admin_audit(
     Ok(Json(json!({ "audit": rows })))
 }
 
+// ── RFC 031: pack management (RBAC-gated) ───────────────────────────
+
+/// Max pack upload/transfer size (bounds disk + the engine's HNSW build).
+const PACK_MAX_UPLOAD_BYTES: usize = 64 * 1024 * 1024;
+
+/// GET /v1/packs/{digest} — peer transfer. Cluster-secret only (internal):
+/// a follower fetches a missing pack file from the leader. Digest-addressed.
+async fn pack_transfer(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    AxumPath(digest): AxumPath<String>,
+) -> Result<axum::response::Response, AppError> {
+    require_master_token(&state, &headers)?;
+    let bytes = state
+        .pack_store
+        .load(&digest) // validates digest + re-verifies content
+        .map_err(|_| app_error(StatusCode::NOT_FOUND, "pack not found"))?;
+    use axum::response::IntoResponse;
+    Ok((
+        [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
+        bytes,
+    )
+        .into_response())
+}
+
+/// POST /v1/admin/packs — upload a `.ydbpack` (octet-stream). Stored by its
+/// content digest; validated + mounted later by the reconciler. **admin**.
+async fn admin_pack_upload(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> AppResult {
+    require_role(&state, &headers, Role::Admin).await?;
+    if body.is_empty() {
+        return Err(app_error(StatusCode::BAD_REQUEST, "empty pack"));
+    }
+    if body.len() > PACK_MAX_UPLOAD_BYTES {
+        return Err(app_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!("pack exceeds {PACK_MAX_UPLOAD_BYTES} bytes"),
+        ));
+    }
+    let digest = state
+        .pack_store
+        .store(&body)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(json!({ "digest": digest, "size": body.len() })))
+}
+
+/// GET /v1/admin/packs — list stored pack files. **readonly**.
+async fn admin_pack_list(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+) -> AppResult {
+    require_role(&state, &headers, Role::Readonly).await?;
+    Ok(Json(json!({ "packs": state.pack_store.list() })))
+}
+
+/// POST /v1/admin/databases/{id}/packs `{digest, name?}` — mount a stored pack
+/// into a database (replicated intent; the reconciler does the physical mount).
+/// Returns **202 accepted, reconciling** — NOT "mounted" (review H1). **admin**.
+async fn admin_pack_mount(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    AxumPath(db_id): AxumPath<i64>,
+    Json(body): Json<Value>,
+) -> Result<(StatusCode, Json<Value>), AppError> {
+    let actor = require_role(&state, &headers, Role::Admin).await?;
+    let digest = body
+        .get("digest")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| app_error(StatusCode::BAD_REQUEST, "missing 'digest'"))?
+        .to_string();
+    if !crate::pack_store::PackStore::is_valid_digest(&digest) {
+        return Err(app_error(StatusCode::BAD_REQUEST, "malformed digest"));
+    }
+    // Validate at PROPOSE time (H3): db exists + pack file is present here.
+    if state
+        .control
+        .lock()
+        .get_database_by_id(db_id)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .is_none()
+    {
+        return Err(app_error(StatusCode::NOT_FOUND, "database not found"));
+    }
+    if !state.pack_store.has(&digest) {
+        return Err(app_error(
+            StatusCode::NOT_FOUND,
+            "pack not uploaded — POST /v1/admin/packs first",
+        ));
+    }
+    let name = body
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&digest[..12])
+        .to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+    if let Some(yrp) = &state.yrp {
+        yrp.mount_pack_replicated(&actor.name, db_id, digest.clone(), name, now)
+            .await
+            .map_err(control_write_err)?;
+    } else {
+        state
+            .control
+            .lock()
+            .apply_mount_pack(db_id, &digest, &name, &now)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(json!({ "database_id": db_id, "digest": digest, "status": "reconciling" })),
+    ))
+}
+
+/// DELETE /v1/admin/databases/{id}/packs/{digest} — unmount. **admin**.
+async fn admin_pack_unmount(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    AxumPath((db_id, digest)): AxumPath<(i64, String)>,
+) -> Result<(StatusCode, Json<Value>), AppError> {
+    let actor = require_role(&state, &headers, Role::Admin).await?;
+    let now = chrono::Utc::now().to_rfc3339();
+    if let Some(yrp) = &state.yrp {
+        yrp.unmount_pack_replicated(&actor.name, db_id, digest.clone(), now)
+            .await
+            .map_err(control_write_err)?;
+    } else {
+        state
+            .control
+            .lock()
+            .apply_unmount_pack(db_id, &digest, &now)
+            .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(json!({ "database_id": db_id, "digest": digest, "status": "unmounting" })),
+    ))
+}
+
+/// GET /v1/admin/databases/{id}/packs — manifest + physical status. **readonly**.
+async fn admin_pack_mounted(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    AxumPath(db_id): AxumPath<i64>,
+) -> AppResult {
+    require_role(&state, &headers, Role::Readonly).await?;
+    let manifest = state
+        .control
+        .lock()
+        .active_pack_mounts_for(db_id)
+        .map_err(|e| app_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let status = state.pack_status.get(db_id);
+    Ok(Json(json!({ "manifest": manifest, "status": status })))
+}
+
+/// GET /v1/pack-context — the mounted packs' constitution+coverage block for
+/// the caller's tenant, plus any packs still pending on this node (H1: the
+/// agent is told when knowledge it mounted isn't yet locally available).
+/// Token-authed (a normal tenant token).
+async fn pack_context(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+) -> AppResult {
+    let (db_id, engine) = resolve_engine(
+        &state,
+        headers.get("authorization").and_then(|v| v.to_str().ok()),
+    )?;
+    let context = engine.pack_context();
+    let status = state.pack_status.get(db_id);
+    Ok(Json(json!({
+        "pack_context": context,
+        "packs_pending": status.pending,
+        "packs_poisoned": status.poisoned,
+    })))
+}
+
 /// GET /v1/admin/control-snapshot — returns a full snapshot of the control
 /// plane (databases + active tokens) for replication to followers.
 ///
@@ -5895,6 +6078,18 @@ pub fn router(state: Arc<AppState>) -> Router {
             get(admin_get_quota).put(admin_set_quota),
         )
         .route("/v1/admin/audit", get(admin_audit))
+        // RFC 031: pack management (small bodies / GET — upload is separate).
+        .route("/v1/packs/{digest}", get(pack_transfer))
+        .route("/v1/admin/packs", get(admin_pack_list))
+        .route(
+            "/v1/admin/databases/{id}/packs",
+            get(admin_pack_mounted).post(admin_pack_mount),
+        )
+        .route(
+            "/v1/admin/databases/{id}/packs/{digest}",
+            delete(admin_pack_unmount),
+        )
+        .route("/v1/pack-context", get(pack_context))
         .route("/v1/admin/snapshot", post(admin_snapshot))
         // RFC 027 / v0.8.24 — autonomous-maintenance operator surface.
         .route("/v1/admin/maintenance/run", post(admin_maintenance_run))
@@ -5929,8 +6124,20 @@ pub fn router(state: Arc<AppState>) -> Router {
         // before any handler runs. Defends against memory-blow attacks
         // and misconfigured clients.
         .layer(tower_http::limit::RequestBodyLimitLayer::new(body_limit))
-        .with_state(state)
-        .merge(principal_auth_router);
+        .with_state(state.clone())
+        .merge(principal_auth_router)
+        // RFC 031: pack UPLOAD needs a large body (packs are MB-scale), so it
+        // rides its own router with a high limit, merged AFTER the 64KB layer
+        // above so that cap does not apply to it. Every other route keeps the
+        // small cap.
+        .merge(
+            Router::new()
+                .route("/v1/admin/packs", post(admin_pack_upload))
+                .layer(tower_http::limit::RequestBodyLimitLayer::new(
+                    PACK_MAX_UPLOAD_BYTES + 1024,
+                ))
+                .with_state(state),
+        );
     app
 }
 
@@ -6582,6 +6789,8 @@ pub(crate) mod e2e_test_support {
             jobs,
             data_dir,
             auth_provider,
+            pack_store: crate::pack_store::PackStore::open(tmp.path()).unwrap(),
+            pack_status: std::sync::Arc::new(crate::pack_reconciler::PackStatus::default()),
         });
 
         E2eFixture {

--- a/crates/yantrikdb-server/src/main.rs
+++ b/crates/yantrikdb-server/src/main.rs
@@ -19,6 +19,8 @@ mod jobs;
 mod key_provider;
 pub(crate) mod metrics;
 mod migrations;
+mod pack_reconciler;
+mod pack_store;
 mod restore;
 mod retrieval;
 mod runtime;
@@ -1888,6 +1890,11 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
         let workers =
             background::WorkerRegistry::new(&cfg.background, &cfg.maintenance, write_gate);
 
+        // RFC 031: content-addressed pack store + shared reconcile status.
+        let pack_store =
+            crate::pack_store::PackStore::open(&cfg.server.data_dir).expect("open pack store");
+        let pack_status = std::sync::Arc::new(crate::pack_reconciler::PackStatus::default());
+
         let state = Arc::new(AppState {
             control,
             pool,
@@ -1902,7 +1909,28 @@ async fn run_server(cfg: ServerConfig) -> anyhow::Result<()> {
             jobs,
             data_dir: cfg.server.data_dir.clone(),
             auth_provider,
+            pack_store: pack_store.clone(),
+            pack_status: pack_status.clone(),
         });
+
+        // RFC 031: the pack reconciler — makes this node's physical mounts
+        // match the replicated db_packs manifest (fetch missing files from the
+        // leader, mount under catch_unwind + poison-quarantine).
+        {
+            let fetcher: Option<std::sync::Arc<dyn crate::pack_reconciler::PackFetcher>> = state
+                .yrp
+                .clone()
+                .map(|h| h as std::sync::Arc<dyn crate::pack_reconciler::PackFetcher>);
+            crate::pack_reconciler::PackReconciler::new(
+                state.control.clone(),
+                pack_store,
+                state.pool.clone(),
+                pack_status,
+                fetcher,
+                &cfg.server.data_dir,
+            )
+            .spawn();
+        }
 
         // Built-in watchdog — periodically probes the engine lock and fires a
         // metric if acquisition takes too long. Complement to the external bash

--- a/crates/yantrikdb-server/src/pack_reconciler.rs
+++ b/crates/yantrikdb-server/src/pack_reconciler.rs
@@ -1,0 +1,341 @@
+//! RFC 031 — the pack reconciler.
+//!
+//! A per-node background actuator that makes this node's *physical* pack mounts
+//! match the *replicated* `db_packs` manifest (the cluster's intent). This is
+//! the best-effort half of the manifest/actuator split: the manifest apply is
+//! fail-stop-safe consensus; the reconciler here can fail transiently (a file
+//! not yet fetched) without fencing the cluster.
+//!
+//! Safety properties the adversarial review demanded (RFC 031 §Review):
+//! - **Poison quarantine (C1):** a mount that panics or fails
+//!   `MAX_ATTEMPTS` times moves that `(db, digest)` to a TERMINAL local
+//!   quarantine (persisted, survives restart) so a bad pack can never
+//!   crash-loop the cluster. The mount runs under `catch_unwind`.
+//! - **Fail-visible (H1):** per-db status (mounted / pending / poisoned) is
+//!   published for `/v1/health`, recall, and the admin API — never silent.
+//! - **Verified-present (M2):** a file counts as present only if it hashes to
+//!   its digest; a truncated file re-fetches. Fetch is single-flight (one
+//!   reconcile at a time), size-capped, and digest-verified before store.
+//! - **Bounded load (M2/H2):** only databases that actually have a manifest
+//!   pack are engine-loaded — an intentional, bounded set, not every tenant.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::{Mutex, RwLock};
+
+use crate::control::ControlDb;
+use crate::pack_store::PackStore;
+use crate::tenant_pool::TenantPool;
+
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(10);
+const MOUNT_MAX_ATTEMPTS: u32 = 3;
+/// Cap on a fetched pack file (bounds disk + the engine's HNSW build — H2/C1).
+const PACK_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Per-database physical-mount status, published for health / recall / API.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct DbPackStatus {
+    /// Digests physically mounted and serving.
+    pub mounted: Vec<String>,
+    /// In the manifest but not yet mounted here (fetching / engine cold).
+    pub pending: Vec<String>,
+    /// Terminally quarantined on this node (a mount that crashed/failed).
+    pub poisoned: Vec<String>,
+}
+
+/// Shared, node-local view of pack reconcile state. Cheap to read on hot paths.
+#[derive(Default)]
+pub struct PackStatus {
+    per_db: RwLock<BTreeMap<i64, DbPackStatus>>,
+}
+
+impl PackStatus {
+    pub fn get(&self, database_id: i64) -> DbPackStatus {
+        self.per_db
+            .read()
+            .get(&database_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+    /// Any database with packs not fully mounted (for /v1/health rollup).
+    pub fn any_incomplete(&self) -> bool {
+        self.per_db
+            .read()
+            .values()
+            .any(|s| !s.pending.is_empty() || !s.poisoned.is_empty())
+    }
+    fn set(&self, database_id: i64, status: DbPackStatus) {
+        self.per_db.write().insert(database_id, status);
+    }
+}
+
+/// Fetches a missing pack file from a cluster peer (the leader first). `None`
+/// in single-node mode, where the file is always already local.
+pub trait PackFetcher: Send + Sync {
+    /// Best (leader) base url + the peer secret, if a cluster is running.
+    fn leader_base_and_secret(&self) -> Option<(String, String)>;
+}
+
+pub struct PackReconciler {
+    control: Arc<Mutex<ControlDb>>,
+    store: PackStore,
+    pool: Arc<TenantPool>,
+    status: Arc<PackStatus>,
+    fetcher: Option<Arc<dyn PackFetcher>>,
+    quarantine_path: std::path::PathBuf,
+    /// (db_id, digest) -> failed attempts this process; promotes to quarantine.
+    attempts: Mutex<BTreeMap<(i64, String), u32>>,
+    quarantine: RwLock<BTreeSet<(i64, String)>>,
+}
+
+impl PackReconciler {
+    pub fn new(
+        control: Arc<Mutex<ControlDb>>,
+        store: PackStore,
+        pool: Arc<TenantPool>,
+        status: Arc<PackStatus>,
+        fetcher: Option<Arc<dyn PackFetcher>>,
+        data_dir: &Path,
+    ) -> Arc<Self> {
+        let quarantine_path = data_dir.join("packs").join("quarantine.json");
+        let quarantine = load_quarantine(&quarantine_path);
+        Arc::new(Self {
+            control,
+            store,
+            pool,
+            status,
+            fetcher,
+            quarantine_path,
+            attempts: Mutex::new(BTreeMap::new()),
+            quarantine: RwLock::new(quarantine),
+        })
+    }
+
+    /// Spawn the reconcile loop (single-flight: one tick at a time).
+    pub fn spawn(self: Arc<Self>) {
+        tokio::spawn(async move {
+            loop {
+                if let Err(e) = self.reconcile_once().await {
+                    tracing::warn!(error = %e, "pack reconcile tick failed");
+                }
+                tokio::time::sleep(RECONCILE_INTERVAL).await;
+            }
+        });
+    }
+
+    /// One reconcile pass over the whole manifest. Public so it can be driven
+    /// synchronously in tests.
+    pub async fn reconcile_once(&self) -> anyhow::Result<()> {
+        // Desired state grouped by database (unmounted rows are excluded).
+        let desired = self.control.lock().active_pack_mounts()?;
+        let mut by_db: BTreeMap<i64, Vec<(String, String)>> = BTreeMap::new();
+        for m in desired {
+            by_db
+                .entry(m.database_id)
+                .or_default()
+                .push((m.pack_digest, m.pack_name));
+        }
+
+        for (db_id, wanted) in by_db {
+            if let Err(e) = self.reconcile_db(db_id, &wanted).await {
+                tracing::warn!(db_id, error = %e, "pack reconcile for db failed");
+            }
+        }
+        Ok(())
+    }
+
+    async fn reconcile_db(&self, db_id: i64, wanted: &[(String, String)]) -> anyhow::Result<()> {
+        // Resolve the tenant engine (lazy-loads — bounded: only dbs with packs
+        // reach here). A missing/failed db is a no-op (H3), reported pending.
+        let db_record = match self.control.lock().get_database_by_id(db_id)? {
+            Some(r) => r,
+            None => return Ok(()), // orphan manifest row (db gone) — ignore
+        };
+        let engine = match self.pool.get_engine(&db_record) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!(db_id, error = %e, "engine load failed; packs pending");
+                let mut st = DbPackStatus::default();
+                st.pending = wanted.iter().map(|(d, _)| d.clone()).collect();
+                self.status.set(db_id, st);
+                return Ok(());
+            }
+        };
+
+        let wanted_digests: BTreeSet<&str> = wanted.iter().map(|(d, _)| d.as_str()).collect();
+        // Current physical mounts (digest recovered from the file path).
+        let mounted = engine.mounted_packs();
+        let mut mounted_by_digest: BTreeMap<String, String> = BTreeMap::new(); // digest -> pack_id
+        for p in &mounted {
+            if let Some(d) = digest_from_path(&p.path) {
+                mounted_by_digest.insert(d, p.pack_id.clone());
+            }
+        }
+
+        // 1. Unmount anything mounted that the manifest no longer wants.
+        for (digest, pack_id) in &mounted_by_digest {
+            if !wanted_digests.contains(digest.as_str()) {
+                let _ = engine.unmount_pack(pack_id);
+            }
+        }
+
+        let mut status = DbPackStatus::default();
+        // 2. Mount everything wanted that isn't mounted and isn't quarantined.
+        for (digest, _name) in wanted {
+            if mounted_by_digest.contains_key(digest) {
+                status.mounted.push(digest.clone());
+                continue;
+            }
+            if self.quarantine.read().contains(&(db_id, digest.clone())) {
+                status.poisoned.push(digest.clone());
+                continue;
+            }
+            match self.ensure_file(digest).await {
+                Ok(true) => {}
+                Ok(false) | Err(_) => {
+                    status.pending.push(digest.clone());
+                    continue;
+                }
+            }
+            // Physical mount under catch_unwind — a pack that panics the engine
+            // must not take down the process (C1).
+            let path = match self.store.path(digest) {
+                Some(p) => p.to_string_lossy().to_string(),
+                None => continue,
+            };
+            let engine2 = engine.clone();
+            let path2 = path.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    engine2.mount_pack(&path2)
+                }))
+            })
+            .await;
+            let ok = matches!(result, Ok(Ok(Ok(_))));
+            if ok {
+                status.mounted.push(digest.clone());
+                self.attempts.lock().remove(&(db_id, digest.clone()));
+            } else {
+                let attempts = {
+                    let mut a = self.attempts.lock();
+                    let n = a.entry((db_id, digest.clone())).or_insert(0);
+                    *n += 1;
+                    *n
+                };
+                // A panic (Err(_) from catch_unwind) quarantines immediately;
+                // a plain error gets MAX_ATTEMPTS before terminal quarantine.
+                let panicked = matches!(&result, Ok(Err(_)));
+                if panicked || attempts >= MOUNT_MAX_ATTEMPTS {
+                    tracing::error!(
+                        db_id,
+                        digest,
+                        attempts,
+                        panicked,
+                        "pack mount terminally failed — quarantining (poison)"
+                    );
+                    self.quarantine.write().insert((db_id, digest.clone()));
+                    self.persist_quarantine();
+                    status.poisoned.push(digest.clone());
+                } else {
+                    status.pending.push(digest.clone());
+                }
+            }
+        }
+        self.status.set(db_id, status);
+        Ok(())
+    }
+
+    /// Ensure the pack file is present-and-verified locally. Fetches from the
+    /// leader if missing (cluster mode); size-capped + digest-verified.
+    async fn ensure_file(&self, digest: &str) -> anyhow::Result<bool> {
+        if self.store.has(digest) {
+            // has() is name-present; confirm it verifies (heals a torn file).
+            if self.store.load(digest).is_ok() {
+                return Ok(true);
+            }
+            // Corrupt/torn — remove and re-fetch.
+            if let Some(p) = self.store.path(digest) {
+                let _ = std::fs::remove_file(p);
+            }
+        }
+        let Some(fetcher) = &self.fetcher else {
+            return Ok(false); // single-node: file should have been local
+        };
+        let Some((base, secret)) = fetcher.leader_base_and_secret() else {
+            return Ok(false);
+        };
+        let client = reqwest::Client::builder().timeout(FETCH_TIMEOUT).build()?;
+        let resp = client
+            .get(format!("{base}/v1/packs/{digest}"))
+            .bearer_auth(secret)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            return Ok(false);
+        }
+        if let Some(len) = resp.content_length() {
+            if len > PACK_MAX_BYTES {
+                anyhow::bail!("pack {digest} exceeds size cap ({len} bytes)");
+            }
+        }
+        let bytes = resp.bytes().await?;
+        if bytes.len() as u64 > PACK_MAX_BYTES {
+            anyhow::bail!("pack {digest} stream exceeded size cap");
+        }
+        self.store.store_verified(digest, &bytes)?; // rejects a digest mismatch
+        Ok(true)
+    }
+
+    fn persist_quarantine(&self) {
+        let list: Vec<String> = self
+            .quarantine
+            .read()
+            .iter()
+            .map(|(db, d)| format!("{db}:{d}"))
+            .collect();
+        if let Ok(json) = serde_json::to_vec(&list) {
+            let _ = std::fs::write(&self.quarantine_path, json);
+        }
+    }
+}
+
+fn load_quarantine(path: &Path) -> BTreeSet<(i64, String)> {
+    let mut out = BTreeSet::new();
+    if let Ok(bytes) = std::fs::read(path) {
+        if let Ok(list) = serde_json::from_slice::<Vec<String>>(&bytes) {
+            for e in list {
+                if let Some((db, d)) = e.split_once(':') {
+                    if let Ok(db) = db.parse::<i64>() {
+                        out.insert((db, d.to_string()));
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// A YRP node fetches missing pack files from the current leader (peer auth =
+/// `cluster_secret`). On the leader itself the file is already local, so this
+/// only fires on followers / rejoining nodes.
+impl PackFetcher for crate::yrp::runtime::YrpHandle {
+    fn leader_base_and_secret(&self) -> Option<(String, String)> {
+        let (_, addr) = self.leader_hint();
+        Some((addr?, self.cluster_secret.clone()?))
+    }
+}
+
+/// Recover a pack's content digest from its stored file path (`<digest>.ydbpack`).
+fn digest_from_path(path: &str) -> Option<String> {
+    let name = Path::new(path).file_name()?.to_string_lossy();
+    let d = name.strip_suffix(".ydbpack")?;
+    if PackStore::is_valid_digest(d) {
+        Some(d.to_string())
+    } else {
+        None
+    }
+}

--- a/crates/yantrikdb-server/src/pack_reconciler.rs
+++ b/crates/yantrikdb-server/src/pack_reconciler.rs
@@ -155,10 +155,14 @@ impl PackReconciler {
             Some(r) => r,
             None => return Ok(()), // orphan manifest row (db gone) — ignore
         };
-        let engine = match self.pool.get_engine(&db_record) {
-            Ok(e) => e,
-            Err(e) => {
-                tracing::warn!(db_id, error = %e, "engine load failed; packs pending");
+        // Lazy engine load can open SQLite / build an index — keep it off the
+        // async runtime (review M-1).
+        let pool = self.pool.clone();
+        let rec = db_record.clone();
+        let engine = match tokio::task::spawn_blocking(move || pool.get_engine(&rec)).await {
+            Ok(Ok(e)) => e,
+            _ => {
+                tracing::warn!(db_id, "engine load failed; packs pending");
                 let mut st = DbPackStatus::default();
                 st.pending = wanted.iter().map(|(d, _)| d.clone()).collect();
                 self.status.set(db_id, st);
@@ -167,6 +171,26 @@ impl PackReconciler {
         };
 
         let wanted_digests: BTreeSet<&str> = wanted.iter().map(|(d, _)| d.as_str()).collect();
+        // L-3: a pack no longer in this db's manifest is recoverable — clear any
+        // quarantine/attempt state so an operator can fix + re-upload + remount.
+        {
+            let stale: Vec<(i64, String)> = self
+                .quarantine
+                .read()
+                .iter()
+                .filter(|(d, dg)| *d == db_id && !wanted_digests.contains(dg.as_str()))
+                .cloned()
+                .collect();
+            if !stale.is_empty() {
+                let mut q = self.quarantine.write();
+                for k in &stale {
+                    q.remove(k);
+                    self.attempts.lock().remove(k);
+                }
+                drop(q);
+                self.persist_quarantine();
+            }
+        }
         // Current physical mounts (digest recovered from the file path).
         let mounted = engine.mounted_packs();
         let mut mounted_by_digest: BTreeMap<String, String> = BTreeMap::new(); // digest -> pack_id
@@ -176,10 +200,13 @@ impl PackReconciler {
             }
         }
 
-        // 1. Unmount anything mounted that the manifest no longer wants.
+        // 1. Unmount anything mounted that the manifest no longer wants
+        //    (unmount frees the HNSW — keep it off the async runtime, M-1).
         for (digest, pack_id) in &mounted_by_digest {
             if !wanted_digests.contains(digest.as_str()) {
-                let _ = engine.unmount_pack(pack_id);
+                let engine_u = engine.clone();
+                let pid = pack_id.clone();
+                let _ = tokio::task::spawn_blocking(move || engine_u.unmount_pack(&pid)).await;
             }
         }
 
@@ -201,8 +228,26 @@ impl PackReconciler {
                     continue;
                 }
             }
+            // M-2: re-check the manifest immediately before mounting — an
+            // UnmountPack may have committed since the tick's snapshot, and we
+            // must not mount (then serve) a pack the cluster just unmounted.
+            let still_wanted = self
+                .control
+                .lock()
+                .active_pack_mounts_for(db_id)
+                .map(|rows| rows.iter().any(|r| &r.pack_digest == digest))
+                .unwrap_or(false);
+            if !still_wanted {
+                continue;
+            }
             // Physical mount under catch_unwind — a pack that panics the engine
-            // must not take down the process (C1).
+            // must not take down the PROCESS (C1). Known limitation (review
+            // M-3): catch_unwind + quarantine protect the cluster from
+            // crash-looping, but a panic partway through mount_pack could leave
+            // THIS tenant's shared engine with a poisoned lock / half-built
+            // index for the process lifetime; true isolation is an engine-side
+            // concern (mount in a child process / arena). The upload size cap +
+            // the engine's own structural vetting make this unlikely in practice.
             let path = match self.store.path(digest) {
                 Some(p) => p.to_string_lossy().to_string(),
                 None => continue,

--- a/crates/yantrikdb-server/src/pack_store.rs
+++ b/crates/yantrikdb-server/src/pack_store.rs
@@ -1,0 +1,171 @@
+//! RFC 031 — content-addressed pack file store.
+//!
+//! Pack `.ydbpack` files are large opaque binaries that must NOT ride the YRP
+//! consensus log (only the small mount *manifest* does — see RFC 031). They
+//! live on disk under `data_dir/packs/<blake3-digest>.ydbpack`, keyed by their
+//! content digest so identity == digest and duplicate uploads dedupe for free.
+//!
+//! The digest is validated as 64 lowercase hex chars before it ever touches a
+//! path, so a digest supplied by a peer or a client can never traverse the
+//! filesystem (`../`, absolute paths, etc. are rejected — RFC 031 Invariant 2).
+
+use std::path::{Path, PathBuf};
+
+/// A content-addressed store of pack files.
+#[derive(Clone)]
+pub struct PackStore {
+    dir: PathBuf,
+}
+
+/// A stored pack's on-disk summary (for listings).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct StoredPack {
+    pub digest: String,
+    pub size: u64,
+}
+
+impl PackStore {
+    /// Open (creating if absent) the pack store under `data_dir/packs/`.
+    pub fn open(data_dir: &Path) -> std::io::Result<Self> {
+        let dir = data_dir.join("packs");
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self { dir })
+    }
+
+    /// True iff `s` is a well-formed blake3 hex digest (64 lowercase hex).
+    /// Everything that turns a digest into a path goes through this first.
+    pub fn is_valid_digest(s: &str) -> bool {
+        s.len() == 64
+            && s.bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    }
+
+    /// The on-disk path for a digest, or `None` if the digest is malformed
+    /// (which also makes path traversal impossible).
+    pub fn path(&self, digest: &str) -> Option<PathBuf> {
+        if Self::is_valid_digest(digest) {
+            Some(self.dir.join(format!("{digest}.ydbpack")))
+        } else {
+            None
+        }
+    }
+
+    pub fn digest_of(bytes: &[u8]) -> String {
+        blake3::hash(bytes).to_hex().to_string()
+    }
+
+    pub fn has(&self, digest: &str) -> bool {
+        self.path(digest).map(|p| p.exists()).unwrap_or(false)
+    }
+
+    /// Store bytes under their own content digest (atomic via temp+rename).
+    /// Returns the digest. Idempotent: re-storing identical bytes is a no-op.
+    pub fn store(&self, bytes: &[u8]) -> std::io::Result<String> {
+        let digest = Self::digest_of(bytes);
+        self.write_atomic(&digest, bytes)?;
+        Ok(digest)
+    }
+
+    /// Store bytes that a PEER served for an EXPECTED digest — verifying the
+    /// bytes actually hash to it before writing (RFC 031 Invariant 2). A
+    /// mismatched stream is refused, never stored.
+    pub fn store_verified(&self, expected: &str, bytes: &[u8]) -> std::io::Result<()> {
+        let actual = Self::digest_of(bytes);
+        if actual != expected {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("pack digest mismatch: expected {expected}, got {actual}"),
+            ));
+        }
+        self.write_atomic(expected, bytes)
+    }
+
+    /// Read a stored pack, re-verifying its digest on the way out (guards
+    /// against on-disk corruption before we hand bytes to a peer or the engine).
+    pub fn load(&self, digest: &str) -> std::io::Result<Vec<u8>> {
+        let path = self
+            .path(digest)
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "bad digest"))?;
+        let bytes = std::fs::read(path)?;
+        if Self::digest_of(&bytes) != digest {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "stored pack failed digest re-verification (corrupt)",
+            ));
+        }
+        Ok(bytes)
+    }
+
+    pub fn list(&self) -> Vec<StoredPack> {
+        let mut out = Vec::new();
+        if let Ok(rd) = std::fs::read_dir(&self.dir) {
+            for e in rd.flatten() {
+                let name = e.file_name();
+                let name = name.to_string_lossy();
+                if let Some(d) = name.strip_suffix(".ydbpack") {
+                    if Self::is_valid_digest(d) {
+                        let size = e.metadata().map(|m| m.len()).unwrap_or(0);
+                        out.push(StoredPack {
+                            digest: d.to_string(),
+                            size,
+                        });
+                    }
+                }
+            }
+        }
+        out.sort_by(|a, b| a.digest.cmp(&b.digest));
+        out
+    }
+
+    fn write_atomic(&self, digest: &str, bytes: &[u8]) -> std::io::Result<()> {
+        let path = self
+            .path(digest)
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "bad digest"))?;
+        if path.exists() {
+            return Ok(()); // content-addressed: identical bytes already present
+        }
+        let tmp = self.dir.join(format!(".{digest}.tmp"));
+        std::fs::write(&tmp, bytes)?;
+        std::fs::rename(&tmp, &path)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_load_roundtrip_and_dedup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = PackStore::open(tmp.path()).unwrap();
+        let bytes = b"a sealed pack's bytes";
+        let digest = store.store(bytes).unwrap();
+        assert!(PackStore::is_valid_digest(&digest));
+        assert!(store.has(&digest));
+        assert_eq!(store.load(&digest).unwrap(), bytes);
+        // dedup: storing again is a no-op returning the same digest
+        assert_eq!(store.store(bytes).unwrap(), digest);
+        assert_eq!(store.list().len(), 1);
+    }
+
+    #[test]
+    fn verified_store_rejects_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = PackStore::open(tmp.path()).unwrap();
+        let good = PackStore::digest_of(b"real bytes");
+        assert!(store.store_verified(&good, b"real bytes").is_ok());
+        // a peer claiming a digest but serving other bytes is refused
+        assert!(store.store_verified(&good, b"TAMPERED").is_err());
+    }
+
+    #[test]
+    fn malformed_digest_cannot_traverse() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = PackStore::open(tmp.path()).unwrap();
+        assert!(store.path("../../etc/passwd").is_none());
+        assert!(store.path("not-hex").is_none());
+        assert!(store.path(&"g".repeat(64)).is_none()); // non-hex chars
+        assert!(!store.has("../../etc/passwd"));
+    }
+}

--- a/crates/yantrikdb-server/src/server.rs
+++ b/crates/yantrikdb-server/src/server.rs
@@ -72,6 +72,11 @@ pub struct AppState {
     /// still authenticate inline via `control.tokens` (same data, no
     /// `Principal`).
     pub auth_provider: Arc<dyn auth::AuthProvider>,
+    /// RFC 031: content-addressed pack file store (`data_dir/packs/`).
+    pub pack_store: crate::pack_store::PackStore,
+    /// RFC 031: per-node physical pack-mount status (mounted/pending/poisoned),
+    /// shared with the reconciler; read on health / recall / admin paths.
+    pub pack_status: Arc<crate::pack_reconciler::PackStatus>,
 }
 
 /// Maximum concurrent blocking operations before shedding load.

--- a/crates/yantrikdb-server/src/yrp/cluster_test.rs
+++ b/crates/yantrikdb-server/src/yrp/cluster_test.rs
@@ -554,6 +554,134 @@ async fn two_node_cluster_over_http_replicates_keyed_and_unkeyed_writes() {
             .any(|e| e["action"] == json!("create_user") && e["actor"] == json!("master-token")),
         "audit must attribute the bootstrap create_user to master-token: {resp}"
     );
+
+    // ── RFC 031: clustered packs — manifest replication + peer file-transfer
+    //    + reconciler poison-quarantine, all in one flow. (A real sealed pack
+    //    mounting + recall is covered by the engine's own pack tests; here we
+    //    prove the SERVER's novel surface with a deliberately-invalid pack so
+    //    the poison-quarantine path — the review's CRITICAL C1 — is exercised.)
+    let tenant_db_id = leader
+        .state
+        .control
+        .lock()
+        .get_database(TENANT)
+        .unwrap()
+        .unwrap()
+        .id;
+
+    // Upload arbitrary bytes as a "pack" to the leader (upload stores by
+    // digest; validity is judged at mount).
+    let client = reqwest::Client::new();
+    let junk = b"not actually a sealed sqlite pack \x00\x01\x02".to_vec();
+    let up = client
+        .post(format!("{}/v1/admin/packs", leader.base))
+        .bearer_auth(SECRET)
+        .header("content-type", "application/octet-stream")
+        .body(junk.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(up.status(), reqwest::StatusCode::OK, "pack upload");
+    let pack_digest = up.json::<Value>().await.unwrap()["digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Peer-transfer: the leader serves the file to a cluster_secret holder,
+    // and refuses without it.
+    let noauth = client
+        .get(format!("{}/v1/packs/{}", leader.base, pack_digest))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(noauth.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    // Mount into the tenant db via the leader → 202 accepted (reconciling).
+    let (st, _) = post_json(
+        &leader.base,
+        SECRET,
+        &format!("/v1/admin/databases/{tenant_db_id}/packs"),
+        &json!({ "digest": pack_digest, "name": "junk-pack" }),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::ACCEPTED, "mount → 202");
+
+    // The MANIFEST replicates to the follower (the consensus half).
+    {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let rows = follower
+                .state
+                .control
+                .lock()
+                .active_pack_mounts_for(tenant_db_id)
+                .unwrap();
+            if rows.iter().any(|r| r.pack_digest == pack_digest) {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "pack mount manifest never replicated to follower"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    // Drive the FOLLOWER's reconciler: it fetches the file from the leader
+    // (peer-transfer), tries to mount the invalid pack, and after MAX_ATTEMPTS
+    // terminally quarantines it — WITHOUT crashing the process (C1).
+    struct LeaderFetcher(String);
+    impl crate::pack_reconciler::PackFetcher for LeaderFetcher {
+        fn leader_base_and_secret(&self) -> Option<(String, String)> {
+            Some((self.0.clone(), SECRET.to_string()))
+        }
+    }
+    let follower_dir = follower.state.data_dir.clone();
+    let reconciler = crate::pack_reconciler::PackReconciler::new(
+        follower.state.control.clone(),
+        follower.state.pack_store.clone(),
+        follower.state.pool.clone(),
+        follower.state.pack_status.clone(),
+        Some(Arc::new(LeaderFetcher(leader.base.clone()))),
+        &follower_dir,
+    );
+    for _ in 0..4 {
+        reconciler.reconcile_once().await.unwrap();
+    }
+
+    // Peer-transfer worked: the follower now holds the file.
+    assert!(
+        follower.state.pack_store.has(&pack_digest),
+        "follower must have fetched the pack file from the leader"
+    );
+    // Poison-quarantine worked: the invalid pack is terminally poisoned on the
+    // follower, and the cluster is still up (we're still running).
+    let status = follower.state.pack_status.get(tenant_db_id);
+    assert!(
+        status.poisoned.contains(&pack_digest),
+        "invalid pack must be quarantined (poisoned), got {status:?}"
+    );
+
+    // Unmount replicates too: the manifest row clears on the follower.
+    let (st, _) = post_json(
+        &follower.base,
+        SECRET,
+        &format!("/v1/admin/databases/{tenant_db_id}/packs"),
+        &json!({ "digest": pack_digest }),
+    )
+    .await;
+    assert_eq!(
+        st,
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "pack mount on a follower must redirect to the leader"
+    );
+    let (st, _) = get_json(
+        &leader.base,
+        SECRET,
+        &format!("/v1/admin/databases/{tenant_db_id}/packs"),
+    )
+    .await;
+    assert_eq!(st, reqwest::StatusCode::OK, "list mounted packs");
 }
 
 async fn spawn_node_on(node_id: u64, peers: Vec<YrpPeer>, port: u16) -> Node {
@@ -653,6 +781,8 @@ async fn spawn_node_inner(node_id: u64, peers: Vec<YrpPeer>, port: u16) -> Node 
         jobs,
         data_dir,
         auth_provider,
+        pack_store: crate::pack_store::PackStore::open(tmp.path()).unwrap(),
+        pack_status: std::sync::Arc::new(crate::pack_reconciler::PackStatus::default()),
     });
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))

--- a/crates/yantrikdb-server/src/yrp/control_op.rs
+++ b/crates/yantrikdb-server/src/yrp/control_op.rs
@@ -166,23 +166,35 @@ impl ControlOp {
                 buf.extend_from_slice(b"ctl:sesskey:");
                 buf.extend_from_slice(kid.as_bytes());
             }
+            // Fold the timestamp into the claim (review H-1): the claim
+            // ledger is a permanent key→index map, so a mount/unmount cycle
+            // on the SAME (db, digest) must produce DISTINCT claims — else a
+            // remount-after-unmount dedupes against the original mount's
+            // committed index, never re-appends, and the UPSERT that clears
+            // `unmounted_at` never runs. mount/unmount apply is idempotent, so
+            // per-op-unique claims are harmless.
             ControlOp::MountPack {
                 database_id,
                 pack_digest,
+                mounted_at,
                 ..
             } => {
                 buf.extend_from_slice(b"ctl:mountpack:");
                 buf.extend_from_slice(&database_id.to_le_bytes());
                 buf.extend_from_slice(pack_digest.as_bytes());
+                buf.push(b':');
+                buf.extend_from_slice(mounted_at.as_bytes());
             }
             ControlOp::UnmountPack {
                 database_id,
                 pack_digest,
-                ..
+                unmounted_at,
             } => {
                 buf.extend_from_slice(b"ctl:unmountpack:");
                 buf.extend_from_slice(&database_id.to_le_bytes());
                 buf.extend_from_slice(pack_digest.as_bytes());
+                buf.push(b':');
+                buf.extend_from_slice(unmounted_at.as_bytes());
             }
         }
         super::op::fnv1a64(&buf)
@@ -419,6 +431,36 @@ mod tests {
         };
         let bytes = op.encode().unwrap();
         assert_eq!(ControlOp::decode(&bytes).unwrap(), op);
+    }
+
+    #[test]
+    fn mount_remount_claim_keys_differ() {
+        // Review H-1: a remount of the SAME (db, digest) after an unmount must
+        // produce a DISTINCT claim (via mounted_at) so it re-appends and the
+        // clear-unmounted_at UPSERT runs — else remount silently no-ops.
+        let m1 = ControlOp::MountPack {
+            database_id: 1,
+            pack_digest: "d".repeat(64),
+            pack_name: "p".into(),
+            mounted_at: "2026-07-29T00:00:00Z".into(),
+        };
+        let m2 = ControlOp::MountPack {
+            database_id: 1,
+            pack_digest: "d".repeat(64),
+            pack_name: "p".into(),
+            mounted_at: "2026-07-29T00:05:00Z".into(), // later remount
+        };
+        let u = ControlOp::UnmountPack {
+            database_id: 1,
+            pack_digest: "d".repeat(64),
+            unmounted_at: "2026-07-29T00:02:00Z".into(),
+        };
+        assert_ne!(
+            m1.claim_key(),
+            m2.claim_key(),
+            "remount must be a new claim"
+        );
+        assert_ne!(m1.claim_key(), u.claim_key(), "mount vs unmount distinct");
     }
 
     #[test]

--- a/crates/yantrikdb-server/src/yrp/control_op.rs
+++ b/crates/yantrikdb-server/src/yrp/control_op.rs
@@ -88,6 +88,20 @@ pub enum ControlOp {
     /// RFC 030 (H3): seed/rotate the replicated admin session-signing key.
     /// `value` is base64 of 32 random bytes; `kid` identifies it in tokens.
     SetAdminSessionKey { kid: String, value: String },
+    /// RFC 031: mount a pack (by content digest) into a database — the
+    /// replicated *intent*; the per-node reconciler fetches the file + mounts.
+    MountPack {
+        database_id: i64,
+        pack_digest: String,
+        pack_name: String,
+        mounted_at: String,
+    },
+    /// RFC 031: unmount a pack from a database.
+    UnmountPack {
+        database_id: i64,
+        pack_digest: String,
+        unmounted_at: String,
+    },
 }
 
 impl ControlOp {
@@ -152,6 +166,24 @@ impl ControlOp {
                 buf.extend_from_slice(b"ctl:sesskey:");
                 buf.extend_from_slice(kid.as_bytes());
             }
+            ControlOp::MountPack {
+                database_id,
+                pack_digest,
+                ..
+            } => {
+                buf.extend_from_slice(b"ctl:mountpack:");
+                buf.extend_from_slice(&database_id.to_le_bytes());
+                buf.extend_from_slice(pack_digest.as_bytes());
+            }
+            ControlOp::UnmountPack {
+                database_id,
+                pack_digest,
+                ..
+            } => {
+                buf.extend_from_slice(b"ctl:unmountpack:");
+                buf.extend_from_slice(&database_id.to_le_bytes());
+                buf.extend_from_slice(pack_digest.as_bytes());
+            }
         }
         super::op::fnv1a64(&buf)
     }
@@ -176,6 +208,29 @@ impl ControlOp {
             ControlOp::SetUserPassword { username, .. } => ("set_user_password", username.clone()),
             ControlOp::DisableUser { username, .. } => ("disable_user", username.clone()),
             ControlOp::SetAdminSessionKey { kid, .. } => ("rotate_session_key", kid.clone()),
+            ControlOp::MountPack {
+                database_id,
+                pack_name,
+                pack_digest,
+                ..
+            } => (
+                "mount_pack",
+                format!(
+                    "db #{database_id} {pack_name} [{}]",
+                    &pack_digest[..pack_digest.len().min(12)]
+                ),
+            ),
+            ControlOp::UnmountPack {
+                database_id,
+                pack_digest,
+                ..
+            } => (
+                "unmount_pack",
+                format!(
+                    "db #{database_id} [{}]",
+                    &pack_digest[..pack_digest.len().min(12)]
+                ),
+            ),
         }
     }
 }
@@ -322,6 +377,24 @@ impl ControlApplySink {
             ControlOp::SetAdminSessionKey { kid, value } => db
                 .apply_set_admin_session_key(kid, value)
                 .map_err(|e| format!("control apply SetAdminSessionKey({kid}): {e}")),
+            // RFC 031: manifest-only apply (unconditional UPSERT — H3). The
+            // physical mount is the reconciler's job, decoupled from this
+            // fail-stop-safe consensus write.
+            ControlOp::MountPack {
+                database_id,
+                pack_digest,
+                pack_name,
+                mounted_at,
+            } => db
+                .apply_mount_pack(*database_id, pack_digest, pack_name, mounted_at)
+                .map_err(|e| format!("control apply MountPack(db={database_id}): {e}")),
+            ControlOp::UnmountPack {
+                database_id,
+                pack_digest,
+                unmounted_at,
+            } => db
+                .apply_unmount_pack(*database_id, pack_digest, unmounted_at)
+                .map_err(|e| format!("control apply UnmountPack(db={database_id}): {e}")),
         }
     }
 }

--- a/crates/yantrikdb-server/src/yrp/runtime.rs
+++ b/crates/yantrikdb-server/src/yrp/runtime.rs
@@ -603,6 +603,49 @@ impl YrpHandle {
             .map(|_| ())
     }
 
+    /// RFC 031: replicate a pack MOUNT intent into the manifest. The per-node
+    /// reconciler does the physical fetch+mount; this only commits the intent
+    /// (fail-stop-safe). The caller has already stored the file + validated
+    /// the target db at propose time.
+    pub async fn mount_pack_replicated(
+        &self,
+        actor: &str,
+        database_id: i64,
+        pack_digest: String,
+        pack_name: String,
+        mounted_at: String,
+    ) -> Result<(), ControlWriteError> {
+        let op = super::control_op::ControlOp::MountPack {
+            database_id,
+            pack_digest,
+            pack_name,
+            mounted_at,
+        };
+        self.propose_control(actor, &op)
+            .await
+            .map_err(ControlWriteError::Propose)
+            .map(|_| ())
+    }
+
+    /// RFC 031: replicate a pack UNMOUNT intent.
+    pub async fn unmount_pack_replicated(
+        &self,
+        actor: &str,
+        database_id: i64,
+        pack_digest: String,
+        unmounted_at: String,
+    ) -> Result<(), ControlWriteError> {
+        let op = super::control_op::ControlOp::UnmountPack {
+            database_id,
+            pack_digest,
+            unmounted_at,
+        };
+        self.propose_control(actor, &op)
+            .await
+            .map_err(ControlWriteError::Propose)
+            .map(|_| ())
+    }
+
     /// Wait for the durable-apply marker to cover `index`, then read its
     /// outcome. (An `Applied` reply already implies coverage; `Duplicate`
     /// may race a lagging apply worker — poll briefly.)

--- a/crates/yantrikdb-server/src/yrp/testkit.rs
+++ b/crates/yantrikdb-server/src/yrp/testkit.rs
@@ -237,6 +237,8 @@ pub async fn spawn_node(
         jobs,
         data_dir: data_dir.clone(),
         auth_provider,
+        pack_store: crate::pack_store::PackStore::open(&data_dir).unwrap(),
+        pack_status: std::sync::Arc::new(crate::pack_reconciler::PackStatus::default()),
     });
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))

--- a/docs/rfcs/rfc_031_server_packs.md
+++ b/docs/rfcs/rfc_031_server_packs.md
@@ -1,0 +1,221 @@
+# RFC 031 — Server-side packs (clustered)
+
+**Status:** Draft · **Depends on:** RFC 029 (control-plane replication), RFC 030 (admin RBAC), engine v0.11.1 (packs) · **Follows:** RFC 028 Phase C (fetch-missing-binary-state)
+
+## The gap
+
+Engine v0.11.0 shipped **packs** — sealed, single-file `.ydbpack` databases a
+model mounts to gain knowledge it wasn't trained on and unmounts to give back
+(seal/mount/unmount/`pack_context`, trust tiers, digest-verified, recall
+auto-includes mounted packs at the engine's merge seam). The **server embeds
+this engine but exposes none of it.** A networked or clustered YantrikDB
+cannot mount a pack, and a self-hosted operator can't manage packs over the
+API.
+
+A node-local bolt-on (mount into whichever node serves the request) is a
+half-feature: mount on the leader, `recall` on a follower, and the pack isn't
+there — silently inconsistent, lost on failover. Packs are a headline
+differentiator; they must work **correctly in the cluster**.
+
+## The core problem: two very different things travel together
+
+A "mounted pack" is **two** kinds of state with opposite requirements:
+
+1. **The mount decision** — "database D has pack with digest X mounted." Tiny,
+   deterministic, must be identical on every node and survive failover. This
+   is control-plane state, and it belongs in the **replicated control log**
+   (RFC 029), exactly like tokens and databases.
+2. **The pack file** — a ~1MB+ opaque binary. Replicating megabytes *through
+   the consensus log* is an anti-pattern (bloats the log, breaks compaction
+   economics). And a file being momentarily absent on a node is a **liveness**
+   problem (fetch it and retry), **not** a divergence — so it must **not**
+   fail-stop the apply worker the way a real control-apply error does.
+
+**The design separates them.** The manifest replicates through consensus; the
+files are content-addressed and moved out-of-band; a best-effort reconciler
+makes each node's *physical* mounts match the *replicated* manifest.
+
+## Design
+
+### 1. Replicated mount manifest (consensus, fail-stop-safe)
+
+A new `control.db` table, materialized from replicated control ops (RFC 029):
+
+```sql
+CREATE TABLE db_packs (
+    database_id  INTEGER NOT NULL,
+    pack_digest  TEXT NOT NULL,   -- blake3 content digest (the identity)
+    pack_name    TEXT NOT NULL,   -- display / filename
+    mounted_at   TEXT NOT NULL,
+    unmounted_at TEXT,            -- soft, tombstone-shaped
+    PRIMARY KEY (database_id, pack_digest)
+);
+```
+
+New `ControlOp` variants (ride the RFC 029 `ControlEnvelope`, actor-audited):
+
+- `MountPack { database_id, pack_digest, pack_name, mounted_at }`
+- `UnmountPack { database_id, pack_digest, unmounted_at }`
+
+`ControlApplySink` applies these to `db_packs` **only** — a small, deterministic
+SQLite write. This is idempotent (PK) and **fail-stop-safe**: writing a
+manifest row can't fail on a healthy node, so it keeps RFC 029's Invariant 2
+(control-apply error ⇒ fence) honestly, *without* coupling it to the physical
+mount, which can legitimately fail transiently.
+
+### 2. Content-addressed pack file store
+
+Pack files live at `data_dir/packs/<blake3-digest>.ydbpack` — **content
+addressed**, so identity == digest and dedup is automatic. The digest is the
+engine's own `seal_pack` content digest (already verified at mount).
+
+- Upload (admin) stores the file by its digest and returns its manifest.
+- A node that needs a digest it doesn't have **fetches it** (below).
+
+### 3. Peer transfer (out-of-band, digest-verified)
+
+`GET /v1/packs/<digest>` — cluster-secret (peer) auth, streams the file. A node
+missing a pack fetches it from the **leader** (leader-hint from YRP), falling
+back to any reachable peer. The receiver **re-hashes and verifies the digest
+before storing** — a mismatched byte stream is refused (untrusted-artifact
+safety; the engine additionally re-verifies at mount). This is the RFC 028
+Phase-C pattern (a node missing durable state pulls it from a peer), applied to
+pack binaries.
+
+### 4. The reconciler (best-effort, retryable, health-surfaced)
+
+A per-node background loop makes physical mounts match the replicated manifest:
+
+```
+for each (database_id, digest) in db_packs where unmounted_at IS NULL:
+    if not already mounted in that db's engine:
+        ensure file present (fetch by digest if missing; verify)
+        resolve the tenant engine; engine.mount_pack(path)
+for each mounted pack NOT in the active manifest:
+    engine.unmount_pack(id)
+```
+
+Failures (file unreachable, engine not loaded yet) are **logged, counted, and
+retried** on the next tick — never fatal. A database whose manifest packs are
+not all physically mounted is **`pack_incomplete`** and says so on
+`/v1/health` (parallel to `engine_incomplete`). Reads still serve host memory;
+they just don't yet see that pack. The reconciler runs on the same cadence as
+other background reconcilers.
+
+**Why not mount inside the apply sink?** Because mounting needs the tenant
+*engine* (from the pool) and a possibly-absent *file* — coupling that to the
+consensus apply marker would let a missing 1MB file wedge the whole cluster's
+data apply. The manifest is the contract; the reconciler is the effort.
+
+### 5. Failover / rejoin
+
+The manifest is replicated control state, so a new leader and a rejoining node
+already have it (log replay / control snapshot). Their reconcilers fetch the
+files and mount — pack mounts **survive failover and reconstruct on a fresh
+node** with no operator action, the same guarantee RFC 029 gave tokens.
+
+## API (RBAC-gated per RFC 030)
+
+- `POST /v1/admin/packs` — upload a `.ydbpack` (octet-stream) → store by digest,
+  return `{digest, name, manifest, trust}`. **admin**.
+- `GET /v1/admin/packs` — list stored packs (digest, name, size, trust). **readonly**.
+- `POST /v1/admin/databases/{id}/packs` `{digest}` — propose `MountPack`
+  (replicated); returns once the manifest commits (mount then reconciles).
+  **admin**.
+- `DELETE /v1/admin/databases/{id}/packs/{digest}` — propose `UnmountPack`. **admin**.
+- `GET /v1/admin/databases/{id}/packs` — mounted + manifest + reconcile state. **readonly**.
+- `GET /v1/packs/{digest}` — peer transfer (cluster-secret). Internal.
+- `GET /v1/pack-context` — the mounted packs' `pack_context()` (constitution +
+  coverage) for the caller's tenant, so an agent injects it into its system
+  prompt. **token-authed** (normal tenant token via `resolve_engine`).
+- **`/v1/recall` is unchanged** — the engine already merges mounted-pack
+  candidates (scored with the host's weights × trust tier). Once mounted,
+  recall surfaces pack content for free.
+
+## Invariants
+
+1. **Manifest is consensus; files are out-of-band.** Never put pack bytes in
+   the YRP log.
+2. **Digest-verified before mount** — a fetched file whose bytes don't hash to
+   the requested digest is refused; the engine re-verifies at mount. Untrusted
+   marketplace artifacts stay verifiable.
+3. **Manifest apply is fail-stop-safe; physical mount is best-effort.** A
+   missing/slow pack file degrades one database to `pack_incomplete`, never
+   fences the cluster.
+4. **Freshness gate (RFC 029 inc2-A) still applies** — a control-stale node
+   won't serve admin pack ops or mint the manifest.
+5. **Mount is idempotent + digest-keyed** — re-applying a `MountPack` or
+   reconciling twice is a no-op.
+
+## Review hardening (adversarial pass — folded in)
+
+- **C1 — poison-pack quarantine + fault isolation (CRITICAL).** A committed
+  `MountPack` whose file crashes/OOMs the shared engine on mount must NOT
+  become a cluster-wide crash loop. Defenses, layered: (a) **upload caps** —
+  reject a pack over `PACK_MAX_BYTES` (default 64 MB) at upload, and the engine
+  already caps rows (2M) so the HNSW build is bounded; (b) **structural
+  pre-vet** (engine `mount_pack` opens read-only, requires a real `memories`
+  table, no `load_extension`); (c) the reconciler wraps each mount in
+  `catch_unwind` and, on panic **or** after `PACK_MOUNT_MAX_ATTEMPTS` (default
+  3) failures, moves that `(db, digest)` to a **terminal per-node
+  `pack_poisoned` quarantine** (a local marker file, NOT the consensus
+  manifest — the manifest stays the cluster's intent), stops retrying, and
+  surfaces it on health. A best-effort actuator over committed state must have
+  a terminal state; retry-forever over a fatal mount is crash-loop-forever.
+- **H1 — fail closed / visible, not silent-open.** `MountPack` returns **202
+  "accepted, reconciling"**, never "mounted." `recall` and `pack-context`
+  responses on a db with manifest packs not yet locally mounted carry
+  `packs_pending: [digest…]` (and `packs_poisoned`), and `pack_context` does
+  **not** advertise coverage for a locally-unmounted pack. An opt-in strict
+  mode (`?require_packs=1` / config) 503s like `engine_incomplete` instead of
+  degrading. The agent is never told it has knowledge this node can't serve.
+- **H2 — caps everywhere + control.db disk reservation.** `PACK_MAX_BYTES`
+  (upload + per-fetch, aborting a peer stream that exceeds it); per-db and
+  per-node mounted-pack caps → a mount over budget stays `pack_over_budget`
+  (health state), never OOMs; the pack store has a disk high-water and
+  **reserves headroom for `control.db`** so pack files can never starve the
+  fail-stop control writes. GC of orphaned files is still a follow-up but the
+  disk cap bounds the store regardless.
+- **H3 / L1 — manifest apply is an unconditional idempotent UPSERT.** No `FK`,
+  no `REFERENCES`, no CHECK, no "database exists" validation in the apply sink
+  — nothing that can fail on committed input and fence the cluster (RFC 029
+  inv2). `MountPack` UPSERTs and **clears `unmounted_at`** (so remount-after-
+  unmount works); db-existence is checked only at **propose time** (endpoint,
+  TOCTOU-tolerant); the reconciler treats a missing db as a no-op. Extend the
+  RFC 029 delete path so `DeleteDatabase` **cascade-tombstones** `db_packs`.
+- **M1 — digest is `^[0-9a-f]{64}$`-validated at every boundary** (upload, URL
+  param, manifest apply) before it touches a path (implemented in
+  `pack_store`), and hex is pinned (no base64 `/`). Downloads are size-capped.
+- **M2 — reconciler correctness.** Single-flight (one reconcile in flight);
+  process `UnmountPack`s before mounts and **re-check `unmounted_at`
+  immediately before `mount_pack`** (no serve-after-unmount window); fetch to
+  `<digest>.tmp.<rand>` → verify → atomic rename, and "present" means
+  **verified-present**, not name-present (a truncated file heals); exponential
+  backoff and a terminal `pack_unresolvable` state after exhausting reachable
+  peers. **Mount hooks the engine LOAD path** — the tenant-pool loader consults
+  `db_packs` and mounts before serving, so a cold/lazy tenant doesn't force-load
+  everything nor retry-forever; the reconciler handles the already-loaded set +
+  deltas. Unmount must free the HNSW (verified against engine v0.11.1).
+- **M3 — failover is log-replay-only, contingent on compaction-off (F1).**
+  §5 corrected: a rejoining node reconstructs mounts via log replay while
+  compaction stays off (the RFC 029 F1 mitigation; control-in-snapshot is the
+  shared follow-up). Cold-start reconcile is **bounded-concurrency and
+  prioritized** (recently-active tenants first) to avoid a fetch/HNSW storm in
+  the most fragile window.
+- **L2/L3 — health + confidentiality notes.** `pack_incomplete`/`_poisoned`/
+  `_over_budget` are **per-db, request-visible, and do NOT flip node health**
+  (a best-effort liveness state must not make a load balancer evict a healthy
+  node). `pack_name` is display-only and never reaches the filesystem (only the
+  digest does). The content-addressed store + `cluster_secret`-only transfer is
+  cluster-global by design (consistent with `cluster_secret` = break-glass
+  owner); narrowing pack access below cluster-global is a future concern.
+
+## Out of scope (follow-ups)
+
+- **GC of orphaned pack files** (a digest no manifest references) — a periodic
+  sweep; deferred, low risk (content-addressed, so safe to keep).
+- **Signed-pack trust enforcement policy** at the server tier (accept only
+  `signed`/`official`) — a config knob; the engine already carries the trust
+  tier into scoring.
+- **Compaction of the `db_packs` manifest** rides RFC 029's control-in-snapshot
+  follow-up; until then compaction stays off (unchanged).


### PR DESCRIPTION
Exposes the engine's **pack** feature (mountable/detachable knowledge, engine v0.11) through the server — correctly **across a cluster**: mount once, and it's consistent on every node and survives failover, the same guarantee RFC 029 gave tokens. This is the differentiator feature, so it's built full, not node-local.

RFC-first (`docs/rfcs/rfc_031_server_packs.md`), **two adversarial reviews** (design → then code).

## Architecture — split by what the state actually is
- The small **mount manifest** replicates through YRP consensus (`db_packs` table + `MountPack`/`UnmountPack` control ops). Apply is an **unconditional UPSERT, no FK, no validation** — so committed input can never fail-apply and fence the cluster (review H3).
- The large **pack files** are **content-addressed** (`data_dir/packs/<blake3>.ydbpack`, path-traversal-safe) and moved **out-of-band** via a cluster-secret peer-transfer endpoint — never through the log.
- A per-node **best-effort reconciler** makes physical mounts match the manifest.

## Review-hardened safety
- **C1 poison-quarantine:** each mount runs under `catch_unwind`; on panic or `MAX_ATTEMPTS` failures the `(db, digest)` is **terminally quarantined** (persisted, survives restart) — so one bad pack can never crash-loop the cluster.
- **H1 fail-visible:** mount returns **202 "reconciling"** (not "mounted"); per-db `mounted`/`pending`/`poisoned` on `/v1/health`, the admin API, and `/v1/pack-context` (`packs_pending`) — never silent-open.
- **H2/H3:** 64 MB upload+fetch cap; manifest apply can't fence.
- **M/L:** single-flight reconcile, **verified-present** (a torn file re-fetches), fetch→temp→verify→rename, bounded engine-load (only pack-bearing dbs).

## Surface (RBAC per RFC 030)
`POST/GET /v1/admin/packs` (upload on a separate 64 MB-limit router / list), `GET/POST/DELETE /v1/admin/databases/{id}/packs` (status+manifest / mount / unmount), `GET /v1/packs/{digest}` (peer transfer, cluster-secret), `GET /v1/pack-context`. **Studio gains a Packs tab** (upload, mount/unmount per db, live status). **`recall` is unchanged** — the engine auto-includes mounted-pack candidates.

Also bumps the embedded engine **v0.10.1 → v0.11.2** (packs + fixes; verified safe — full suite green before any pack work).

## Validation
2-node cluster test proves the whole flow: upload → peer-transfer (401 without secret) → mount(202) → **manifest replicates to the follower** → the follower **fetches the file from the leader** → an invalid pack is **poison-quarantined without crashing** → follower redirects writes to the leader. Plus `pack_store` unit tests (roundtrip/dedup, tamper-reject, path-traversal). Full suite green (356).

Refs RFC 031. Cluster-replicated pack GC + control-in-snapshot compaction are documented follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
