### PR TITLE
v0.15.1 — engine bump 0.13.1 → 0.14.0 (security fixes + record API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] — 2026-08-10
+
+**Engine bump 0.13.1 → 0.14.0.** A minor bump (0.13.2/.3/.4 + 0.14.0) carrying
+**security fixes** for encrypted-at-rest deployments, plus additive engine APIs.
+Required a small server adaptation (the engine's record API gained a
+`created_at` parameter) but no server API/behavior change.
+
+### Security (from the engine)
+- **0.13.2 — the oplog no longer writes plaintext on encrypted databases.** On
+  an encrypted DB the change-log was persisting plaintext; fixed at the engine
+  write path. Forward-looking: it stops new plaintext oplog rows; any pre-existing
+  rows age out via compaction. (The default homelab config runs with encryption
+  disabled, so it was unaffected — but any encrypted deployment should upgrade.)
+- **0.13.3** — the security advisory's own check now reaches the Python layer.
+- **0.13.4** — sealing a row is not erasing it (seal semantics hardened).
+
+### Changed
+- **Engine `yantrikdb` 0.13.1 → 0.14.0.** The engine's `record_with_idempotency`
+  / `record_text_with_idempotency` / `RecordInput` gained a `created_at:
+  Option<f64>` for the new **historical-import** capability; the server passes
+  `None` (engine stamps `now()`), preserving existing behavior. Historical import
+  (caller-supplied timestamps) is **not surfaced** by the server yet — it needs to
+  ride the replicated mutation path to stay cluster-correct (a follow-up, like the
+  deferred RFC 032 writes). Also picks up new engine APIs (caller-supplied
+  consolidation, rid point-read, pack namespace) + an embedder process-global init
+  + download-retry fix.
+
 ## [0.15.0] — 2026-08-10
 
 **HTTP route parity for the six embedded-only tool families (RFC 032, issue

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4679,8 +4679,8 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yantrikdb"
-version = "0.13.1"
-source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.13.1#c936b342f1740507d5934588cd61854e8753d47c"
+version = "0.14.0"
+source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.14.0#dda4f23cd4568083ff807ba5fb32ac41dd8ff8dc"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "AGPL-3.0-only"
@@ -17,24 +17,22 @@ name = "yantrikdb"
 path = "src/main.rs"
 
 [dependencies]
-# Engine v0.13.1 — latest tagged release. Pinned by tag for a reproducible,
-# released dependency. 0.12.1→0.13.1 is a MINOR bump (0.13.0 + 0.13.1) but
+# Engine v0.14.0 — latest tagged release. Pinned by tag for a reproducible,
+# released dependency. 0.13.1→0.14.0 is a MINOR bump (0.13.2/.3/.4 + 0.14.0) but
 # verified ADDITIVE from the server's contract POV — server builds clean, full
-# suite green. It is retrieval-QUALITY + retrieval-EXPLAINABILITY work the server
-# inherits for free at recall time, no server code change:
-#   0.13.0 — BM25 LEXICAL FUSION + matched-window spans (exact phrases now
-#     surface, hybrid lexical+vector); a "token diet" (recall stops shipping
-#     payload by the kilobyte); reranked recall. (Cross-encoder rerank is a
-#     PYTHON-only feature, not the Rust API the server links.)
-#   0.13.1 — the EXPLAIN surface: retrieval admission is inspectable WITHOUT a
-#     debug build (candidate for a future server /explain endpoint, RFC-first) +
-#     a batch of cross-open DETERMINISM fixes in the vector/retrieval lane, and a
-#     tokenize() change (apostrophe exemption removed) that can shift recall
-#     ordering — validated: no server recall-ordering tests regressed.
-# Earlier: 0.12.x added `recall_as_of` (bitemporal, still unsurfaced) + chunked
-# embeddings + the recency-wall-down ranking; 0.11.3 let a pack carry its
-# author-measured retrieval settings. Engine owns no timer thread — host drives.
-yantrikdb = { version = "0.13.1", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.13.1" }
+# suite green. Notably it carries SECURITY fixes the server's encrypted-at-rest
+# deployments want:
+#   0.13.2 — the oplog was writing PLAINTEXT on encrypted databases (fixed).
+#   0.13.3 — the security advisory's own check now reaches the Python layer.
+#   0.13.4 — sealing a row is not erasing it (seal semantics hardened).
+#   0.14.0 — new engine APIs (historical import, caller-supplied consolidation,
+#     a rid point-read, pack namespace) — additive, unsurfaced by the server for
+#     now; + an embedder process-global init + download-retry fix.
+# Earlier: 0.13.0 BM25 lexical fusion + matched-window spans + token diet;
+# 0.12.x `recall_as_of` (bitemporal, surfaced via /v1/temporal/as_of in RFC 032)
+# + chunked embeddings + recency-wall-down; the EXPLAIN surface (0.13.1) is still
+# unsurfaced. Engine owns no timer thread — host drives run_maintenance_cycle().
+yantrikdb = { version = "0.14.0", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.14.0" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime

--- a/crates/yantrikdb-server/src/http_gateway.rs
+++ b/crates/yantrikdb-server/src/http_gateway.rs
@@ -948,6 +948,7 @@ async fn remember_with_idempotency(
             &source,
             emotional_state.as_deref(),
             Some(&key),
+            None, // created_at: engine stamps now() (historical import unsurfaced)
         ),
         // No embedder + no client vector: the engine's text path applies
         // its own embedding policy, identical to the unkeyed route.
@@ -964,6 +965,7 @@ async fn remember_with_idempotency(
             &source,
             emotional_state.as_deref(),
             Some(&key),
+            None, // created_at
         ),
     })
     .await
@@ -1314,6 +1316,7 @@ async fn remember_batch_with_idempotency(
             source: m.source,
             emotional_state: m.emotional_state,
             idempotency_key: key,
+            created_at: None, // engine stamps now() (historical import unsurfaced)
         });
     }
     let outcome = tokio::task::spawn_blocking(move || engine.record_batch(&inputs))

