### PR TITLE
deps: anyhow 1.0.102 → 1.0.104 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"


### PR DESCRIPTION
The **Security Audit** job has been red since 2026-08-17 on [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) — *Unsoundness in `Error::downcast_mut()`* (advisory dated 2026-06-25) — which affects the `anyhow 1.0.102` pinned in the lockfile.

Lockfile-only bump to 1.0.104. No source change; `cargo check` clean.

Pre-existing and unrelated to the engine 0.15.3 bump — surfaced while investigating a separate CI failure on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)