### PR TITLE
v0.14.3 — engine bump 0.12.1 → 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.3] — 2026-07-30
+
+**Engine bump 0.12.1 → 0.13.1.** A minor bump (0.13.0 + 0.13.1) but verified
+additive from the server's contract POV — server builds clean, full suite green;
+no server API/behavior change. Retrieval-quality + retrieval-explainability work
+the server inherits for free at recall time:
+
+### Changed
+- **Engine `yantrikdb` 0.12.1 → 0.13.1** — better recall for every tenant, no
+  server code touched:
+  - **BM25 lexical fusion + matched-window spans** (0.13.0) — hybrid
+    lexical+vector retrieval, so an **exact phrase now surfaces** even when the
+    vector similarity alone wouldn't rank it; recall no longer misses
+    literal-string queries.
+  - **Token diet** (0.13.0) — recall stops shipping payload by the kilobyte
+    (leaner responses) + reranked recall.
+  - **Determinism fixes** (0.13.1) — a batch of cross-open determinism fixes in
+    the vector/retrieval lane (total order on claim anchors, deterministic
+    reserve band, level RNG no longer drawing entropy per open), so recall is
+    reproducible across process restarts.
+  - `tokenize()` change (apostrophe exemption removed) — can shift recall
+    ordering; verified no server recall-ordering tests regressed.
+  - A new engine **explain surface** (0.13.1) makes retrieval admission
+    inspectable without a debug build — not yet surfaced by the server; a
+    candidate for a future `/explain` endpoint (RFC-first).
+
+### Notes
+- Same pre-existing Windows-only flake in the real-process YRP `chaos_test`
+  (unrelated to this bump; property proven by the deterministic sim + the
+  `chaos-gate` CI job, both green).
+
 ## [0.14.2] — 2026-07-30
 
 **Engine bump 0.12.0 → 0.12.1.** A patch bump, additive from the server's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4679,8 +4679,8 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yantrikdb"
-version = "0.12.1"
-source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.12.1#cdcd7fd7da734aa4f19acd39211c3e123bc49b49"
+version = "0.13.1"
+source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.13.1#c936b342f1740507d5934588cd61854e8753d47c"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"
@@ -17,20 +17,24 @@ name = "yantrikdb"
 path = "src/main.rs"
 
 [dependencies]
-# Engine v0.12.1 — latest tagged release. Pinned by tag for a reproducible,
-# released dependency. 0.12.0→0.12.1 is a patch bump, ADDITIVE from the server's
-# contract POV (verified: server builds clean, full suite green). It is all
-# retrieval-QUALITY work the server inherits for free at recall time — no server
-# code change: (1) CHUNKED EMBEDDINGS — a record longer than the embedder's
-# input window is now findable from any part of its text (was silently truncated
-# → silent retrieval loss); (2) the RECENCY WALL came down — freshness now
-# MULTIPLIES relevance instead of adding to it, so an old-but-relevant memory is
-# no longer buried by newer noise; (3) graph expansion off by default + MMR
-# diversity softened. Earlier: 0.12.0 added `recall_as_of` (bitemporal) + a lean
-# recall projection (still unsurfaced — future server endpoint, RFC-first); 0.11.3
-# let a pack carry its author-measured retrieval settings (inherited at mount).
-# The engine owns no timer thread — the host drives run_maintenance_cycle().
-yantrikdb = { version = "0.12.1", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.12.1" }
+# Engine v0.13.1 — latest tagged release. Pinned by tag for a reproducible,
+# released dependency. 0.12.1→0.13.1 is a MINOR bump (0.13.0 + 0.13.1) but
+# verified ADDITIVE from the server's contract POV — server builds clean, full
+# suite green. It is retrieval-QUALITY + retrieval-EXPLAINABILITY work the server
+# inherits for free at recall time, no server code change:
+#   0.13.0 — BM25 LEXICAL FUSION + matched-window spans (exact phrases now
+#     surface, hybrid lexical+vector); a "token diet" (recall stops shipping
+#     payload by the kilobyte); reranked recall. (Cross-encoder rerank is a
+#     PYTHON-only feature, not the Rust API the server links.)
+#   0.13.1 — the EXPLAIN surface: retrieval admission is inspectable WITHOUT a
+#     debug build (candidate for a future server /explain endpoint, RFC-first) +
+#     a batch of cross-open DETERMINISM fixes in the vector/retrieval lane, and a
+#     tokenize() change (apostrophe exemption removed) that can shift recall
+#     ordering — validated: no server recall-ordering tests regressed.
+# Earlier: 0.12.x added `recall_as_of` (bitemporal, still unsurfaced) + chunked
+# embeddings + the recency-wall-down ranking; 0.11.3 let a pack carry its
+# author-measured retrieval settings. Engine owns no timer thread — host drives.
+yantrikdb = { version = "0.13.1", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.13.1" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime


### PR DESCRIPTION
Keeps the server current with the **core** (engine `yantrikdb` **0.13.1**). A minor bump (0.13.0 + 0.13.1), but verified additive — no server API/behavior change. Retrieval-quality + explainability the server inherits for free at recall time:

- **BM25 lexical fusion + matched-window spans** (0.13.0) — hybrid lexical+vector, so an **exact phrase surfaces** even when vector similarity alone wouldn't rank it.
- **Token diet** (0.13.0) — recall stops shipping payload by the kilobyte; reranked recall.
- **Determinism fixes** (0.13.1) — cross-open determinism in the vector/retrieval lane (total order on claim anchors, deterministic reserve band, level RNG), so recall is reproducible across restarts.
- **New explain surface** (0.13.1) — retrieval admission inspectable without a debug build. Not yet surfaced; candidate for a future `/explain` endpoint (RFC-first).

## Validation
- **Build clean** against 0.13.1 (no signature drift on the minor bump); **full suite green: 918 passing**, and **no recall-ordering test regressed** despite the BM25 fusion + `tokenize()` apostrophe change.
- The one red test — `yrp::chaos_test::torn_state_boots_quarantined_then_rejoins_via_grant` — is the **same pre-existing Windows-only flake** (property proven by the deterministic sim + the `chaos-gate` CI job, both green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)