### PR TITLE
deps: engine v0.18.0; release v0.17.1 — mounted packs work again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to `yantrikdb-server` are recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] — 2026-08-26
+
+### Fixed
+- **Mounted packs work again.** The server exposes packs (`POST`/`GET /v1/packs/{digest}`,
+  `GET /v1/pack-context`, replicated mount) on top of the embedded engine, and every pack
+  published before engine 0.16 failed to mount with `no such column: synthesis_state` —
+  measured across the whole published line, 40 of 40. Engine 0.18.0 carries the fix
+  (schema-aware projection for a read-only pack database, which can never be migrated);
+  your `.ydbpack` files are unchanged and need no re-sealing.
+
+### Changed
+- Engine pin `0.17.1` → **`0.18.0`**, which also brings the pack substrate: structured
+  per-hit pack provenance, the signed retrieval settings on `mounted_packs()`,
+  `pack_context_for(pack_ids)` and `recall_from_packs_for(pack_ids, …)`.
+
+No server API change. Suite green against 0.18.0: 356 + 350 + 13 + 6 + 4 + 2 + 2 passed.
+
 ## [0.17.0] — 2026-08-25
 
 **Engine 0.17.1** (thread-aware retrieval, reachable event time, convergent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,7 +1746,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2662,7 +2662,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2699,7 +2699,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4679,8 +4679,8 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yantrikdb"
-version = "0.17.1"
-source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.17.1#8a4c870f22c0048543b9db4e912772cd540741d4"
+version = "0.18.0"
+source = "git+https://github.com/yantrikos/yantrikdb.git?tag=v0.18.0#6a45f15e29dbb8f8641f91557e3cb8c9304c8639"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "yantrikdb-server"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/crates/yantrikdb-server/Cargo.toml
+++ b/crates/yantrikdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-server"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 description = "YantrikDB database server — multi-tenant cognitive memory with wire protocol, HTTP gateway, replication, auto-failover, and at-rest encryption"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ path = "src/main.rs"
 # 0.12.x `recall_as_of` (bitemporal, surfaced via /v1/temporal/as_of in RFC 032)
 # + chunked embeddings + recency-wall-down; the EXPLAIN surface (0.13.1) is still
 # unsurfaced. Engine owns no timer thread — host drives run_maintenance_cycle().
-yantrikdb = { version = "0.17.1", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.17.1" }
+yantrikdb = { version = "0.18.0", git = "https://github.com/yantrikos/yantrikdb.git", tag = "v0.18.0" }
 yantrikdb-protocol = { version = "0.1.0", path = "../yantrikdb-protocol" }
 
 # Async runtime


### PR DESCRIPTION
## Why now

This server exposes packs on top of the embedded engine — `POST`/`GET /v1/packs/{digest}`, `GET /v1/pack-context`, and replicated mount through `apply_mount_pack`. Engine 0.17.1, which v0.17.0 shipped with, cannot mount **any** pack published before engine 0.16: it fails with `no such column: synthesis_state`. Measured across the whole published line — **40 of 40 failed, 40 of 40 mount with 0.18.0**.

The cause was a fixed column projection shared between the host database (always migrated, so the break never surfaced) and a mounted pack's (opened read-only from a publisher's sealed file, never migratable). Engine 0.18.0 makes the projection schema-aware; publisher artifacts are never rewritten and need no re-sealing.

## What changed

- Engine pin `0.17.1` → `0.18.0` (lockfile delta is exactly the engine swap, 6 lines)
- Server crate `0.17.0` → `0.17.1`
- No server API change

0.18.0 also brings the pack substrate the endpoints can grow into: structured per-hit provenance, the signed retrieval settings on `mounted_packs()`, `pack_context_for(pack_ids)`, and `recall_from_packs_for(pack_ids, …)` with the floor-as-a-wall rule.

## Verification

`cargo build --locked` clean, `cargo fmt --check` clean, clippy 0 errors, and the full suite green against 0.18.0: 356 + 350 + 13 + 6 + 4 + 2 + 2 passed, 0 failed.