--- a/crates/yantrikdb-server/tests/compat_test.rs
+++ b/crates/yantrikdb-server/tests/compat_test.rs
@@ -239,6 +239,7 @@ fn idempotency_same_key_same_payload_returns_original_rid_zero_writes() {
             "user",
             None,
             Some("key-1"),
+            None, // created_at
         )
         .unwrap();
     let rid2 = db
@@ -256,6 +257,7 @@ fn idempotency_same_key_same_payload_returns_original_rid_zero_writes() {
             "user",
             None,
             Some("key-1"),
+            None, // created_at
         )
         .unwrap();
     assert_eq!(rid1, rid2, "retry must return the ORIGINAL rid");
@@ -286,6 +288,7 @@ fn idempotency_same_key_divergent_payload_conflicts_with_existing_rid() {
             "user",
             None,
             Some("key-2"),
+            None, // created_at
         )
         .unwrap();
     let err = db
@@ -303,6 +306,7 @@ fn idempotency_same_key_divergent_payload_conflicts_with_existing_rid() {
             "user",
             None,
             Some("key-2"),
+            None, // created_at
         )
         .unwrap_err();
     match err {
@@ -333,6 +337,7 @@ fn idempotency_batch_per_item_keys_all_or_nothing() {
         source: "user".into(),
         emotional_state: None,
         idempotency_key: key.map(String::from),
+        created_at: None,
     };
     // First batch: two keyed items (the "{caller_key}:{index}" derivation
     // the gateway applies for a batch-level key produces exactly this).
@@ -381,6 +386,7 @@ fn idempotency_invalid_key_is_refused_loudly() {
             "user",
             None,
             Some("   "),
+            None, // created_at
         )
         .unwrap_err();
     assert!(


### PR DESCRIPTION
Keeps the server current with the **core** (engine `yantrikdb` **0.14.0**). A minor bump carrying **security fixes** plus additive APIs; required a small server adaptation but no server API/behavior change.

## Security (from the engine)
- **0.13.2 — the oplog no longer writes plaintext on encrypted databases.** On an encrypted DB the change-log was persisting plaintext; fixed at the engine write path. Forward-looking (stops new plaintext rows; pre-existing ones age out via compaction). The default homelab runs encryption-disabled, so it was unaffected — but any encrypted deployment should upgrade.
- **0.13.3** — the security advisory's own check now reaches the Python layer.
- **0.13.4** — sealing a row is not erasing it.

## Breaking-change adaptation
The engine's `record_with_idempotency` / `record_text_with_idempotency` / `RecordInput` gained a `created_at: Option<f64>` for the new **historical-import** capability. The server passes `None` (engine stamps `now()`), preserving behavior. Historical import (caller-supplied timestamps) is **not surfaced** yet — it must ride the replicated mutation path to stay cluster-correct (a follow-up, like the deferred RFC 032 writes).

## Validation
- Builds clean against 0.14.0; **full suite 920 pass** — the `idempotency_*` / record compat tests that exercise the adapted path are all green.
- Only red check is the pre-existing Windows-only chaos flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)