### PR TITLE
docs: the README's contradiction example does not reproduce (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,19 @@ db.get_conflicts()
 # → [{"kind": "identity_fact", ...}]
 ```
 
-Detection runs over the **relations the extractor recognises** — here
-`headquartered_in`, which holds one value at a time — not over arbitrary
-sentences. `"CEO is Alice"` followed by `"CEO is Bob"` is *not* detected: no
-entity is extracted from a bare copular sentence with no named subject, so
-there is nothing for the claim scan to compare. Name the subject
-(`"Acme's CEO is Alice"`) and the same limitation still applies to
-inverse-functional relations — tracked in
-[#95](https://github.com/yantrikos/yantrikdb-server/issues/95).
+Detection runs over the **relations the extractor recognises** — here a
+location relation, single-valued at any moment — not over arbitrary sentences.
+Two limits are worth knowing before you rely on it:
+
+- **Claims are keyed by subject.** `"Alice is the CEO of Acme"` and
+  `"Bob is the CEO of Acme"` have *different* subjects with one value each, so
+  nothing compares. The constraint here is inverse-functional — it lives on the
+  object ("CEO of Acme" admits one filler) — and that direction is not modelled.
+- **Copular attribute claims are off by default.** `"The logo is blue"` →
+  `"The logo is green"` needs `ThinkConfig.extract_attribute_claims`; without
+  it the copular path never runs.
+
+Both are tracked in [#95](https://github.com/yantrikos/yantrikdb-server/issues/95).
 
 Plus: temporal decay with configurable half-life, entity graph with relationship edges, personality derivation from memory patterns, session-aware context surfacing, multi-signal scoring (recency × importance × similarity × graph proximity).
 

--- a/README.md
+++ b/README.md
@@ -67,14 +67,23 @@ db.think()
 ### 3. It detects contradictions
 
 ```python
-db.record("CEO is Alice")
-db.record("CEO is Bob")  # added later in another conversation
+db.record("Acme is based in Boston.")
+db.record("Acme is based in Denver.")   # added later, in another conversation
 
 db.think()
-# → {"conflicts_found": 1, "conflicts": [{"memory_a": "CEO is Alice",
-#                                         "memory_b": "CEO is Bob",
-#                                         "type": "factual_contradiction"}]}
+# → {"conflicts_found": 1, ...}
+db.get_conflicts()
+# → [{"kind": "identity_fact", ...}]
 ```
+
+Detection runs over the **relations the extractor recognises** — here
+`headquartered_in`, which holds one value at a time — not over arbitrary
+sentences. `"CEO is Alice"` followed by `"CEO is Bob"` is *not* detected: no
+entity is extracted from a bare copular sentence with no named subject, so
+there is nothing for the claim scan to compare. Name the subject
+(`"Acme's CEO is Alice"`) and the same limitation still applies to
+inverse-functional relations — tracked in
+[#95](https://github.com/yantrikos/yantrikdb-server/issues/95).
 
 Plus: temporal decay with configurable half-life, entity graph with relationship edges, personality derivation from memory patterns, session-aware context surfacing, multi-signal scoring (recency × importance × similarity × graph proximity).
 


### PR DESCRIPTION
Closes the docs half of #95.

Triple-checked on 0.15.5 in a clean venv, 5 trials each, fresh DB every time — fully deterministic, zero flake:

| example | `conflicts_found` | `get_conflicts()` | verdict |
|---|---|---|---|
| `"CEO is Alice"` / `"CEO is Bob"` — **this README** | 0 ×5 | 0 ×5 | **false** — nothing detected |
| `"works at Google"` / `"...at Meta"` — engine README | 0 ×5 | 1 ×5 | substance right, count wrong (#142) |
| `"Acme is based in Boston."` / `"...Denver."` | 1 ×5 | 1 ×5 | **verified** |
| `"Alice is the CEO of Acme"` / `"Bob is..."` | 0 ×5 | 0 ×5 | inverse-functional gap |

The shipped snippet was the one that detects nothing.

## What changed

Swapped in the verified pair, and stated the boundary rather than implying detection works over arbitrary prose: it runs over the **relations the extractor recognises** (`headquartered_in` holds one value at a time), and a bare copular sentence with no named subject mints no entity — so there is nothing for the claim scan to compare.

## Why this is worth a narrower claim

Contradiction detection is the headline differentiator here, on the website, and in every listing description. The shortest path from "interesting claim" to "it doesn't do that" is the first snippet someone copies. A snippet that runs beats a broader claim that doesn't.

The site's own example (`Boston`/`Denver`) is the verified one and already carries the mechanism note — so this brings the README in line with what the site already says correctly.

## Not closed by this

The engine-side fix — entity/claim extraction firing on plain `record()` text — is the write-time cognition arc, gated on relation-extraction quality. #95 stays open for it.