### PR TITLE
chore: republish protocol and witness as 0.1.1 — Apache-2.0 on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "rmp-serde",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-witness"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/crates/yantrikdb-protocol/Cargo.toml
+++ b/crates/yantrikdb-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-protocol"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Wire protocol codec for YantrikDB — binary frames, opcodes, MessagePack messages, Tokio codec"
 license = "Apache-2.0"

--- a/crates/yantrikdb-witness/Cargo.toml
+++ b/crates/yantrikdb-witness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-witness"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "YantrikDB cluster witness — vote-only daemon for 2-node Raft failover (tiny tiebreaker)"
 license = "Apache-2.0"


### PR DESCRIPTION
Both crates were relicensed in the repository but never republished, so crates.io kept serving their **April 0.1.0 metadata as AGPL-3.0-only**. The repository said Apache while the artifact people actually read said AGPL — and crates.io version metadata is immutable, so the only fix is a new version.

Already published:

| crate | was | now |
|---|---|---|
| `yantrikdb-protocol` | 0.1.0 · AGPL-3.0-only | **0.1.1 · Apache-2.0** |
| `yantrikdb-witness` | 0.1.0 · AGPL-3.0-only | **0.1.1 · Apache-2.0** |

Dependents needed no change — `version = "0.1.0"` is a caret requirement, so `yantrikdb-server` and `yantrikdb-witness` both accept 0.1.1. Published in dependency order, protocol first. `yql` stays 0.1.0/MIT, which is correct as published.

This commit brings the repository in line with what is now on the registry.

### crates.io after this

```
yantrikdb            0.15.4   Apache-2.0
yantrikdb-server     0.16.2   Apache-2.0
yantrikdb-witness    0.1.1    Apache-2.0
yantrikdb-protocol   0.1.1    Apache-2.0
yql                  0.1.0    MIT
```